### PR TITLE
[RUM][REPLAY] Add shadow DOM metadata

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -386,6 +386,7 @@ export interface ElementNode {
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
     isSVG?: true;
+    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -385,7 +385,13 @@ export interface ElementNode {
     tagName: string;
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
+    /**
+     * Is this node a SVG instead of a HTML
+     */
     isSVG?: true;
+    /**
+     * Is this node a host of a shadow root
+     */
     isShadowHost?: true;
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -689,7 +689,13 @@ export interface ElementNode {
     tagName: string;
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
+    /**
+     * Is this node a SVG instead of a HTML
+     */
     isSVG?: true;
+    /**
+     * Is this node a host of a shadow root
+     */
     isShadowHost?: true;
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -690,6 +690,7 @@ export interface ElementNode {
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
     isSVG?: true;
+    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -386,6 +386,7 @@ export interface ElementNode {
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
     isSVG?: true;
+    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -385,7 +385,13 @@ export interface ElementNode {
     tagName: string;
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
+    /**
+     * Is this node a SVG instead of a HTML
+     */
     isSVG?: true;
+    /**
+     * Is this node a host of a shadow root
+     */
     isShadowHost?: true;
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -689,7 +689,13 @@ export interface ElementNode {
     tagName: string;
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
+    /**
+     * Is this node a SVG instead of a HTML
+     */
     isSVG?: true;
+    /**
+     * Is this node a host of a shadow root
+     */
     isShadowHost?: true;
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -690,6 +690,7 @@ export interface ElementNode {
     attributes: Attributes;
     childNodes: SerializedNodeWithId[];
     isSVG?: true;
+    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/schemas/session-replay/browser/element-node-schema.json
+++ b/schemas/session-replay/browser/element-node-schema.json
@@ -26,10 +26,12 @@
       }
     },
     "isSVG": {
-      "const": true
+      "const": true,
+      "description": "Is this node a SVG instead of a HTML"
     },
     "isShadowHost": {
-      "const": true
+      "const": true,
+      "description": "Is this node a host of a shadow root"
     }
   }
 }

--- a/schemas/session-replay/browser/element-node-schema.json
+++ b/schemas/session-replay/browser/element-node-schema.json
@@ -27,6 +27,9 @@
     },
     "isSVG": {
       "const": true
+    },
+    "isShadowHost": {
+      "const": true
     }
   }
 }


### PR DESCRIPTION
Add support for shadow DOM in replay

Existing rrweb datastructure: https://github.com/rrweb-io/rrweb-snapshot/blob/775291042d8661af1a512832e2c3e44077466a4a/src/types.ts#L59-L60

Rrweb added two fields on the `Node` datastructure (HtmlElement, TextNode, Comment...): 
- `isShadowHost`: meaning when we build the node we have to call `node.attachShadow({ mode: 'open' })`
- `isShadow`: is the node a direct parent of a shadow DOM meaning when we build the node we have to add it to its parent using `node.shadowRoot.appendChild(childNode)` instead of `node.appendChild(childNode)`

We do need `isShadowHost` but I don't think we need `isShadow` because we already know the parent is a host.

The only possible issue that I have found is: what happens if we create a shadow root and add two types of children: normal child & shadow DOM. In this case, we see both tags in the DOM but only the shadow DOM is shown (see screenshot). For replay, we won't be recording the non-shadow DOM children. The rendering replay should be the same (but not the DOM). If we're not okay with that, we'll have to add the `isShadow` prop.


![Screenshot 2022-10-19 at 09 39 44](https://user-images.githubusercontent.com/44997281/196630298-815bf1d2-9395-4380-bb10-fcfa0dc00559.png)



