### PR TITLE
[REPLAY] update Schemas to enable string ids for replay node map and mutations

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -42,7 +42,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: string;
+    id: string | number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
@@ -426,8 +426,8 @@ export interface AddedNodeMutation {
      * Id for the parent node for this AddedNodeMutation.
      */
     parentId: number;
-    nextId: number | null;
-    previousId?: number | null;
+    nextId: number | (string | number);
+    previousId?: (string | number) | null;
 }
 /**
  * Schema of a RemovedNodeMutation.
@@ -436,11 +436,11 @@ export interface RemovedNodeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Id for the parent node for this RemovedNodeMutation
      */
-    parentId: number;
+    parentId: string | number;
 }
 /**
  * Schema of an AttributeMutation.
@@ -449,7 +449,7 @@ export interface AttributeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Attributes for this AttributeMutation
      */
@@ -464,7 +464,7 @@ export interface TextMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Value for this TextMutation
      */

--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -42,7 +42,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: number;
+    id: string;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.

--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -425,8 +425,8 @@ export interface AddedNodeMutation {
     /**
      * Id for the parent node for this AddedNodeMutation.
      */
-    parentId: number;
-    nextId: number | (string | number);
+    parentId: string | number;
+    nextId: (string | number) | null;
     previousId?: (string | number) | null;
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -50,7 +50,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: string;
+    id: string | number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
@@ -730,8 +730,8 @@ export interface AddedNodeMutation {
      * Id for the parent node for this AddedNodeMutation.
      */
     parentId: number;
-    nextId: number | null;
-    previousId?: number | null;
+    nextId: number | (string | number);
+    previousId?: (string | number) | null;
 }
 /**
  * Schema of a RemovedNodeMutation.
@@ -740,11 +740,11 @@ export interface RemovedNodeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Id for the parent node for this RemovedNodeMutation
      */
-    parentId: number;
+    parentId: string | number;
 }
 /**
  * Schema of an AttributeMutation.
@@ -753,7 +753,7 @@ export interface AttributeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Attributes for this AttributeMutation
      */
@@ -768,7 +768,7 @@ export interface TextMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Value for this TextMutation
      */

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -729,8 +729,8 @@ export interface AddedNodeMutation {
     /**
      * Id for the parent node for this AddedNodeMutation.
      */
-    parentId: number;
-    nextId: number | (string | number);
+    parentId: string | number;
+    nextId: (string | number) | null;
     previousId?: (string | number) | null;
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -50,7 +50,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: number;
+    id: string;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -42,7 +42,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: string;
+    id: string | number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
@@ -426,8 +426,8 @@ export interface AddedNodeMutation {
      * Id for the parent node for this AddedNodeMutation.
      */
     parentId: number;
-    nextId: number | null;
-    previousId?: number | null;
+    nextId: number | (string | number);
+    previousId?: (string | number) | null;
 }
 /**
  * Schema of a RemovedNodeMutation.
@@ -436,11 +436,11 @@ export interface RemovedNodeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Id for the parent node for this RemovedNodeMutation
      */
-    parentId: number;
+    parentId: string | number;
 }
 /**
  * Schema of an AttributeMutation.
@@ -449,7 +449,7 @@ export interface AttributeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Attributes for this AttributeMutation
      */
@@ -464,7 +464,7 @@ export interface TextMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Value for this TextMutation
      */

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -42,7 +42,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: number;
+    id: string;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -425,8 +425,8 @@ export interface AddedNodeMutation {
     /**
      * Id for the parent node for this AddedNodeMutation.
      */
-    parentId: number;
-    nextId: number | (string | number);
+    parentId: string | number;
+    nextId: (string | number) | null;
     previousId?: (string | number) | null;
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -50,7 +50,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: string;
+    id: string | number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
@@ -730,8 +730,8 @@ export interface AddedNodeMutation {
      * Id for the parent node for this AddedNodeMutation.
      */
     parentId: number;
-    nextId: number | null;
-    previousId?: number | null;
+    nextId: number | (string | number);
+    previousId?: (string | number) | null;
 }
 /**
  * Schema of a RemovedNodeMutation.
@@ -740,11 +740,11 @@ export interface RemovedNodeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Id for the parent node for this RemovedNodeMutation
      */
-    parentId: number;
+    parentId: string | number;
 }
 /**
  * Schema of an AttributeMutation.
@@ -753,7 +753,7 @@ export interface AttributeMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Attributes for this AttributeMutation
      */
