### PR TITLE
[RUMF-1446] add `cache_status` field for resoucres

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -436,6 +436,10 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             [k: string]: unknown;
         };
         /**
+         * Is the resource loaded from cache or fetched
+         */
+        readonly cache_status?: 'cached' | 'fetched';
+        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -436,6 +436,10 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             [k: string]: unknown;
         };
         /**
+         * Is the resource loaded from cache or fetched
+         */
+        readonly cache_status?: 'cached' | 'fetched';
+        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -29,7 +29,8 @@
     "first_byte": {
       "duration": 157090000,
       "start": 88945000
-    }
+    },
+    "cache_status": "fetched"
   },
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -186,6 +186,12 @@
               },
               "readOnly": true
             },
+            "cache_status": {
+              "type": "string",
+              "description": "Is the resource loaded from cache or fetched",
+              "enum": ["cached", "fetched"],
+              "readOnly": true
+            },
             "provider": {
               "type": "object",
               "description": "The provider for this resource",


### PR DESCRIPTION
We can determine if a resource was collected from `cache` or `fetched` based on [`PerformanceResourceTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize#value) values. 

This PR adds the field `cache_status`.