### PR TITLE
Update schemas title

### DIFF
--- a/rum-events-format.json
+++ b/rum-events-format.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "rum-events-format.json",
-  "title": "RumEventsFormat",
+  "title": "RumEvent",
   "type": "object",
   "description": "Schema of all properties of a RUM event",
   "oneOf": [

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "_common-schema.json",
-  "title": "CommonSchema",
+  "title": "CommonProperties",
   "type": "object",
   "description": "Schema of common properties of RUM events",
   "required": [

--- a/schemas/action-schema.json
+++ b/schemas/action-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "action-schema.json",
-  "title": "ActionSchema",
+  "title": "RumActionEvent",
   "type": "object",
   "description": "Schema of all properties of an Action event",
   "allOf": [

--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "error-schema.json",
-  "title": "ErrorSchema",
+  "title": "RumErrorEvent",
   "type": "object",
   "description": "Schema of all properties of an Error event",
   "allOf": [

--- a/schemas/long_task-schema.json
+++ b/schemas/long_task-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "long_task-schema.json",
-  "title": "LongTaskSchema",
+  "title": "RumLongTaskEvent",
   "type": "object",
   "description": "Schema of all properties of a Long Task event",
   "allOf": [

--- a/schemas/resource-schema.json
+++ b/schemas/resource-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "resource-schema.json",
-  "title": "ResourceSchema",
+  "title": "RumResourceEvent",
   "type": "object",
   "description": "Schema of all properties of a Resource event",
   "allOf": [

--- a/schemas/view-schema.json
+++ b/schemas/view-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "view-schema.json",
-  "title": "ViewSchema",
+  "title": "RumViewEvent",
   "type": "object",
   "description": "Schema of all properties of a View event",
   "allOf": [


### PR DESCRIPTION
Following https://github.com/DataDog/rum-events-format/pull/21 and [discussion on browser type namings](https://github.com/DataDog/rum-events-format/pull/21), update titles to have more consistent namings.

Related update in browser-sdk: https://github.com/DataDog/browser-sdk/pull/644