### PR TITLE
[ci-visibility] Use `ci_test` for ci visibility information

### DIFF
--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -45,7 +45,7 @@
         "type": {
           "type": "string",
           "description": "Type of the session",
-          "enum": ["user", "synthetics", "ci-test"],
+          "enum": ["user", "synthetics", "ci_test"],
           "readOnly": true
         },
         "has_replay": {

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -180,7 +180,7 @@
       },
       "readOnly": true
     },
-    "ci_visibility": {
+    "ci_test": {
       "type": "object",
       "description": "CI Visibility properties",
       "required": ["test_execution_id"],


### PR DESCRIPTION
Better consistency between this key and the session type used (`ci-test`) 