### PR TITLE
Add "unknown" to the resource.provider.type enum

### DIFF
--- a/schemas/resource-schema.json
+++ b/schemas/resource-schema.json
@@ -224,7 +224,7 @@
                 "type": {
                   "type": "string",
                   "description": "The type of provider",
-                  "enum": ["ad", "advertising", "analytics", "cdn", "content", "customer-success", "first party", "hosting", "marketing", "other", "social", "tag-manager", "utility", "video"],
+                  "enum": ["ad", "advertising", "analytics", "cdn", "content", "customer-success", "first party", "hosting", "marketing", "other", "social", "tag-manager", "unknown", "utility", "video"],
                   "readOnly": true
                 }
               },


### PR DESCRIPTION
This value is set by our backend `ThirdPartyProcessor` if it fails to detect the provider.