### PR TITLE
Add feature flags to telemetry event

### DIFF
--- a/samples/rum-schema/telemetry/debug.json
+++ b/samples/rum-schema/telemetry/debug.json
@@ -19,6 +19,7 @@
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
+  "experimental_features": ["foo"],
   "telemetry": {
     "status": "debug",
     "message": "Session inconsistencies detected",

--- a/samples/rum-schema/telemetry/error.json
+++ b/samples/rum-schema/telemetry/error.json
@@ -19,6 +19,7 @@
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
+  "experimental_features": ["foo"],
   "telemetry": {
     "status": "error",
     "message": "XHR error POST https://app.datadoghq.com/api/v1/logs-analytics/aggregate?type=rum",

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -92,6 +92,14 @@
           "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
         }
       }
+    },
+    "experimental_features":  {
+      "type": "array",
+      "description": "Enabled experimental features",
+      "items": {
+        "type": "string"
+      },
+      "readOnly": true
     }
   }
 }


### PR DESCRIPTION
Since the browser SDK uses standard feature flags (cf: https://github.com/DataDog/web-ui/pull/60432) we can now sample them.
The goal is to help us investigate an experimental feature impact by comparing two data sets:
- One with the feature enabled
- Another with the feature disabled

To do so, we also need to add the enabled feature flag to the telemetry events to filter on them.