### PR TITLE
[REPLAY] MobileMutationData.source is mandatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   check-is-built:

--- a/dist/generated/mobileSessionReplay.d.ts
+++ b/dist/generated/mobileSessionReplay.d.ts
@@ -174,7 +174,7 @@ export declare type MobileMutationData = {
     /**
      * The source of this type of incremental data.
      */
-    readonly source?: 0;
+    readonly source: 0;
 } & MobileMutationPayload;
 /**
  * Mobile-specific. Schema of a MutationPayload.

--- a/dist/generated/rum.d.ts
+++ b/dist/generated/rum.d.ts
@@ -46,7 +46,7 @@ export declare type RumActionEvent = CommonProperties & {
             /**
              * Action frustration types
              */
-            readonly type: ('rage_click' | 'dead_click' | 'error_click')[];
+            readonly type: ('rage_click' | 'dead_click' | 'error_click' | 'rage_tap' | 'error_tap')[];
             [k: string]: unknown;
         };
         /**

--- a/dist/generated/sessionReplay.d.ts
+++ b/dist/generated/sessionReplay.d.ts
@@ -436,7 +436,7 @@ export declare type MobileMutationData = {
     /**
      * The source of this type of incremental data.
      */
-    readonly source?: 0;
+    readonly source: 0;
 } & MobileMutationPayload;
 /**
  * Mobile-specific. Schema of a MutationPayload.

--- a/schemas/session-replay/mobile/mutation-data-schema.json
+++ b/schemas/session-replay/mobile/mutation-data-schema.json
@@ -6,6 +6,7 @@
   "description": "Mobile-specific. Schema of a MutationData.",
   "allOf": [
     {
+      "required": ["source"],
       "properties": {
         "source": {
           "type": "integer",


### PR DESCRIPTION
Same as for Browser, `MobileMutationData.source` must be mandatory to allow telling what has triggered an IncrementalRecord.

This will be needed in the future and enables interoperability in the player.

Additionally, `synchronize` is added as a `pull_request` trigger for CI actions.