### PR TITLE
[RUMF-1380] Add telemetry.configuration.telemetry_configuration_sample_rate

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -92,6 +92,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             telemetry_sample_rate?: number;
             /**
+             * The percentage of telemetry configuration events sent after being sampled by telemetry_sample_rate
+             */
+            telemetry_configuration_sample_rate?: number;
+            /**
              * The percentage of requests traced
              */
             trace_sample_rate?: number;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -92,6 +92,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             telemetry_sample_rate?: number;
             /**
+             * The percentage of telemetry configuration events sent after being sampled by telemetry_sample_rate
+             */
+            telemetry_configuration_sample_rate?: number;
+            /**
              * The percentage of requests traced
              */
             trace_sample_rate?: number;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -25,6 +25,7 @@
     "configuration": {
       "session_sample_rate": 100,
       "telemetry_sample_rate": 100,
+      "telemetry_configuration_sample_rate": 5,
       "trace_sample_rate": 100,
       "session_replay_sample_rate": 100,
       "premium_sample_rate": 100,

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -37,6 +37,12 @@
                   "minimum": 0,
                   "maximum": 100
                 },
+                "telemetry_configuration_sample_rate": {
+                  "type": "integer",
+                  "description": "The percentage of telemetry configuration events sent after being sampled by telemetry_sample_rate",
+                  "minimum": 0,
+                  "maximum": 100
+                },
                 "trace_sample_rate": {
                   "type": "integer",
                   "description": "The percentage of requests traced",


### PR DESCRIPTION
In SDKs, the telemetry configuration is sample with `telemetry_sample_rate` and an extra sampling with `telemetry_configuration_sample_rate`.

For testing purposes the `telemetry_configuration_sample_rate` (default 5%) can be override by the init configuration.
Even if the option is ment for testing, we will collect it to see if some users mess with it.
