### PR TITLE
Add resolveDuration to RumResourceEvent

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -342,6 +342,10 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly duration: number;
         /**
+         * Duration until the callback of the resource is resolved
+         */
+        readonly resolveDuration?: number;
+        /**
          * Size in octet of the resource response body
          */
         readonly size?: number;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -342,6 +342,10 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly duration: number;
         /**
+         * Duration until the callback of the resource is resolved
+         */
+        readonly resolveDuration?: number;
+        /**
          * Size in octet of the resource response body
          */
         readonly size?: number;

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -60,6 +60,12 @@
               "minimum": 0,
               "readOnly": true
             },
+            "resolveDuration": {
+              "type": "integer",
+              "description": "Duration until the callback of the resource is resolved",
+              "minimum": 0,
+              "readOnly": true
+            },
             "size": {
               "type": "integer",
               "description": "Size in octet of the resource response body",


### PR DESCRIPTION
We want to track the timings that are registered when the `fetch` resource are resolved