### PR TITLE
Add CPU architecture to RUM error events

### DIFF
--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -289,6 +289,11 @@
           "type": "string",
           "description": "Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.",
           "readOnly": true
+        },
+        "architecture": {
+          "type": "string",
+          "description": "The CPU architecture of the device that is reporting the error",
+          "readOnly": true
         }
       }
     },


### PR DESCRIPTION
The CPU architecture will be needed by Flutter to determine which symbols file to use to decode Dart stack traces.