### PR TITLE
[RUMF-995] fix misplaced "readOnly" property

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -171,9 +171,9 @@
           "type": "string",
           "description": "The identifier of the current Synthetics test results",
           "readOnly": true
-        },
-        "readOnly": true
-      }
+        }
+      },
+      "readOnly": true
     },
     "_dd": {
       "type": "object",


### PR DESCRIPTION
The "readOnly" property was misplaced and generated a new field on `synthetics.readOnly`:  
```
synthetics?: {
  /**
  * The identifier of the current Synthetics test
  */
  readonly test_id: string
  /**
  * The identifier of the current Synthetics test results
  */
  readonly result_id: string
  readOnly?: true
  [k: string]: unknown
}
```
instead of
```
  /**
   * Synthetics properties
   */
  readonly synthetics?: {
    /**
     * The identifier of the current Synthetics test
     */
    readonly test_id: string
    /**
     * The identifier of the current Synthetics test results
     */
    readonly result_id: string
    [k: string]: unknown
  }
```