### PR TITLE
[RUM] introduce image wireframe schema

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -41,7 +41,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -154,6 +154,23 @@ export declare type TextPosition = {
     };
 };
 /**
+ * Schema of all properties of a ImageWireframe.
+ */
+export declare type ImageWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension: string;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -207,7 +224,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -238,6 +255,23 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+};
+/**
+ * Schema of all properties of a ImageWireframeUpdate.
+ */
+export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64?: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -162,13 +162,13 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension: string;
+    mimeType?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -265,13 +265,13 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64?: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension?: string;
+    mimeType?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -433,13 +433,13 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension: string;
+    mimeType?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -536,13 +536,13 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64?: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension?: string;
+    mimeType?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -312,7 +312,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -425,6 +425,23 @@ export declare type TextPosition = {
     };
 };
 /**
+ * Schema of all properties of a ImageWireframe.
+ */
+export declare type ImageWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension: string;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -478,7 +495,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -509,6 +526,23 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+};
+/**
+ * Schema of all properties of a ImageWireframeUpdate.
+ */
+export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64?: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -41,7 +41,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -154,6 +154,23 @@ export declare type TextPosition = {
     };
 };
 /**
+ * Schema of all properties of a ImageWireframe.
+ */
+export declare type ImageWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension: string;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -207,7 +224,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -238,6 +255,23 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+};
+/**
+ * Schema of all properties of a ImageWireframeUpdate.
+ */
+export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64?: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -162,13 +162,13 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension: string;
+    mimeType?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -265,13 +265,13 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64?: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension?: string;
+    mimeType?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -433,13 +433,13 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension: string;
+    mimeType?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -536,13 +536,13 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      */
     readonly type: 'image';
     /**
-     * base64 representation of the image. Can have a null value
+     * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
-    base64?: string | null;
+    base64?: string;
     /**
-     * Extension of the image file
+     * MIME type of the image file
      */
-    imageFileExtension?: string;
+    mimeType?: string;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -312,7 +312,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -425,6 +425,23 @@ export declare type TextPosition = {
     };
 };
 /**
+ * Schema of all properties of a ImageWireframe.
+ */
+export declare type ImageWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension: string;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -478,7 +495,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -509,6 +526,23 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+};
+/**
+ * Schema of all properties of a ImageWireframeUpdate.
+ */
+export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'image';
+    /**
+     * base64 representation of the image. Can have a null value
+     */
+    base64?: string | null;
+    /**
+     * Extension of the image file
+     */
+    imageFileExtension?: string;
 };
 /**
  * Schema of a TouchData.

--- a/samples/session-replay/mobile/record/full-snapshot-record.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record.json
@@ -17,6 +17,24 @@
           "type": "sans-serif",
           "color": "#FF000000"
         }
+      },
+      {
+        "id": 2,
+        "x": 10,
+        "y": 10,
+        "width": 20,
+        "height": 30,
+        "type": "image",
+        "base64": "base64Mock",
+        "mimeType": "image/jpeg"
+      },
+      {
+        "id": 3,
+        "x": 10,
+        "y": 10,
+        "width": 20,
+        "height": 30,
+        "type": "image"
       }
     ]
   }

--- a/samples/session-replay/mobile/record/incremental-snapshot-record.json
+++ b/samples/session-replay/mobile/record/incremental-snapshot-record.json
@@ -21,6 +21,17 @@
             "color": "#FF000000"
           }
         }
+      },
+      {
+        "previousId": 11,
+        "wireframe": {
+          "id": 14,
+          "x": 10,
+          "y": 10,
+          "width": 20,
+          "height": 30,
+          "type": "image"
+        }
       }
     ],
     "removes": [
@@ -45,6 +56,12 @@
         "type": "shape",
         "x": 0,
         "y": 10
+      },
+      {
+        "id": 12,
+        "type": "image",
+        "base64": "base64Mock",
+        "mimeType": "image/jpeg"
       }
     ]
   }

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -9,7 +9,7 @@
       "$ref": "_common-shape-wireframe-schema.json"
     },
     {
-      "required": ["type", "base64", "imageFileExtension"],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -18,13 +18,13 @@
           "readOnly": true
         },
         "base64": {
-          "type": ["string", "null"],
-          "description": "base64 representation of the image. Can have a null value",
+          "type": "string",
+          "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
-        "imageFileExtension": {
+        "mimeType": {
           "type": "string",
-          "description": "Extension of the image file",
+          "description": "MIME type of the image file",
           "readOnly": false
         }
       }

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/image-wireframe-schema.json",
+  "title": "ImageWireframe",
+  "type": "object",
+  "description": "Schema of all properties of a ImageWireframe.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-schema.json"
+    },
+    {
+      "required": ["type", "base64", "imageFileExtension"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "image",
+          "readOnly": true
+        },
+        "base64": {
+          "type": ["string", "null"],
+          "description": "base64 representation of the image. Can have a null value",
+          "readOnly": false
+        },
+        "imageFileExtension": {
+          "type": "string",
+          "description": "Extension of the image file",
+          "readOnly": false
+        }
+      }
+    }
+  ]
+}

--- a/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/image-wireframe-update-schema.json",
+  "title": "ImageWireframeUpdate",
+  "type": "object",
+  "description": "Schema of all properties of a ImageWireframeUpdate.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-update-schema.json"
+    },
+    {
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "image",
+          "readOnly": true
+        },
+        "base64": {
+          "type": ["string", "null"],
+          "description": "base64 representation of the image. Can have a null value",
+          "readOnly": false
+        },
+        "imageFileExtension": {
+          "type": "string",
+          "description": "Extension of the image file",
+          "readOnly": false
+        }
+      }
+    }
+  ]
+}

--- a/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -18,13 +18,13 @@
           "readOnly": true
         },
         "base64": {
-          "type": ["string", "null"],
-          "description": "base64 representation of the image. Can have a null value",
+          "type": "string",
+          "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
-        "imageFileExtension": {
+        "mimeType": {
           "type": "string",
-          "description": "Extension of the image file",
+          "description": "MIME type of the image file",
           "readOnly": false
         }
       }

--- a/schemas/session-replay/mobile/wireframe-schema.json
+++ b/schemas/session-replay/mobile/wireframe-schema.json
@@ -10,6 +10,9 @@
     },
     {
       "$ref": "text-wireframe-schema.json"
+    },
+    {
+      "$ref": "image-wireframe-schema.json"
     }
   ]
 }

--- a/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
+++ b/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
@@ -10,6 +10,9 @@
     },
     {
       "$ref": "shape-wireframe-update-schema.json"
+    },
+    {
+      "$ref": "image-wireframe-update-schema.json"
     }
   ]
 }


### PR DESCRIPTION
# Motivation

Introduce new `ImageWireframe` schema to `[rum-events-format](https://github.com/DataDog/rum-events-format)` 

# Changes

- Add  `image-wireframe-schema.json` and `image-wireframe-update-schema.json` files
- Generate the associated TS

