### PR TITLE
[RUMF-995] add synthetics.{test_id,result_id} in the common schema

### DIFF
--- a/samples/view.json
+++ b/samples/view.json
@@ -47,6 +47,10 @@
       "plan": 1
     }
   },
+  "synthetics": {
+    "test_id": "foo",
+    "result_id": "bar"
+  },
   "context": {
     "foo": "bar"
   }

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -157,6 +157,24 @@
         }
       }
     },
+    "synthetics": {
+      "type": "object",
+      "description": "Synthetics properties",
+      "required": ["test_id", "result_id"],
+      "properties": {
+        "test_id": {
+          "type": "string",
+          "description": "The identifier of the current Synthetics test",
+          "readOnly": true
+        },
+        "result_id": {
+          "type": "string",
+          "description": "The identifier of the current Synthetics test results",
+          "readOnly": true
+        },
+        "readOnly": true
+      }
+    },
     "_dd": {
       "type": "object",
       "description": "Internal properties",


### PR DESCRIPTION
Add fields representing the synthetics test and its result when the session is created during a browser test