### PR TITLE
Add constraint on type field

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -4,7 +4,6 @@
   "type": "object",
   "description": "Schema of common properties of RUM events",
   "required": [
-    "type",
     "date",
     "application",
     "session",
@@ -12,11 +11,6 @@
     "_dd"
   ],
   "properties": {
-    "type": {
-      "type": "string",
-      "description": "RUM event type",
-      "enum": ["action", "error", "long_task", "resource", "view"]
-    },
     "date": {
       "type": "integer",
       "description": "Start of the event in ms from epoch",

--- a/schemas/action-schema.json
+++ b/schemas/action-schema.json
@@ -9,9 +9,15 @@
     },
     {
       "required": [
+        "type",
         "action"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "action"
+        },
         "action": {
           "type": "object",
           "description": "Action properties",

--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -9,9 +9,15 @@
     },
     {
       "required": [
+        "type",
         "error"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "error"
+        },
         "error": {
           "type": "object",
           "description": "Error properties",

--- a/schemas/long_task-schema.json
+++ b/schemas/long_task-schema.json
@@ -9,9 +9,15 @@
     },
     {
       "required": [
+        "type",
         "long_task"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "long_task"
+        },
         "long_task": {
           "type": "object",
           "description": "Long Task properties",

--- a/schemas/resource-schema.json
+++ b/schemas/resource-schema.json
@@ -9,9 +9,15 @@
     },
     {
       "required": [
+        "type",
         "resource"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "resource"
+        },
         "resource": {
           "type": "object",
           "description": "Resource properties",

--- a/schemas/view-schema.json
+++ b/schemas/view-schema.json
@@ -9,10 +9,16 @@
     },
     {
       "required": [
+        "type",
         "view",
         "_dd"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "view"
+        },
         "view": {
           "type": "object",
           "description": "View properties",


### PR DESCRIPTION
In the current version of the schema, one could send the following event (following the definition of `action-schema.json` and it would be considered valid. But the field `type` being `error` it could lead to invalid data being recorded.

```json
{
  "type": "error",
  "date": 1591284428705,
  "application": {
    "id": "ac8218cf-498b-4d33-bd44-151095959547"
  },
  "session": {
    "id": "cacbf45c-3a05-48ce-b066-d76349460599",
    "type": "user"
  },
  "view": {
    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
    "referrer": "",
    "url": "https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view"
  },
  "action": {
    "type": "click",
    "id": "47af0abb-3de1-4170-a491-4473716df979",
    "loading_time": 566250000,
    "target": {
      "name": "Options"
    },
    "error": {
      "count": 0
    },
    "long_task": {
      "count": 0
    },
    "resource": {
      "count": 1
    }
  },
  "_dd": {
    "format_version": 2
  }
}
```

The solution in this PR uses the `const` schema paradigm to ensure that if an event follows the `action-schema.json` structure, then type **must** be `action` 