### PR TITLE
Remove required ids for backward compatibility

### DIFF
--- a/schemas/action-schema.json
+++ b/schemas/action-schema.json
@@ -24,8 +24,7 @@
           "type": "object",
           "description": "Action properties",
           "required": [
-            "type",
-            "id"
+            "type"
           ],
           "properties": {
             "type": {

--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -24,7 +24,6 @@
           "type": "object",
           "description": "Error properties",
           "required": [
-            "id",
             "message",
             "source"
           ],

--- a/schemas/long_task-schema.json
+++ b/schemas/long_task-schema.json
@@ -24,7 +24,6 @@
           "type": "object",
           "description": "Long Task properties",
           "required": [
-            "id",
             "duration"
           ],
           "properties": {

--- a/schemas/resource-schema.json
+++ b/schemas/resource-schema.json
@@ -24,7 +24,6 @@
           "type": "object",
           "description": "Resource properties",
           "required": [
-            "id",
             "type",
             "url",
             "duration"


### PR DESCRIPTION
### Motivation
Ids should not be required to keep events backward compatibility and to be compliant with the RFC

### Changes
Remove ids required from format files

### Testing
./validate.sh