### PR TITLE
RUMM-2195: Add OS and device information properties to the RUM schema

### DIFF
--- a/samples/rum/view.json
+++ b/samples/rum/view.json
@@ -57,5 +57,16 @@
   },
   "context": {
     "foo": "bar"
+  },
+  "device": {
+    "type": "tablet",
+    "name": "iPad",
+    "model": "iPad",
+    "brand": "Apple"
+  },
+  "os": {
+    "name": "iOS",
+    "version": "15.1.1",
+    "version_major": "15"
   }
 }

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -204,6 +204,70 @@
       },
       "readOnly": true
     },
+    "os": {
+      "type": "object",
+      "description": "Operating system properties",
+      "required": [
+        "name",
+        "version",
+        "version_major"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operating system name, e.g. Android, iOS",
+          "readOnly": true
+        },
+        "version": {
+          "type": "string",
+          "description": "Full operating system version, e.g. 8.1.1",
+          "readOnly": true
+        },
+        "version_major": {
+          "type": "string",
+          "description": "Major operating system version, e.g. 8",
+          "readOnly": true
+        }
+      }
+    },
+    "device": {
+      "type": "object",
+      "description": "Device properties",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Device type info",
+          "enum": [
+            "mobile",
+            "desktop",
+            "tablet",
+            "tv",
+            "gaming_console",
+            "bot",
+            "other"
+          ],
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.",
+          "readOnly": true
+        },
+        "model": {
+          "type": "string",
+          "description": "Device SKU model, e.g. Samsung SM-988GN, etc. Quite often name and model can be the same.",
+          "readOnly": true
+        },
+        "brand": {
+          "type": "string",
+          "description": "Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.",
+          "readOnly": true
+        }
+      }
+    },
     "_dd": {
       "type": "object",
       "description": "Internal properties",


### PR DESCRIPTION
This change adds OS and device information properties to the RUM schema to stop relying on the User Agent parsing for mobile devices, because UA parsing is not quite reliable as a result of the wide range of UA formats which can be found across different Mobile/Tablet/TV/etc. devices.

This change is mostly backfill of the backend logic which extracts the following from the parsed UA:

* `os.name`
* `os.version`
* `os.version_major`
* `device.type`
* `device.name`
* `device.model`
* `device.brand`

All the fields of `os` property are required in assumption that it is always possible to get those values in any runtime.

Only `type` field of `device` is required, because SDK running on the `desktop`, for example, probably may not have any info about `name`, `model`, `brand` (or they can be not very representative).

`device.type` is taken from what we have already in the dashboard, with the only difference that `Appliance` type is replaced by the `TV`, because we have now a stronger focus on the TV platforms and any other device from `appliance` type can be marked as `other`.