### PR TITLE
RUMM-787 Add the view.is_active attribute

### DIFF
--- a/schemas/view-schema.json
+++ b/schemas/view-schema.json
@@ -86,6 +86,10 @@
               "description": "Duration in ns to the end of the load event handler execution",
               "minimum": 0
             },
+            "is_active": {
+              "type": "boolean",
+              "description": "Whether the View corresponding to this event is considered active"
+            },
             "action": {
               "type": "object",
               "description": "Properties of the actions of the view",


### PR DESCRIPTION
Add the `view.is_active` boolean attribute to let the SDKs mark Views as active (`view.is_active` set to `true`) or closed for good (`view.is_active` set to `false`). The attribute is optional when the SDK can't determine the status accurately.