### PR TITLE
[RUMF-1432] Add `track_resources` and `track_long_task`

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -128,6 +128,14 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_session_across_subdomains?: boolean;
             /**
+             * Whether resources are tracked
+             */
+            track_resources?: boolean;
+            /**
+             * Whether long tasks are tracked
+             */
+            track_long_task?: boolean;
+            /**
              * Whether a secure cross-site session cookie is used
              */
             use_cross_site_session_cookie?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -128,6 +128,14 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_session_across_subdomains?: boolean;
             /**
+             * Whether resources are tracked
+             */
+            track_resources?: boolean;
+            /**
+             * Whether long tasks are tracked
+             */
+            track_long_task?: boolean;
+            /**
              * Whether a secure cross-site session cookie is used
              */
             use_cross_site_session_cookie?: boolean;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -34,6 +34,8 @@
       "use_before_send": true,
       "silent_multiple_init": false,
       "track_session_across_subdomains": true,
+      "track_resources": true,
+      "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
       "action_name_attribute": "foo",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -83,6 +83,14 @@
                   "type": "boolean",
                   "description": "Whether sessions across subdomains for the same site are tracked"
                 },
+                "track_resources": {
+                  "type": "boolean",
+                  "description": "Whether resources are tracked"
+                },
+                "track_long_task": {
+                  "type": "boolean",
+                  "description": "Whether long tasks are tracked"
+                },
                 "use_cross_site_session_cookie": {
                   "type": "boolean",
                   "description": "Whether a secure cross-site session cookie is used"


### PR DESCRIPTION
Add `track_resources` and `track_long_task` to track for configuration telemetry