### PR TITLE
RUMM-517 Quicktype conformance

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -136,6 +136,7 @@
       ],
       "properties": {
         "format_version": {
+          "type": "integer",
           "const": 2,
           "description": "Version of the RUM event format"
         }


### PR DESCRIPTION
We use quicktype tool to generate Swift code from schema
It doesn't handle properties without `type` attribute
that's why I add `type` added to `format_version`