### PR TITLE
✨ [RUMF-1236] Open Telemetry usage

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -148,9 +148,17 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             action_name_attribute?: string;
             /**
-             * Whether the allowed tracing origins list is used
+             * Whether the allowed tracing origins list is used (deprecated in favor of use_allowed_tracing_urls)
              */
             use_allowed_tracing_origins?: boolean;
+            /**
+             * Whether the allowed tracing urls list is used
+             */
+            use_allowed_tracing_urls?: boolean;
+            /**
+             * A list of selected tracing propagators
+             */
+            selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[];
             /**
              * Session replay default privacy level
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -148,9 +148,17 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             action_name_attribute?: string;
             /**
-             * Whether the allowed tracing origins list is used
+             * Whether the allowed tracing origins list is used (deprecated in favor of use_allowed_tracing_urls)
              */
             use_allowed_tracing_origins?: boolean;
+            /**
+             * Whether the allowed tracing urls list is used
+             */
+            use_allowed_tracing_urls?: boolean;
+            /**
+             * A list of selected tracing propagators
+             */
+            selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[];
             /**
              * Session replay default privacy level
              */

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -109,7 +109,19 @@
                 },
                 "use_allowed_tracing_origins": {
                   "type": "boolean",
-                  "description": "Whether the allowed tracing origins list is used"
+                  "description": "Whether the allowed tracing origins list is used (deprecated in favor of use_allowed_tracing_urls)"
+                },
+                "use_allowed_tracing_urls": {
+                  "type": "boolean",
+                  "description": "Whether the allowed tracing urls list is used"
+                },
+                "selected_tracing_propagators": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["datadog", "b3", "b3multi", "tracecontext"]
+                  },
+                  "description": "A list of selected tracing propagators"
                 },
                 "default_privacy_level": {
                   "type": "string",


### PR DESCRIPTION
Add new fields to collect telemetry about Open Telemetry usage:

```use_allowed_tracing_urls``` gives the possibility to define which tracing headers should be sent, and replaces ```use_allowed_tracing_origins``` which has been deprecated.
```selected_tracing_propagators``` to monitor which propagators are used for tracing (datadog/b3/b3multi/tracecontext)