### PR TITLE
Update action.target schema with Android fields

### DIFF
--- a/schemas/action-schema.json
+++ b/schemas/action-schema.json
@@ -56,6 +56,27 @@
                   "type": "string",
                   "description": "Target name",
                   "readOnly": false
+                },
+                "classname": {
+                  "type": "string",
+                  "description": "Target class name",
+                  "readOnly": false
+                },
+                "parent": {
+                  "type": "object",
+                  "description": "Parent element of the target",
+                  "properties": {
+                    "classname": {
+                      "type": "string",
+                      "description": "Class name of the parent element",
+                      "readOnly": false
+                    }
+                  }
+                },
+                "resource_id": {
+                  "type": "string",
+                  "description": "identifier for the target resource",
+                  "readOnly": true
                 }
               },
               "readOnly": true


### PR DESCRIPTION
Adds the following fields to the format, that are set for Android actions:
- `action.target.classname`
- `action.target.parent.classname`
- `action.target.resource_id`
