### PR TITLE
View schema - add Android specific values for loading_type

### DIFF
--- a/schemas/view-schema.json
+++ b/schemas/view-schema.json
@@ -39,7 +39,7 @@
             "loading_type": {
               "type": "string",
               "description": "Type of the loading of the view",
-              "enum": ["initial_load", "route_change"]
+              "enum": ["initial_load", "route_change", "activity_display", "activity_redisplay", "fragment_display", "fragment_redisplay"]
             },
             "time_spent": {
               "type": "integer",


### PR DESCRIPTION
Adding new values for the `loading_type` attribute to be able to make this property more Android friendly.