### PR TITLE
Add `longTask._dd.discarded`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -293,6 +293,16 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
         readonly is_frozen_frame?: boolean;
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Whether the long task should be discarded or indexed
+         */
+        readonly discarded?: boolean;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -293,6 +293,16 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
         readonly is_frozen_frame?: boolean;
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Whether the long task should be discarded or indexed
+         */
+        readonly discarded?: boolean;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -44,6 +44,18 @@
             }
           },
           "readOnly": true
+        },
+        "_dd": {
+          "type": "object",
+          "description": "Internal properties",
+          "properties": {
+            "discarded": {
+              "type": "boolean",
+              "description": "Whether the long task should be discarded or indexed",
+              "readOnly": true
+            }
+          },
+          "readOnly": true
         }
       }
     }


### PR DESCRIPTION
Following #102, introduce `longTask._dd.discarded` to allow the backend to correctly discard/index long task events.