### PR TITLE
RUMM-2658 Add clip property for SR wireframes

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -436,6 +436,28 @@ export interface CommonWireframe {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height: number;
+    clip?: WireframeClip;
+}
+/**
+ * Schema of clipping information for a Wireframe.
+ */
+export interface WireframeClip {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
 }
 /**
  * Schema of common properties for WireframeUpdate events type.
@@ -461,6 +483,7 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
+    clip?: WireframeClip;
 }
 /**
  * Schema of a ViewportResizeDimension.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -935,6 +935,28 @@ export interface CommonWireframe {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height: number;
+    clip?: WireframeClip;
+}
+/**
+ * Schema of clipping information for a Wireframe.
+ */
+export interface WireframeClip {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
 }
 /**
  * Schema of common properties for WireframeUpdate events type.
@@ -960,4 +982,5 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
+    clip?: WireframeClip;
 }

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -436,6 +436,28 @@ export interface CommonWireframe {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height: number;
+    clip?: WireframeClip;
+}
+/**
+ * Schema of clipping information for a Wireframe.
+ */
+export interface WireframeClip {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
 }
 /**
  * Schema of common properties for WireframeUpdate events type.
@@ -461,6 +483,7 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
+    clip?: WireframeClip;
 }
 /**
  * Schema of a ViewportResizeDimension.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -935,6 +935,28 @@ export interface CommonWireframe {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height: number;
+    clip?: WireframeClip;
+}
+/**
+ * Schema of clipping information for a Wireframe.
+ */
+export interface WireframeClip {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
 }
 /**
  * Schema of common properties for WireframeUpdate events type.
@@ -960,4 +982,5 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
+    clip?: WireframeClip;
 }

--- a/schemas/session-replay/mobile/_common-wireframe-schema.json
+++ b/schemas/session-replay/mobile/_common-wireframe-schema.json
@@ -30,6 +30,9 @@
       "type": "integer",
       "description": "The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.",
       "readOnly": true
+    },
+    "clip": {
+      "$ref": "wireframe-clip-schema.json"
     }
   }
 }

--- a/schemas/session-replay/mobile/_common-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/_common-wireframe-update-schema.json
@@ -30,6 +30,9 @@
       "type": "integer",
       "description": "The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.",
       "readOnly": true
+    },
+    "clip": {
+      "$ref": "wireframe-clip-schema.json"
     }
   }
 }

--- a/schemas/session-replay/mobile/wireframe-clip-schema.json
+++ b/schemas/session-replay/mobile/wireframe-clip-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/wireframe-clip-schema.json",
+  "title": "WireframeClip",
+  "type": "object",
+  "description": "Schema of clipping information for a Wireframe.",
+  "properties": {
+    "top": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.",
+      "readOnly": true
+    },
+    "bottom": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.",
+      "readOnly": true
+    },
+    "left": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.",
+      "readOnly": true
+    },
+    "right": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.",
+      "readOnly": true
+    }
+  }
+}


### PR DESCRIPTION
Following this [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2666595788/RFC+-+Scrollable+containers+in+Mobile+Session+Replay) we are adding the `clipTop`, `clipBottom`, `clipLeft`, `clipRight` properties for the SR wireframes in order to achieve the look&feel of a mobile scrollable list on the player side.