### PR TITLE
[RUMF-1277] rename frustration types

### DIFF
--- a/samples/rum/action.json
+++ b/samples/rum/action.json
@@ -31,7 +31,7 @@
       "count": 1
     },
     "frustration": {
-      "type": ["rage"]
+      "type": ["rage_click"]
     }
   },
   "_dd": {

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -73,7 +73,7 @@
                   "readOnly": true,
                   "items": {
                     "type": "string",
-                    "enum": ["rage", "dead", "error"]
+                    "enum": ["rage_click", "dead_click", "error_click"]
                   }
                 }
               },


### PR DESCRIPTION
While dogfooding, we found out that we are showing the frustration type alone in many places (ex: facet, chart legend,…). Showing “dead” or “rage” alone is not really meaningful and can be a bit shocking or hurtful (we don’t want to display “dead” all over the place). 

In the last sync, we chose to rename `dead` to `dead_click` and so forth. It will change a bit how we make analytics when we have frustration associated to mutliple types of action (ex: `rage_click` is similar to `rage_tap` , but both will need to be specified when querying any rage inducing frustration). This is a small drawback but we decided that we can live with it.