### PR TITLE
RUMM-1716 Add an error.source_type attribute

### DIFF
--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -74,6 +74,7 @@
             "source_type": {
               "type": "string",
               "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
+              "enum": ["android", "browser", "ios", "react-native"],
               "readOnly": true
             },
             "resource": {

--- a/schemas/error-schema.json
+++ b/schemas/error-schema.json
@@ -71,6 +71,11 @@
               "description": "Handling call stack",
               "readOnly": true
             },
+            "source_type": {
+              "type": "string",
+              "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
+              "readOnly": true
+            },
             "resource": {
               "type": "object",
               "description": "Resource properties of the error",


### PR DESCRIPTION
For hybrid / crossplatform errors, add an `error.source_type` attribute to specify the type of source the error comes from. It can be either a platform (e.g.: `ios`) or language family (e.g.: `jvm`, `javascript`), which will help the source code integration process, as well as fingerprinting for Error Tracking