### PR TITLE
[RUMF-1134] Add version on RUM events

### DIFF
--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -31,6 +31,11 @@
       "description": "The service name for this application",
       "readOnly": true
     },
+    "version": {
+      "type": "string",
+      "description": "The version for this application",
+      "readOnly": true
+    },
     "session": {
       "type": "object",
       "description": "Session properties",


### PR DESCRIPTION
### Motivation
In the context of sub apps, we need to be able to specify the version as an event field instead of a tag.