@@ -768,7 +768,7 @@ export interface TextMutation {
     /**
      * Id of the mutated node.
      */
-    id: number;
+    id: string | number;
     /**
      * Value for this TextMutation
      */

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -729,8 +729,8 @@ export interface AddedNodeMutation {
     /**
      * Id for the parent node for this AddedNodeMutation.
      */
-    parentId: number;
-    nextId: number | (string | number);
+    parentId: string | number;
+    nextId: (string | number) | null;
     previousId?: (string | number) | null;
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -50,7 +50,7 @@ export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
  * Serialized node contained by this Record.
  */
 export declare type SerializedNodeWithId = {
-    id: number;
+    id: string;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.

--- a/schemas/session-replay/browser/attribute-mutation-schema.json
+++ b/schemas/session-replay/browser/attribute-mutation-schema.json
@@ -7,7 +7,7 @@
   "required": ["id", "attributes"],
   "properties": {
     "id": {
-      "type": "integer",
+      "type": ["string", "number"],
       "description": "Id of the mutated node."
     },
     "attributes": {

--- a/schemas/session-replay/browser/node-added-mutation-schema.json
+++ b/schemas/session-replay/browser/node-added-mutation-schema.json
@@ -10,17 +10,17 @@
       "$ref": "serialized-node-with-id-schema.json"
     },
     "parentId": {
-      "type": "integer",
+      "type": ["string", "number"],
       "description": "Id for the parent node for this AddedNodeMutation."
     },
     "nextId": {
       "anyOf": [
         {
-          "type": "integer",
+          "type": ["string", "number"],
           "description": "Id for the next sibling node for this AddedNodeMutation."
         },
         {
-          "type": ["string", "number"],
+          "type": "null",
           "description": "Sent when there is no next sibling anymore."
         }
       ]

--- a/schemas/session-replay/browser/node-added-mutation-schema.json
+++ b/schemas/session-replay/browser/node-added-mutation-schema.json
@@ -20,7 +20,7 @@
           "description": "Id for the next sibling node for this AddedNodeMutation."
         },
         {
-          "type": "null",
+          "type": ["string", "number"],
           "description": "Sent when there is no next sibling anymore."
         }
       ]
@@ -28,7 +28,7 @@
     "previousId": {
       "anyOf": [
         {
-          "type": "integer",
+          "type": ["string", "number"],
           "description": "Id for the previous sibling node for this AddedNodeMutation."
         },
         {

--- a/schemas/session-replay/browser/node-removed-mutation-schema.json
+++ b/schemas/session-replay/browser/node-removed-mutation-schema.json
@@ -7,11 +7,11 @@
   "required": ["id", "parentId"],
   "properties": {
     "id": {
-      "type": "integer",
+      "type": ["string", "number"],
       "description": "Id of the mutated node."
     },
     "parentId": {
-      "type": "integer",
+      "type": ["string", "number"],
       "description": "Id for the parent node for this RemovedNodeMutation"
     }
   }

--- a/schemas/session-replay/browser/serialized-node-with-id-schema.json
+++ b/schemas/session-replay/browser/serialized-node-with-id-schema.json
@@ -10,7 +10,7 @@
       "required": ["id"],
       "properties": {
         "id": {
-          "type": "integer"
+          "type": "string"
         }
       }
     },

--- a/schemas/session-replay/browser/serialized-node-with-id-schema.json
+++ b/schemas/session-replay/browser/serialized-node-with-id-schema.json
@@ -10,7 +10,7 @@
       "required": ["id"],
       "properties": {
         "id": {
-          "type": "string"
+          "type": ["string", "number"]
         }
       }
     },

--- a/schemas/session-replay/browser/text-mutation-schema.json
+++ b/schemas/session-replay/browser/text-mutation-schema.json
@@ -7,7 +7,7 @@
   "required": ["id", "value"],
   "properties": {
     "id": {
-      "type": "integer",
+      "type": ["string", "number"],
       "description": "Id of the mutated node."
     },
     "value": {


### PR DESCRIPTION
## Context

There is no 1 to 1 mapping between wireframes and DOM nodes as 1 wireframe can be rendered with up to 3 nodes.

## Current implementation

currently the added nodes that are created while rendering a wireframe use unique number ids that need to be stored as metadata to later enable mutations.

## PR Improvements 

Instead of maintaining a map of these created number ids, using a string, this new ids can be prefixed and therefore `wireframe.id:1` can lead to `node.id:1`, `node.id:1-text-container` and `node.id:1-text-content`.

This allows us to apply the `TextMutation` of the `wireframe.id:1` as

```
TextMutation {
        id: '1-text-content',
        value: 'updatedText',
}
```