### PR TITLE
[RUMF-724] Add "custom" error source

### DIFF
--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -33,7 +33,7 @@
             "source": {
               "type": "string",
               "description": "Source of the error",
-              "enum": ["network", "source", "console", "logger", "agent", "webview"]
+              "enum": ["network", "source", "console", "logger", "agent", "webview", "custom"]
             },
             "stack": {
               "type": "string",


### PR DESCRIPTION
In the same spirit as the action "custom" type, add a "custom" error source for manually sent errors.

See https://datadoghq.atlassian.net/browse/RUMF-724
And https://github.com/DataDog/browser-sdk/issues/516