### PR TITLE
[RUMF-1068] Add _dd.browser_sdk_version attribute

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -197,6 +197,11 @@
               "enum": [1, 2]
             }
           }
+        },
+        "browser_sdk_version": {
+          "type": "string",
+          "description": "Browser SDK version",
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
The mobile SDKs (Android and iOS) want to track events that happen inside a webView using the browser SDK. The proposed way to do that is to inject a JS bridge interface that the browser SDK will call instead of sending the events to the intake.

To easily monitor browser sdk event sent though mobile, we need to keep the browser SDK version tag.
Because it is not easy for the mobile to keep browser tags yet, we decided to add it as `_dd` attribute.

