### PR TITLE
RUMF-1175 Add report error source

### DIFF
--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -42,7 +42,7 @@
             "source": {
               "type": "string",
               "description": "Source of the error",
-              "enum": ["network", "source", "console", "logger", "agent", "webview", "custom"],
+              "enum": ["network", "source", "console", "logger", "agent", "webview", "custom", "report"],
               "readOnly": true
             },
             "stack": {


### PR DESCRIPTION
# Motivation

With the collection of `intervention` and `CSP violation` web reports, a new error source is needed.

# Changes

Add report error source in error schema
