### PR TITLE
👷 fix CODEOWNERS attribution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,2 @@
-*   @Datadog/rum-back @Datadog/rum-browser @Datadog/rum-mobile
-
-# Session Replay
-/samples/session-replay-schema/ @DataDog/rum-session-replay
-/schemas/session-replay/ @DataDog/rum-session-replay
-/schemas/session-replay-browser-schema.json @DataDog/rum-session-replay
-/schemas/session-replay-mobile-schema.json @DataDog/rum-session-replay
-/session-replay-browser-format.json @DataDog/rum-session-replay
-/session-replay-mobile-format.json @DataDog/rum-session-replay
+*                 @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
+session-replay*   @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *                 @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
-session-replay*   @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
+session-replay*   @DataDog/rum-session-replay


### PR DESCRIPTION
Codeowners syntax is not cumulative, each line replace other owners. This PR simplifies the CODEOWNERS and makes sure rum-browser and rum-mobile also own session-replay files.

Checked with this unofficial [`codeowners`](https://github.com/hmarr/codeowners) cli:

```
$ codeowners | sort
.github/CODEOWNERS                                                      @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
.github/workflows/ci.yml                                                @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
LICENSE                                                                 @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
NOTICE                                                                  @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
README.md                                                               @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
lint.sh                                                                 @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
rum-events-format.json                                                  @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/action.json                                      @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/app_start.json                                   @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/error.json                                       @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/extended_error.json                              @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/long_task.json                                   @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/resource.json                                    @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/rum/view.json                                        @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/telemetry/debug.json                                 @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/rum-schema/telemetry/error.json                                 @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
samples/session-replay-schema/mobile-records/json/full-snapshot-record.json  @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
samples/session-replay-schema/mobile-records/json/has-focus-record.json  @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
samples/session-replay-schema/mobile-records/json/incremental-snapshot-record.json  @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
samples/session-replay-schema/mobile-records/json/metadata-record.json  @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
samples/session-replay-schema/mobile-records/json/view-end-record.json  @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
samples/session-replay-schema/mobile-segments/json/segment.json         @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
schemas/rum-events-schema.json                                          @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/_action-child-schema.json                                   @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/_common-schema.json                                         @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/action-schema.json                                          @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/error-schema.json                                           @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/long_task-schema.json                                       @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/resource-schema.json                                        @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/rum/view-schema.json                                            @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/session-replay-browser-schema.json                              @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
schemas/session-replay-mobile-schema.json                               @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
schemas/session-replay-schema.json                                      @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
schemas/session-replay/browser/attribute-mutation-schema.json           @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
[...]
schemas/session-replay/segment-schema.json                              @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
schemas/telemetry-events-schema.json                                    @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/telemetry/_common-schema.json                                   @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/telemetry/debug-schema.json                                     @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
schemas/telemetry/error-schema.json                                     @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
session-replay-browser-format.json                                      @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
session-replay-mobile-format.json                                       @DataDog/rum-browser @DataDog/rum-mobile @DataDog/rum-session-replay
validate.py                                                             @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
validate.sh                                                             @Datadog/rum-browser @Datadog/rum-mobile @Datadog/rum-back
```