### PR TITLE
RUMM-1604 Add a native resource type

### DIFF
--- a/schemas/resource-schema.json
+++ b/schemas/resource-schema.json
@@ -38,7 +38,7 @@
             "type": {
               "type": "string",
               "description": "Resource type",
-              "enum": ["document", "xhr", "beacon", "fetch", "css", "js", "image", "font", "media", "other"],
+              "enum": ["document", "xhr", "beacon", "fetch", "css", "js", "image", "font", "media", "other", "native"],
               "readOnly": true
             },
             "method": {


### PR DESCRIPTION
Adds a `native` resource type. 

## Additional details

Most existing resource types are specific to browser technology (`xhr`, `fetch`, …). So far, mobile SDKs have been using `xhr` as a default but this doesn't make any sense for mobile devs. Using a `native` type allows us to display a value that actually make sense. 