### PR TITLE
Add session.has_replay property

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -58,6 +58,11 @@
           "description": "Type of the session",
           "enum": ["user", "synthetics"],
           "readOnly": true
+        },
+        "has_replay": {
+          "type": "boolean",
+          "description": "Whether this session has a replay",
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
This flag, optionally present in all events, indicates if the session was recorded while the event happened.