### PR TITLE
[ci-visibility] Add `"ci_visibility"` Property and `"ci-test"` Session Type

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -180,6 +180,19 @@
       },
       "readOnly": true
     },
+    "ci_visibility": {
+      "type": "object",
+      "description": "CI Visibility properties",
+      "required": ["test_execution_id"],
+      "properties": {
+        "test_execution_id": {
+          "type": "string",
+          "description": "The identifier of the current CI Visibility test execution",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
     "_dd": {
       "type": "object",
       "description": "Internal properties",

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -45,7 +45,7 @@
         "type": {
           "type": "string",
           "description": "Type of the session",
-          "enum": ["user", "synthetics"],
+          "enum": ["user", "synthetics", "ci-test"],
           "readOnly": true
         },
         "has_replay": {


### PR DESCRIPTION
Related PR: https://github.com/DataDog/browser-sdk/pull/1192 

* Add `ci_visibility` property.
* Update session type enum to include `'ci-test'`