### PR TITLE
RUMM-1901 Add 'source' property in the common schema

### DIFF
--- a/samples/action.json
+++ b/samples/action.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "android",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "referrer": "",

--- a/samples/app_start.json
+++ b/samples/app_start.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "flutter",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "url": ""

--- a/samples/error.json
+++ b/samples/error.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "browser",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "referrer": "",

--- a/samples/extended_error.json
+++ b/samples/extended_error.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "browser",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "referrer": "",

--- a/samples/long_task.json
+++ b/samples/long_task.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "react-native",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "referrer": "",

--- a/samples/resource.json
+++ b/samples/resource.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "ios",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "referrer": "",

--- a/samples/view.json
+++ b/samples/view.json
@@ -8,6 +8,7 @@
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
     "type": "user"
   },
+  "source": "browser",
   "view": {
     "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
     "referrer": "",

--- a/schemas/_common-schema.json
+++ b/schemas/_common-schema.json
@@ -56,6 +56,12 @@
       },
       "readOnly": true
     },
+    "source": {
+      "type": "string",
+      "description": "The source of this event",
+      "enum": ["android", "ios", "browser", "flutter", "react-native"],
+      "readOnly": true
+    },
     "view": {
       "type": "object",
       "description": "View properties",


### PR DESCRIPTION
As a follow up on the https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2290156382/RFC+-+Display+the+event+types+in+a+Hybrid+application RFC we are going to add a new `source` property in the `_common-schema.json`:
```
"source": {
      "type": "string",
      "description": "The source of this event",
      "enum": ["android", "ios", "browser", "flutter", "react-native"],
      "readOnly": true
    }
```