### PR TITLE
[RUMF-1280] Add click position

### DIFF
--- a/samples/rum/action.json
+++ b/samples/rum/action.json
@@ -19,7 +19,14 @@
     "id": "47af0abb-3de1-4170-a491-4473716df979",
     "loading_time": 566250000,
     "target": {
-      "name": "Options"
+      "name": "Options",
+      "selector": "#options",
+      "width": 10,
+      "height": 10
+    },
+    "position": {
+      "x": 5,
+      "y": 5
     },
     "error": {
       "count": 0

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -56,6 +56,21 @@
                   "type": "string",
                   "description": "Target name",
                   "readOnly": false
+                },
+                "selector": {
+                  "type": "string",
+                  "description": "CSS selector path of the target element",
+                  "readOnly": true
+                },
+                "width": {
+                  "type": "integer",
+                  "description": "Width of the target element (in pixels)",
+                  "readOnly": true
+                },
+                "height": {
+                  "type": "integer",
+                  "description": "Height of the target element (in pixels)",
+                  "readOnly": true
                 }
               },
               "readOnly": true
@@ -75,6 +90,24 @@
                     "type": "string",
                     "enum": ["rage_click", "dead_click", "error_click"]
                   }
+                }
+              },
+              "readOnly": true
+            },
+            "position": {
+              "type": "object",
+              "description": "Action position properties",
+              "required": ["x", "y"],
+              "properties": {
+                "x": {
+                  "type": "integer",
+                  "description": "X coordinate of the action (in pixels)",
+                  "readOnly": true
+                },
+                "y": {
+                  "type": "integer",
+                  "description": "Y coordinate of the action (in pixels)",
+                  "readOnly": true
                 }
               },
               "readOnly": true


### PR DESCRIPTION
To build clickmaps, the browser SDK needs to collect the action click position:
- adds `action.position`: Contains x and y click coordinates
- adds `action.target.selector`: CSS selector path of the target element
- adds `action.target.width` and `action.target.height`: Dimension of the target element