### PR TITLE
RUMM-2434 allow roku as error.source_type

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -216,7 +216,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */
-        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter';
+        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku';
         /**
          * Resource properties of the error
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -216,7 +216,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */
-        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter';
+        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku';
         /**
          * Resource properties of the error
          */

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -104,7 +104,7 @@
             "source_type": {
               "type": "string",
               "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
-              "enum": ["android", "browser", "ios", "react-native", "flutter"],
+              "enum": ["android", "browser", "ios", "react-native", "flutter", "roku"],
               "readOnly": true
             },
             "resource": {


### PR DESCRIPTION
Allow errors from our Roku SDK to be treated as specific `error.source_type`