### PR TITLE
add nullable clip field

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -59,6 +59,28 @@ export declare type CommonShapeWireframe = CommonWireframe & {
     border?: ShapeBorder;
 };
 /**
+ * Schema of clipping information for a Wireframe.
+ */
+export declare type WireframeClip = WireframeClip1 & WireframeClip2;
+export declare type WireframeClip2 = {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
+} | null;
+/**
  * The style of this wireframe.
  */
 export declare type ShapeStyle = {
@@ -438,10 +460,7 @@ export interface CommonWireframe {
     readonly height: number;
     clip?: WireframeClip;
 }
-/**
- * Schema of clipping information for a Wireframe.
- */
-export interface WireframeClip {
+export interface WireframeClip1 {
     /**
      * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
      */
@@ -483,7 +502,7 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
-    clip?: WireframeClip;
+    clip?: WireframeClip2;
 }
 /**
  * Schema of a ViewportResizeDimension.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -321,6 +321,28 @@ export declare type CommonShapeWireframe = CommonWireframe & {
     border?: ShapeBorder;
 };
 /**
+ * Schema of clipping information for a Wireframe.
+ */
+export declare type WireframeClip = WireframeClip1 & WireframeClip2;
+export declare type WireframeClip2 = {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
+} | null;
+/**
  * The style of this wireframe.
  */
 export declare type ShapeStyle = {
@@ -937,10 +959,7 @@ export interface CommonWireframe {
     readonly height: number;
     clip?: WireframeClip;
 }
-/**
- * Schema of clipping information for a Wireframe.
- */
-export interface WireframeClip {
+export interface WireframeClip1 {
     /**
      * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
      */
@@ -982,5 +1001,5 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
-    clip?: WireframeClip;
+    clip?: WireframeClip2;
 }

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -59,6 +59,28 @@ export declare type CommonShapeWireframe = CommonWireframe & {
     border?: ShapeBorder;
 };
 /**
+ * Schema of clipping information for a Wireframe.
+ */
+export declare type WireframeClip = WireframeClip1 & WireframeClip2;
+export declare type WireframeClip2 = {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
+} | null;
+/**
  * The style of this wireframe.
  */
 export declare type ShapeStyle = {
@@ -438,10 +460,7 @@ export interface CommonWireframe {
     readonly height: number;
     clip?: WireframeClip;
 }
-/**
- * Schema of clipping information for a Wireframe.
- */
-export interface WireframeClip {
+export interface WireframeClip1 {
     /**
      * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
      */
@@ -483,7 +502,7 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
-    clip?: WireframeClip;
+    clip?: WireframeClip2;
 }
 /**
  * Schema of a ViewportResizeDimension.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -321,6 +321,28 @@ export declare type CommonShapeWireframe = CommonWireframe & {
     border?: ShapeBorder;
 };
 /**
+ * Schema of clipping information for a Wireframe.
+ */
+export declare type WireframeClip = WireframeClip1 & WireframeClip2;
+export declare type WireframeClip2 = {
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+     */
+    readonly top?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+     */
+    readonly bottom?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+     */
+    readonly left?: number;
+    /**
+     * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+     */
+    readonly right?: number;
+} | null;
+/**
  * The style of this wireframe.
  */
 export declare type ShapeStyle = {
@@ -937,10 +959,7 @@ export interface CommonWireframe {
     readonly height: number;
     clip?: WireframeClip;
 }
-/**
- * Schema of clipping information for a Wireframe.
- */
-export interface WireframeClip {
+export interface WireframeClip1 {
     /**
      * The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
      */
@@ -982,5 +1001,5 @@ export interface CommonWireframeUpdate {
      * The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
      */
     readonly height?: number;
-    clip?: WireframeClip;
+    clip?: WireframeClip2;
 }

--- a/schemas/session-replay/mobile/wireframe-clip-schema.json
+++ b/schemas/session-replay/mobile/wireframe-clip-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "session-replay/mobile/wireframe-clip-schema.json",
   "title": "WireframeClip",
-  "type": "object",
+  "type": ["object", "null"],
   "description": "Schema of clipping information for a Wireframe.",
   "properties": {
     "top": {


### PR DESCRIPTION
`clip` is optional (some wireframes don’t have any clip).

If you send an update that remove the clipping, either you need to send a `clip:{top:0, right:0, left:0, bottom:0,}` or a `clip: null` if you want to replace the wireframe clipping stored in the player memory.

The second option makes more sense to me.

EDIT: Mobile sdk would have trouble to send `clip: null` on their end. we will go for the other approach.





