### PR TITLE
Add view.first_byte

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -500,7 +500,7 @@ export declare type RumViewEvent = CommonProperties & {
         /**
          * Duration in ns to the response start of the document request
          */
-        readonly time_to_first_byte?: number;
+        readonly first_byte?: number;
         /**
          * User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
          */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -498,6 +498,10 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly load_event?: number;
         /**
+         * Duration in ns to the response start of the document request
+         */
+        readonly time_to_first_byte?: number;
+        /**
          * User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
          */
         readonly custom_timings?: {

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -478,7 +478,7 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
-         * Total layout shift score that occured on the view
+         * Total layout shift score that occurred on the view
          */
         readonly cumulative_layout_shift?: number;
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -500,7 +500,7 @@ export declare type RumViewEvent = CommonProperties & {
         /**
          * Duration in ns to the response start of the document request
          */
-        readonly time_to_first_byte?: number;
+        readonly first_byte?: number;
         /**
          * User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -498,6 +498,10 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly load_event?: number;
         /**
+         * Duration in ns to the response start of the document request
+         */
+        readonly time_to_first_byte?: number;
+        /**
          * User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
          */
         readonly custom_timings?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -478,7 +478,7 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
-         * Total layout shift score that occured on the view
+         * Total layout shift score that occurred on the view
          */
         readonly cumulative_layout_shift?: number;
         /**

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -103,6 +103,12 @@
               "minimum": 0,
               "readOnly": true
             },
+            "time_to_first_byte": {
+              "type": "integer",
+              "description": "Duration in ns to the response start of the document request",
+              "minimum": 0,
+              "readOnly": true
+            },
             "custom_timings": {
               "type": "object",
               "description": "User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $",

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -103,7 +103,7 @@
               "minimum": 0,
               "readOnly": true
             },
-            "time_to_first_byte": {
+            "first_byte": {
               "type": "integer",
               "description": "Duration in ns to the response start of the document request",
               "minimum": 0,

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -75,7 +75,7 @@
             },
             "cumulative_layout_shift": {
               "type": "number",
-              "description": "Total layout shift score that occured on the view",
+              "description": "Total layout shift score that occurred on the view",
               "minimum": 0,
               "readOnly": true
             },


### PR DESCRIPTION
We already collect this data for resource events, cf [resource schema](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/resource-schema.json#L149).
Here the time to first byte of the resource corresponding to the document loading is attached to the view as a new timing metric.

More info on [ttfb](https://web.dev/ttfb/#measure-ttfb-in-javascript).