### PR TITLE
Passing some mobile vitals metrics fields to integer

### DIFF
--- a/schemas/view-schema.json
+++ b/schemas/view-schema.json
@@ -221,22 +221,22 @@
               "readOnly": true
             },
             "memory_average": {
-              "type": "number",
+              "type": "integer",
               "description": "Average memory used during the view lifetime (in bytes)",
               "readOnly": true
             },
             "memory_max": {
-              "type": "number",
+              "type": "integer",
               "description": "Peak memory used during the view lifetime (in bytes)",
               "readOnly": true
             },
             "cpu_ticks_count": {
-              "type": "number",
+              "type": "integer",
               "description": "Total number of cpu ticks during the view’s lifetime",
               "readOnly": true
             },
             "cpu_ticks_per_second": {
-              "type": "number",
+              "type": "integer",
               "description": "Average number of cpu ticks per second during the view’s lifetime",
               "readOnly": true
             },


### PR DESCRIPTION
This PR changes the type of some view fields related to mobile vitals metrics.
Memory_average/max and cpu_ticks_count and cpu_ticks_per_second should be long integers instead of floating numbers, especially with the given unit.