### PR TITLE
RUMM-2374 Add support for OTA updates in error schema

### DIFF
--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -131,6 +131,11 @@
                 }
               },
               "readOnly": true
+            },
+            "bundle_version": {
+              "type": "string",
+              "description": "Version of the javascript bundle used in the case of Over The Air updates",
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
# Purpose of this PR

This PR adds support for OTA (over the air) updates for javascript cross-platform technologies such as React Native.

OTA Updates enable developers to update the javascript bundle of their app remotely, without having to submit their app to the stores:
![image](https://user-images.githubusercontent.com/8973379/181265704-2e8b9616-1c0e-498c-a78f-6eb4657b4b15.png)


When using OTA updates we need 2 attributes to match an error to its source maps:
- the native version (generated when the app was submitted to the stores)
- the bundle version (generated when the bundle is built)

The main OTA updates services for react native are [CodePush](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/) and [Expo EAS Update](https://docs.expo.dev/eas-update/introduction/).

We have access to the bundle version in the app, so we can send it to the backend when there's a crash to unminify the error using the correct sourcemaps.
![image](https://user-images.githubusercontent.com/8973379/181266383-db46db4e-fee9-4493-ad8c-24f5a408f07c.png)

The idea is then to display this information as a facet when it is available in the UI to quickly see if a bug is fixed in a new update:

![image](https://user-images.githubusercontent.com/8973379/181266632-3e2e0c38-2df9-4ed9-9c38-80adcf3f1909.png)
