### PR TITLE
[REPLAY-945] Distinct Mobile and Browser full & incremental snapshot record type integer values

### DIFF
--- a/samples/session-replay-schema/mobile-records/json/full-snapshot-record.json
+++ b/samples/session-replay-schema/mobile-records/json/full-snapshot-record.json
@@ -1,6 +1,6 @@
 {
     "timestamp": 1657618587157,
-    "type": 2,
+    "type": 10,
     "data": {
         "wireframes": [
             {

--- a/samples/session-replay-schema/mobile-records/json/incremental-snapshot-record.json
+++ b/samples/session-replay-schema/mobile-records/json/incremental-snapshot-record.json
@@ -1,6 +1,6 @@
 {
     "timestamp": 1657620232337,
-    "type": 3,
+    "type": 11,
     "data": {
         "source": 0,
         "adds": [

--- a/samples/session-replay-schema/mobile-segments/json/segment.json
+++ b/samples/session-replay-schema/mobile-segments/json/segment.json
@@ -18,7 +18,7 @@
     "records": [
         {
             "timestamp": 1657629228218,
-            "type": 2,
+            "type": 10,
             "data": {
                 "wireframes": [
                     {
@@ -57,7 +57,7 @@
         },
         {
             "timestamp": 1657629228273,
-            "type": 3,
+            "type": 11,
             "data": {
                 "source": 0,
                 "adds": [

--- a/schemas/session-replay/mobile/full-snapshot-record-schema.json
+++ b/schemas/session-replay/mobile/full-snapshot-record-schema.json
@@ -14,7 +14,7 @@
         "type": {
           "type": "integer",
           "description": "The type of this Record.",
-          "const": 2,
+          "const": 10,
           "readOnly": true
         },
         "data": {

--- a/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
+++ b/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
@@ -14,7 +14,7 @@
         "type": {
           "type": "integer",
           "description": "The type of this Record.",
-          "const": 3,
+          "const": 11,
           "readOnly": true
         },
         "data": {


### PR DESCRIPTION
## What is this PR doing?

It's been agreed that we will want to distinguish records for both Full and Incremental snapshots, either for Mobile or Browser Session Replay recordings.

This PR sets the new integer identifier values for Mobile record types.

## QA

Samples have been adjusted to validate against the schema changes.
