### PR TITLE
Remove invalid property from `segment-metadata-schema`

### DIFF
--- a/schemas/session-replay/mobile/segment-metadata-schema.json
+++ b/schemas/session-replay/mobile/segment-metadata-schema.json
@@ -12,7 +12,7 @@
       "$ref": "../common/_common-segment-metadata-schema.json"
     },
     {
-      "required": ["source", "has_full_snapshot_record"],
+      "required": ["source"],
       "properties": {
         "source": {
           "type": "string",


### PR DESCRIPTION
### What & Why?

🐞 This PR fixes `segment-metadata-schema.json` for mobile - it was requiring `has_full_snapshot_record` property, but it wasn't defining its schema.

### How?

I'm removing `has_full_snapshot_record` from the list of required properties. If we really need it, it should be added back along with its schema definition.
