### PR TITLE
[RUMF-1402] Add feature_flags to view to error

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -265,6 +265,12 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
         readonly in_foreground?: boolean;
         [k: string]: unknown;
     };
+    /**
+     * Feature flags properties
+     */
+    readonly feature_flags?: {
+        [k: string]: boolean | string;
+    };
     [k: string]: unknown;
 };
 /**
@@ -672,6 +678,12 @@ export declare type RumViewEvent = CommonProperties & {
          */
         js_refresh_rate?: RumPerfMetric;
         [k: string]: unknown;
+    };
+    /**
+     * Feature flags properties
+     */
+    readonly feature_flags?: {
+        [k: string]: boolean | string;
     };
     /**
      * Internal properties

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -269,7 +269,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
      * Feature flags properties
      */
     readonly feature_flags?: {
-        [k: string]: boolean | string;
+        [k: string]: unknown;
     };
     [k: string]: unknown;
 };
@@ -683,7 +683,7 @@ export declare type RumViewEvent = CommonProperties & {
      * Feature flags properties
      */
     readonly feature_flags?: {
-        [k: string]: boolean | string;
+        [k: string]: unknown;
     };
     /**
      * Internal properties

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -265,6 +265,12 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
         readonly in_foreground?: boolean;
         [k: string]: unknown;
     };
+    /**
+     * Feature flags properties
+     */
+    readonly feature_flags?: {
+        [k: string]: boolean | string;
+    };
     [k: string]: unknown;
 };
 /**
@@ -672,6 +678,12 @@ export declare type RumViewEvent = CommonProperties & {
          */
         js_refresh_rate?: RumPerfMetric;
         [k: string]: unknown;
+    };
+    /**
+     * Feature flags properties
+     */
+    readonly feature_flags?: {
+        [k: string]: boolean | string;
     };
     /**
      * Internal properties

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -269,7 +269,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
      * Feature flags properties
      */
     readonly feature_flags?: {
-        [k: string]: boolean | string;
+        [k: string]: unknown;
     };
     [k: string]: unknown;
 };
@@ -683,7 +683,7 @@ export declare type RumViewEvent = CommonProperties & {
      * Feature flags properties
      */
     readonly feature_flags?: {
-        [k: string]: boolean | string;
+        [k: string]: unknown;
     };
     /**
      * Internal properties

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -43,6 +43,10 @@
   "action": {
     "id": ["ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c", "be3a5d82-cdd1-468d-9bc9-3aa9e54d953c"]
   },
+  "feature_flags": {
+    "feature_one": true,
+    "feature_two": "foo"
+  },
   "_dd": {
     "format_version": 2,
     "session": {

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -45,7 +45,9 @@
   },
   "feature_flags": {
     "feature_one": true,
-    "feature_two": "foo"
+    "feature_two": "foo",
+    "feature_three": 2,
+    "feature_four": { "foo": "bar" }
   },
   "_dd": {
     "format_version": 2,

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -71,6 +71,8 @@
   },
   "feature_flags": {
     "feature_one": true,
-    "feature_two": "foo"
+    "feature_two": "foo",
+    "feature_three": 2,
+    "feature_four": { "foo": "bar" }
   }
 }

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -68,5 +68,9 @@
     "name": "iOS",
     "version": "15.1.1",
     "version_major": "15"
+  },
+  "feature_flags": {
+    "feature_one": true,
+    "feature_two": "foo"
   }
 }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -189,7 +189,7 @@
         "feature_flags": {
           "type": "object",
           "description": "Feature flags properties",
-          "additionalProperties": { "type": ["boolean", "string"] },
+          "additionalProperties": true,
           "readOnly": true
         }
       }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -185,6 +185,12 @@
             }
           },
           "readOnly": true
+        },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags properties",
+          "additionalProperties": { "type": ["boolean", "string"] },
+          "readOnly": true
         }
       }
     }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -300,7 +300,7 @@
         "feature_flags": {
           "type": "object",
           "description": "Feature flags properties",
-          "additionalProperties": { "type": ["boolean", "string"] },
+          "additionalProperties": true,
           "readOnly": true
         },
         "_dd": {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -297,6 +297,12 @@
           },
           "readOnly": true
         },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags properties",
+          "additionalProperties": { "type": ["boolean", "string"] },
+          "readOnly": true
+        },
         "_dd": {
           "type": "object",
           "description": "Internal properties",


### PR DESCRIPTION
In the context of Feature Flag Analysis, we need to be able to collect them from RUM SDKs. 
This PR adds the `feature_flags` attribute to `view` and `error`
