### PR TITLE
[RUMF-936] add _dd.session.plan: 1|2 in the common schema

### DIFF
--- a/samples/action.json
+++ b/samples/action.json
@@ -31,6 +31,9 @@
     }
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "session": {
+      "plan": 1
+    }
   }
 }

--- a/samples/app_start.json
+++ b/samples/app_start.json
@@ -24,6 +24,9 @@
     }
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "session": {
+      "plan": 2
+    }
   }
 }

--- a/samples/error.json
+++ b/samples/error.json
@@ -31,6 +31,9 @@
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "session": {
+      "plan": 1
+    }
   }
 }

--- a/samples/long_task.json
+++ b/samples/long_task.json
@@ -21,6 +21,9 @@
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "session": {
+      "plan": 1
+    }
   }
 }

--- a/samples/resource.json
+++ b/samples/resource.json
@@ -36,7 +36,10 @@
   "_dd": {
     "format_version": 2,
     "span_id": "12345",
-    "trace_id": "7890"
+    "trace_id": "7890",
+    "session": {
+      "plan": 1
+    }
   }
 }
 

--- a/samples/view.json
+++ b/samples/view.json
@@ -42,7 +42,10 @@
   },
   "_dd": {
     "document_version": 9,
-    "format_version": 2
+    "format_version": 2,
+    "session": {
+      "plan": 1
+    }
   },
   "context": {
     "foo": "bar"

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -167,6 +167,17 @@
           "const": 2,
           "description": "Version of the RUM event format",
           "readOnly": true
+        },
+        "session": {
+          "type": "object",
+          "description": "Session-related internal properties",
+          "properties": {
+            "plan": {
+              "type": "number",
+              "description": "Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan",
+              "enum": [1, 2]
+            }
+          }
         }
       },
       "readOnly": true

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -171,6 +171,7 @@
         "session": {
           "type": "object",
           "description": "Session-related internal properties",
+          "required": ["plan"],
           "properties": {
             "plan": {
               "type": "number",


### PR DESCRIPTION
Motivation: RUM SDKs will introduce configuration options to let the customer chose which plan they want to use. This field will be used by:
* @DataDog/rum-back  to filter events according to the wanted plan and bill accordingly
* @DataDog/rum-app  to adapt the UI according to the chosen plan

