### PR TITLE
[REPLAY]  Update shadow DOM structure

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -47,7 +47,7 @@ export declare type SerializedNodeWithId = {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -357,6 +357,20 @@ export interface DocumentNode {
      * The type of this Node.
      */
     readonly type: 0;
+    childNodes: SerializedNodeWithId[];
+}
+/**
+ * Schema of a Document FragmentNode.
+ */
+export interface DocumentFragmentNode {
+    /**
+     * The type of this Node.
+     */
+    readonly type: 11;
+    /**
+     * Is this node a shadow root or not
+     */
+    readonly isShadowRoot: boolean;
     childNodes: SerializedNodeWithId[];
 }
 /**

--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -398,10 +398,6 @@ export interface ElementNode {
      * Is this node a SVG instead of a HTML
      */
     isSVG?: true;
-    /**
-     * Is this node a host of a shadow root
-     */
-    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -55,7 +55,7 @@ export declare type SerializedNodeWithId = {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -661,6 +661,20 @@ export interface DocumentNode {
      * The type of this Node.
      */
     readonly type: 0;
+    childNodes: SerializedNodeWithId[];
+}
+/**
+ * Schema of a Document FragmentNode.
+ */
+export interface DocumentFragmentNode {
+    /**
+     * The type of this Node.
+     */
+    readonly type: 11;
+    /**
+     * Is this node a shadow root or not
+     */
+    readonly isShadowRoot: boolean;
     childNodes: SerializedNodeWithId[];
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -702,10 +702,6 @@ export interface ElementNode {
      * Is this node a SVG instead of a HTML
      */
     isSVG?: true;
-    /**
-     * Is this node a host of a shadow root
-     */
-    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/cjs/src/session-replay-browser.d.ts
+++ b/lib/cjs/src/session-replay-browser.d.ts
@@ -23,6 +23,7 @@ export declare const NodeType: {
     Element: SessionReplay.ElementNode['type'];
     Text: SessionReplay.TextNode['type'];
     CDATA: SessionReplay.CDataNode['type'];
+    DocumentFragment: SessionReplay.DocumentFragmentNode['type'];
 };
 export declare type NodeType = typeof NodeType[keyof typeof NodeType];
 export declare const IncrementalSource: {

--- a/lib/cjs/src/session-replay-browser.js
+++ b/lib/cjs/src/session-replay-browser.js
@@ -37,6 +37,7 @@ exports.NodeType = {
     Element: 2,
     Text: 3,
     CDATA: 4,
+    DocumentFragment: 11,
 };
 exports.IncrementalSource = {
     Mutation: 0,

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -47,7 +47,7 @@ export declare type SerializedNodeWithId = {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -357,6 +357,20 @@ export interface DocumentNode {
      * The type of this Node.
      */
     readonly type: 0;
+    childNodes: SerializedNodeWithId[];
+}
+/**
+ * Schema of a Document FragmentNode.
+ */
+export interface DocumentFragmentNode {
+    /**
+     * The type of this Node.
+     */
+    readonly type: 11;
+    /**
+     * Is this node a shadow root or not
+     */
+    readonly isShadowRoot: boolean;
     childNodes: SerializedNodeWithId[];
 }
 /**

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -398,10 +398,6 @@ export interface ElementNode {
      * Is this node a SVG instead of a HTML
      */
     isSVG?: true;
-    /**
-     * Is this node a host of a shadow root
-     */
-    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -55,7 +55,7 @@ export declare type SerializedNodeWithId = {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -661,6 +661,20 @@ export interface DocumentNode {
      * The type of this Node.
      */
     readonly type: 0;
+    childNodes: SerializedNodeWithId[];
+}
+/**
+ * Schema of a Document FragmentNode.
+ */
+export interface DocumentFragmentNode {
+    /**
+     * The type of this Node.
+     */
+    readonly type: 11;
+    /**
+     * Is this node a shadow root or not
+     */
+    readonly isShadowRoot: boolean;
     childNodes: SerializedNodeWithId[];
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -702,10 +702,6 @@ export interface ElementNode {
      * Is this node a SVG instead of a HTML
      */
     isSVG?: true;
-    /**
-     * Is this node a host of a shadow root
-     */
-    isShadowHost?: true;
 }
 /**
  * Schema of an Attributes type.

--- a/lib/esm/src/session-replay-browser.d.ts
+++ b/lib/esm/src/session-replay-browser.d.ts
@@ -23,6 +23,7 @@ export declare const NodeType: {
     Element: SessionReplay.ElementNode['type'];
     Text: SessionReplay.TextNode['type'];
     CDATA: SessionReplay.CDataNode['type'];
+    DocumentFragment: SessionReplay.DocumentFragmentNode['type'];
 };
 export declare type NodeType = typeof NodeType[keyof typeof NodeType];
 export declare const IncrementalSource: {

--- a/lib/esm/src/session-replay-browser.js
+++ b/lib/esm/src/session-replay-browser.js
@@ -20,6 +20,7 @@ export var NodeType = {
     Element: 2,
     Text: 3,
     CDATA: 4,
+    DocumentFragment: 11,
 };
 export var IncrementalSource = {
     Mutation: 0,

--- a/lib/src/session-replay-browser.ts
+++ b/lib/src/session-replay-browser.ts
@@ -37,12 +37,14 @@ export const NodeType: {
   Element: SessionReplay.ElementNode['type']
   Text: SessionReplay.TextNode['type']
   CDATA: SessionReplay.CDataNode['type']
+  DocumentFragment: SessionReplay.DocumentFragmentNode['type']
 } = {
   Document: 0,
   DocumentType: 1,
   Element: 2,
   Text: 3,
   CDATA: 4,
+  DocumentFragment: 11,
 } as const
 
 export type NodeType = typeof NodeType[keyof typeof NodeType]

--- a/schemas/session-replay/browser/document-fragment-node-schema.json
+++ b/schemas/session-replay/browser/document-fragment-node-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/browser/document-fragment-node-schema.json",
+  "title": "DocumentFragmentNode",
+  "type": "object",
+  "description": "Schema of a Document FragmentNode.",
+  "required": ["type", "childNodes", "isShadowRoot"],
+  "properties": {
+    "type": {
+      "type": "integer",
+      "description": "The type of this Node.",
+      "const": 11,
+      "readOnly": true
+    },
+    "isShadowRoot": {
+      "type": "boolean",
+      "description": "Is this node a shadow root or not",
+      "readOnly": true
+    },
+    "childNodes": {
+      "type": "array",
+      "items": {
+        "$ref": "serialized-node-with-id-schema.json"
+      }
+    }
+  }
+}

--- a/schemas/session-replay/browser/element-node-schema.json
+++ b/schemas/session-replay/browser/element-node-schema.json
@@ -28,10 +28,6 @@
     "isSVG": {
       "const": true,
       "description": "Is this node a SVG instead of a HTML"
-    },
-    "isShadowHost": {
-      "const": true,
-      "description": "Is this node a host of a shadow root"
     }
   }
 }

--- a/schemas/session-replay/browser/serialized-node-schema.json
+++ b/schemas/session-replay/browser/serialized-node-schema.json
@@ -6,6 +6,7 @@
   "description": "Serialized node contained by this Record.",
   "anyOf": [
     { "$ref": "document-node-schema.json" },
+    { "$ref": "document-fragment-node-schema.json" },
     { "$ref": "document-type-node-schema.json" },
     { "$ref": "element-node-schema.json" },
     { "$ref": "text-node-schema.json" },


### PR DESCRIPTION
Since a shadow root can have some property like [`ShadowRoot.adoptedStyleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/adoptedStyleSheets), let record a document fragment in order to better support it

![image](https://user-images.githubusercontent.com/44997281/207554747-f2a1e8f4-8361-40c7-bc93-8ec81e41e963.png)
