### PR TITLE
REPLAY-1033: Add BrowserSource and MobileSource consts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
-lib
+lib/cjs
+lib/esm
+lib/generated

--- a/lib/cjs/src/session-replay-browser.d.ts
+++ b/lib/cjs/src/session-replay-browser.d.ts
@@ -1,5 +1,12 @@
 import type * as SessionReplay from '../generated/browserSessionReplay';
 export * from '../generated/browserSessionReplay';
+/**
+ * For backward compatibility reasons, `undefined` should be accepted as a possible value for Browser segments, too.
+ **/
+export declare const BrowserSource: {
+    [key: string]: SessionReplay.BrowserSegmentMetadata['source'];
+};
+export declare type BrowserSource = typeof BrowserSource[keyof typeof BrowserSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.BrowserFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.BrowserIncrementalSnapshotRecord['type'];

--- a/lib/cjs/src/session-replay-browser.js
+++ b/lib/cjs/src/session-replay-browser.js
@@ -14,8 +14,14 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.MediaInteractionType = exports.MouseInteractionType = exports.IncrementalSource = exports.NodeType = exports.RecordType = void 0;
+exports.MediaInteractionType = exports.MouseInteractionType = exports.IncrementalSource = exports.NodeType = exports.RecordType = exports.BrowserSource = void 0;
 __exportStar(require("../generated/browserSessionReplay"), exports);
+/**
+ * For backward compatibility reasons, `undefined` should be accepted as a possible value for Browser segments, too.
+ **/
+exports.BrowserSource = {
+    Browser: 'browser',
+};
 exports.RecordType = {
     FullSnapshot: 2,
     IncrementalSnapshot: 3,

--- a/lib/cjs/src/session-replay-mobile.d.ts
+++ b/lib/cjs/src/session-replay-mobile.d.ts
@@ -1,5 +1,9 @@
 import type * as SessionReplay from '../generated/mobileSessionReplay';
 export * from '../generated/mobileSessionReplay';
+export declare const MobileSource: {
+    [key: string]: SessionReplay.MobileSegmentMetadata['source'];
+};
+export declare type MobileSource = typeof MobileSource[keyof typeof MobileSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.MobileFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.MobileIncrementalSnapshotRecord['type'];

--- a/lib/cjs/src/session-replay-mobile.js
+++ b/lib/cjs/src/session-replay-mobile.js
@@ -14,8 +14,14 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IncrementalSource = exports.WireframeType = exports.RecordType = void 0;
+exports.IncrementalSource = exports.WireframeType = exports.RecordType = exports.MobileSource = void 0;
 __exportStar(require("../generated/mobileSessionReplay"), exports);
+exports.MobileSource = {
+    Android: 'android',
+    Ios: 'ios',
+    Flutter: 'flutter',
+    ReactNative: 'react-native',
+};
 exports.RecordType = {
     FullSnapshot: 10,
     IncrementalSnapshot: 11,

--- a/lib/cjs/src/session-replay.d.ts
+++ b/lib/cjs/src/session-replay.d.ts
@@ -1,8 +1,8 @@
 import type { RecordType as BrowserRecordType } from './session-replay-browser';
 import type { RecordType as MobileRecordType } from './session-replay-mobile';
 export * from '../generated/sessionReplay';
-export { NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType } from './session-replay-browser';
-export { WireframeType } from './session-replay-mobile';
+export { BrowserSource, NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType, } from './session-replay-browser';
+export { MobileSource, WireframeType } from './session-replay-mobile';
 export declare const RecordType: {
     BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot;
     BrowserIncrementalSnapshot: typeof BrowserRecordType.IncrementalSnapshot;

--- a/lib/cjs/src/session-replay.js
+++ b/lib/cjs/src/session-replay.js
@@ -14,14 +14,16 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.RecordType = exports.WireframeType = exports.MediaInteractionType = exports.MouseInteractionType = exports.IncrementalSource = exports.NodeType = void 0;
+exports.RecordType = exports.WireframeType = exports.MobileSource = exports.MediaInteractionType = exports.MouseInteractionType = exports.IncrementalSource = exports.NodeType = exports.BrowserSource = void 0;
 __exportStar(require("../generated/sessionReplay"), exports);
 var session_replay_browser_1 = require("./session-replay-browser");
+Object.defineProperty(exports, "BrowserSource", { enumerable: true, get: function () { return session_replay_browser_1.BrowserSource; } });
 Object.defineProperty(exports, "NodeType", { enumerable: true, get: function () { return session_replay_browser_1.NodeType; } });
 Object.defineProperty(exports, "IncrementalSource", { enumerable: true, get: function () { return session_replay_browser_1.IncrementalSource; } });
 Object.defineProperty(exports, "MouseInteractionType", { enumerable: true, get: function () { return session_replay_browser_1.MouseInteractionType; } });
 Object.defineProperty(exports, "MediaInteractionType", { enumerable: true, get: function () { return session_replay_browser_1.MediaInteractionType; } });
 var session_replay_mobile_1 = require("./session-replay-mobile");
+Object.defineProperty(exports, "MobileSource", { enumerable: true, get: function () { return session_replay_mobile_1.MobileSource; } });
 Object.defineProperty(exports, "WireframeType", { enumerable: true, get: function () { return session_replay_mobile_1.WireframeType; } });
 exports.RecordType = {
     BrowserFullSnapshot: 2,

--- a/lib/esm/src/session-replay-browser.d.ts
+++ b/lib/esm/src/session-replay-browser.d.ts
@@ -1,5 +1,12 @@
 import type * as SessionReplay from '../generated/browserSessionReplay';
 export * from '../generated/browserSessionReplay';
+/**
+ * For backward compatibility reasons, `undefined` should be accepted as a possible value for Browser segments, too.
+ **/
+export declare const BrowserSource: {
+    [key: string]: SessionReplay.BrowserSegmentMetadata['source'];
+};
+export declare type BrowserSource = typeof BrowserSource[keyof typeof BrowserSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.BrowserFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.BrowserIncrementalSnapshotRecord['type'];

--- a/lib/esm/src/session-replay-browser.js
+++ b/lib/esm/src/session-replay-browser.js
@@ -1,4 +1,10 @@
 export * from '../generated/browserSessionReplay';
+/**
+ * For backward compatibility reasons, `undefined` should be accepted as a possible value for Browser segments, too.
+ **/
+export var BrowserSource = {
+    Browser: 'browser',
+};
 export var RecordType = {
     FullSnapshot: 2,
     IncrementalSnapshot: 3,

--- a/lib/esm/src/session-replay-mobile.d.ts
+++ b/lib/esm/src/session-replay-mobile.d.ts
@@ -1,5 +1,9 @@
 import type * as SessionReplay from '../generated/mobileSessionReplay';
 export * from '../generated/mobileSessionReplay';
+export declare const MobileSource: {
+    [key: string]: SessionReplay.MobileSegmentMetadata['source'];
+};
+export declare type MobileSource = typeof MobileSource[keyof typeof MobileSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.MobileFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.MobileIncrementalSnapshotRecord['type'];

--- a/lib/esm/src/session-replay-mobile.js
+++ b/lib/esm/src/session-replay-mobile.js
@@ -1,4 +1,10 @@
 export * from '../generated/mobileSessionReplay';
+export var MobileSource = {
+    Android: 'android',
+    Ios: 'ios',
+    Flutter: 'flutter',
+    ReactNative: 'react-native',
+};
 export var RecordType = {
     FullSnapshot: 10,
     IncrementalSnapshot: 11,

--- a/lib/esm/src/session-replay.d.ts
+++ b/lib/esm/src/session-replay.d.ts
@@ -1,8 +1,8 @@
 import type { RecordType as BrowserRecordType } from './session-replay-browser';
 import type { RecordType as MobileRecordType } from './session-replay-mobile';
 export * from '../generated/sessionReplay';
-export { NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType } from './session-replay-browser';
-export { WireframeType } from './session-replay-mobile';
+export { BrowserSource, NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType, } from './session-replay-browser';
+export { MobileSource, WireframeType } from './session-replay-mobile';
 export declare const RecordType: {
     BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot;
     BrowserIncrementalSnapshot: typeof BrowserRecordType.IncrementalSnapshot;

--- a/lib/esm/src/session-replay.js
+++ b/lib/esm/src/session-replay.js
@@ -1,6 +1,6 @@
 export * from '../generated/sessionReplay';
-export { NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType } from './session-replay-browser';
-export { WireframeType } from './session-replay-mobile';
+export { BrowserSource, NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType, } from './session-replay-browser';
+export { MobileSource, WireframeType } from './session-replay-mobile';
 export var RecordType = {
     BrowserFullSnapshot: 2,
     BrowserIncrementalSnapshot: 3,

--- a/lib/src/session-replay-browser.ts
+++ b/lib/src/session-replay-browser.ts
@@ -2,6 +2,17 @@ import type * as SessionReplay from '../generated/browserSessionReplay'
 
 export * from '../generated/browserSessionReplay'
 
+/**
+ * For backward compatibility reasons, `undefined` should be accepted as a possible value for Browser segments, too.
+ **/
+export const BrowserSource: {
+  [key: string]: SessionReplay.BrowserSegmentMetadata['source']
+} = {
+  Browser: 'browser',
+}
+
+export type BrowserSource = typeof BrowserSource[keyof typeof BrowserSource]
+
 export const RecordType: {
   FullSnapshot: SessionReplay.BrowserFullSnapshotRecord['type']
   IncrementalSnapshot: SessionReplay.BrowserIncrementalSnapshotRecord['type']

--- a/lib/src/session-replay-mobile.ts
+++ b/lib/src/session-replay-mobile.ts
@@ -2,6 +2,17 @@ import type * as SessionReplay from '../generated/mobileSessionReplay'
 
 export * from '../generated/mobileSessionReplay'
 
+export const MobileSource: {
+  [key: string]: SessionReplay.MobileSegmentMetadata['source']
+} = {
+  Android: 'android',
+  Ios: 'ios',
+  Flutter: 'flutter',
+  ReactNative: 'react-native',
+}
+
+export type MobileSource = typeof MobileSource[keyof typeof MobileSource]
+
 export const RecordType: {
   FullSnapshot: SessionReplay.MobileFullSnapshotRecord['type']
   IncrementalSnapshot: SessionReplay.MobileIncrementalSnapshotRecord['type']

--- a/lib/src/session-replay.ts
+++ b/lib/src/session-replay.ts
@@ -3,8 +3,8 @@ import type { RecordType as MobileRecordType } from './session-replay-mobile'
 
 export * from '../generated/sessionReplay'
 
-export { NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType } from './session-replay-browser'
-export { WireframeType } from './session-replay-mobile'
+export { BrowserSource, NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType } from './session-replay-browser'
+export { MobileSource, WireframeType } from './session-replay-mobile'
 
 export const RecordType: {
   BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot

--- a/lib/src/session-replay.ts
+++ b/lib/src/session-replay.ts
@@ -3,7 +3,13 @@ import type { RecordType as MobileRecordType } from './session-replay-mobile'
 
 export * from '../generated/sessionReplay'
 
-export { BrowserSource, NodeType, IncrementalSource, MouseInteractionType, MediaInteractionType } from './session-replay-browser'
+export {
+  BrowserSource,
+  NodeType,
+  IncrementalSource,
+  MouseInteractionType,
+  MediaInteractionType,
+} from './session-replay-browser'
 export { MobileSource, WireframeType } from './session-replay-mobile'
 
 export const RecordType: {


### PR DESCRIPTION
# Motivation

In order to have type guards for `SegmentMetadata['source']` properties, let's export some consts containing the possible values for both Browser & Mobile segments.

# Changes

Adds two exported objects: `BrowserSource` and `MobileSource`.