### PR TITLE
[RUM][REPLAY] fix pointer exports

### DIFF
--- a/lib/cjs/src/session-replay.d.ts
+++ b/lib/cjs/src/session-replay.d.ts
@@ -17,14 +17,14 @@ export declare const RecordType: {
 export declare type RecordType = typeof RecordType[keyof typeof RecordType];
 export declare type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource;
 export declare const PointerEventType: {
-    PointerDown: string;
-    PointerUp: string;
-    PointerMove: string;
+    readonly PointerDown: "down";
+    readonly PointerUp: "up";
+    readonly PointerMove: "move";
 };
 export declare type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType];
 export declare const PointerType: {
-    Mouse: string;
-    Touch: string;
-    Pen: string;
+    readonly Mouse: "mouse";
+    readonly Touch: "touch";
+    readonly Pen: "pen";
 };
 export declare type PointerType = typeof PointerType[keyof typeof PointerType];

--- a/lib/esm/src/session-replay.d.ts
+++ b/lib/esm/src/session-replay.d.ts
@@ -17,14 +17,14 @@ export declare const RecordType: {
 export declare type RecordType = typeof RecordType[keyof typeof RecordType];
 export declare type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource;
 export declare const PointerEventType: {
-    PointerDown: string;
-    PointerUp: string;
-    PointerMove: string;
+    readonly PointerDown: "down";
+    readonly PointerUp: "up";
+    readonly PointerMove: "move";
 };
 export declare type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType];
 export declare const PointerType: {
-    Mouse: string;
-    Touch: string;
-    Pen: string;
+    readonly Mouse: "mouse";
+    readonly Touch: "touch";
+    readonly Pen: "pen";
 };
 export declare type PointerType = typeof PointerType[keyof typeof PointerType];

--- a/lib/src/session-replay.ts
+++ b/lib/src/session-replay.ts
@@ -44,11 +44,7 @@ export type RecordType = typeof RecordType[keyof typeof RecordType]
 
 export type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource
 
-export const PointerEventType: {
-  PointerDown: string
-  PointerUp: string
-  PointerMove: string
-} = {
+export const PointerEventType = {
   PointerDown: 'down',
   PointerUp: 'up',
   PointerMove: 'move',
@@ -56,11 +52,7 @@ export const PointerEventType: {
 
 export type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType]
 
-export const PointerType: {
-  Mouse: string
-  Touch: string
-  Pen: string
-} = {
+export const PointerType = {
   Mouse: 'mouse',
   Touch: 'touch',
   Pen: 'pen',


### PR DESCRIPTION
### Issue

Generated const are erroneous:

```
export declare const PointerEventType: {
    PointerDown: string;
    PointerUp: string;
    PointerMove: string;
};
export declare type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType];
export declare const PointerType: {
    Mouse: string;
    Touch: string;
    Pen: string;
};
export declare type PointerType = typeof PointerType[keyof typeof PointerType];
```

### Change

- fix the erroneous const generation to get
```
export declare const PointerEventType: {
    readonly PointerDown: "down";
    readonly PointerUp: "up";
    readonly PointerMove: "move";
};
export declare type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType];
export declare const PointerType: {
    readonly Mouse: "mouse";
    readonly Touch: "touch";
    readonly Pen: "pen";
};
export declare type PointerType = typeof PointerType[keyof typeof PointerType];
```