### PR TITLE
[RUMF-1214] adjust frustration fields

### DIFF
--- a/samples/rum/action.json
+++ b/samples/rum/action.json
@@ -30,7 +30,9 @@
     "resource": {
       "count": 1
     },
-    "frustration_type": ["rage"]
+    "frustration": {
+      "type": ["rage"]
+    }
   },
   "_dd": {
     "format_version": 2,

--- a/samples/rum/view.json
+++ b/samples/rum/view.json
@@ -36,6 +36,9 @@
     "resource": {
       "count": 9
     },
+    "frustration": {
+      "count": 9
+    },
     "in_foreground_periods": [
       {"start": 1345678, "duration": 67},
       {"start": 1645678, "duration": 67}

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -60,14 +60,24 @@
               },
               "readOnly": true
             },
-            "frustration_type": {
-              "type": "array",
-              "description": "Action frustration types",
-              "readOnly": true,
-              "items": {
-                "type": "string",
-                "enum": ["rage", "dead", "error"]
-              }
+            "frustration": {
+              "type": "object",
+              "description": "Action frustration properties",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "array",
+                  "description": "Action frustration types",
+                  "readOnly": true,
+                  "items": {
+                    "type": "string",
+                    "enum": ["rage", "dead", "error"]
+                  }
+                }
+              },
+              "readOnly": true
             },
             "error": {
               "type": "object",

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -214,6 +214,20 @@
               },
               "readOnly": true
             },
+            "frustration": {
+              "type": "object",
+              "description": "Properties of the frustrations of the view",
+              "required": ["count"],
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "description": "Number of frustrations that occurred on the view",
+                  "minimum": 0,
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            },
             "in_foreground_periods": {
               "type": "array",
               "description": "List of the periods of time the user had the view in foreground (focused in the browser)",


### PR DESCRIPTION
* introduce a new field `view.frustration.count` to count frustrations occuring during the lifetime of the view
* rename `action.frustration_type` to `action.frustration.type` to match the counter field pattern

TypeScript diff:
```diff
@@ -42,9 +42,15 @@ export type RumActionEvent = CommonProperties & {
       [k: string]: unknown
     }
     /**
-     * Action frustration types
+     * Action frustration properties
      */
-    readonly frustration_type?: ('rage' | 'dead' | 'error')[]
+    readonly frustration?: {
+      /**
+       * Action frustration types
+       */
+      readonly type: ('rage' | 'dead' | 'error')[]
+      [k: string]: unknown
+    }
     /**
      * Properties of the errors of the action
      */
@@ -569,6 +575,16 @@ export type RumViewEvent = CommonProperties & {
       readonly count: number
       [k: string]: unknown
     }
+    /**
+     * Properties of the frustrations of the view
+     */
+    readonly frustration?: {
+      /**
+       * Number of frustrations that occurred on the view
+       */
+      readonly count: number
+      [k: string]: unknown
+    }
     /**
      * List of the periods of time the user had the view in foreground (focused in the browser)
      */
```
