### PR TITLE
Add 'webview' error source

### DIFF
--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -33,7 +33,7 @@
             "source": {
               "type": "string",
               "description": "Source of the error",
-              "enum": ["network", "source", "console", "logger", "agent"]
+              "enum": ["network", "source", "console", "logger", "agent", "webview"]
             },
             "stack": {
               "type": "string",


### PR DESCRIPTION
Mobile apps can embed Webviews, and the SDK can detect error hapenning in those webviews. Tagging the source as such will help our customers in filtering those.