### PR TITLE
Run Browser SDK tests on push

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -1,0 +1,31 @@
+name: browser-sdk
+
+on:
+  push:
+
+jobs:
+  browser-sdk-test:
+    strategy:
+      matrix:
+        test_type: [unit, e2e]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/browser-sdk'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Update rum-events-format
+        run: |
+          cd rum-events-format
+          git checkout ${{ github.sha }}
+
+      - name: Run ${{matrix.test_type}} tests
+        run: yarn test:${{matrix.test_type}}


### PR DESCRIPTION
In the Browser SDK, we have many tests leveraging the `rum-events-format`. Currently, whenever those tests are running in the Browser SDK repo CI, we are updating `rum-events-format` to the latest to make sure they still pass with any recent change. This is not ideal because:

* we don't catch breaking change before they are merged into `rum-events-format` main branch

* `rum-event-format` is unexpectedly updated in the SDK repository:
  *  every time we install dependencies with `yarn`, which is quite annoying
  * when we run unrelated CI jobs (ex: publish to NPM), making the repository "unclean"

This PR will make those tests run for every `rum-events-format` change, and help us to detect breaking changes sooner. It will also allow us to remove this unexpected automatic `rum-events-format` update in the SDK repository.

Only the local tests are run (executed in a local chrome browser), so they should not be as flaky as browserstack tests. Nonetheless, some flakyness is still to be expected, and we'll provide assistance in this case. Also, those jobs are not required to merge a PR, so if you think that they are unexpectedly failing, you can still merge your PR. (It could be nice if you could ping us on Slack in this case)

Example Workflow run: https://github.com/DataDog/rum-events-format/actions/runs/3706272702/jobs/6281420300