### PR TITLE
[RUMF-1450] Browser Mouse Interaction: remove x/y for blur and focus

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -107,7 +107,7 @@ export declare type MouseInteractionData = {
  */
 export declare type MouseInteraction = {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
     readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
     /**
@@ -124,7 +124,7 @@ export declare type MouseInteraction = {
     y: number;
 } | {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 5=focus, 6=blur
      */
     readonly type: 5 | 6;
     /**

--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -103,6 +103,36 @@ export declare type MouseInteractionData = {
     readonly source: 2;
 } & MouseInteraction;
 /**
+ * Browser-specific. Schema of a MouseInteraction.
+ */
+export declare type MouseInteraction = {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+    /**
+     * X-axis coordinate for this MouseInteraction.
+     */
+    x: number;
+    /**
+     * Y-axis coordinate for this MouseInteraction.
+     */
+    y: number;
+} | {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 5 | 6;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+};
+/**
  * Browser-specific. Schema of a ScrollData.
  */
 export declare type ScrollData = {
@@ -554,27 +584,6 @@ export interface MousePosition {
      * Observed time offset for this MousePosition.
      */
     timeOffset: number;
-}
-/**
- * Browser-specific. Schema of a MouseInteraction.
- */
-export interface MouseInteraction {
-    /**
-     * The type of MouseInteraction.
-     */
-    readonly type: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 9;
-    /**
-     * Id for the target node for this MouseInteraction.
-     */
-    id: number;
-    /**
-     * X-axis coordinate for this MouseInteraction.
-     */
-    x: number;
-    /**
-     * Y-axis coordinate for this MouseInteraction.
-     */
-    y: number;
 }
 /**
  * Browser-specific. Schema of a ScrollPosition.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -111,6 +111,36 @@ export declare type MouseInteractionData = {
     readonly source: 2;
 } & MouseInteraction;
 /**
+ * Browser-specific. Schema of a MouseInteraction.
+ */
+export declare type MouseInteraction = {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+    /**
+     * X-axis coordinate for this MouseInteraction.
+     */
+    x: number;
+    /**
+     * Y-axis coordinate for this MouseInteraction.
+     */
+    y: number;
+} | {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 5 | 6;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+};
+/**
  * Browser-specific. Schema of a ScrollData.
  */
 export declare type ScrollData = {
@@ -892,27 +922,6 @@ export interface MousePosition {
      * Observed time offset for this MousePosition.
      */
     timeOffset: number;
-}
-/**
- * Browser-specific. Schema of a MouseInteraction.
- */
-export interface MouseInteraction {
-    /**
-     * The type of MouseInteraction.
-     */
-    readonly type: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 9;
-    /**
-     * Id for the target node for this MouseInteraction.
-     */
-    id: number;
-    /**
-     * X-axis coordinate for this MouseInteraction.
-     */
-    x: number;
-    /**
-     * Y-axis coordinate for this MouseInteraction.
-     */
-    y: number;
 }
 /**
  * Browser-specific. Schema of a ScrollPosition.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -115,7 +115,7 @@ export declare type MouseInteractionData = {
  */
 export declare type MouseInteraction = {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
     readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
     /**
@@ -132,7 +132,7 @@ export declare type MouseInteraction = {
     y: number;
 } | {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 5=focus, 6=blur
      */
     readonly type: 5 | 6;
     /**

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -107,7 +107,7 @@ export declare type MouseInteractionData = {
  */
 export declare type MouseInteraction = {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
     readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
     /**
@@ -124,7 +124,7 @@ export declare type MouseInteraction = {
     y: number;
 } | {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 5=focus, 6=blur
      */
     readonly type: 5 | 6;
     /**

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -103,6 +103,36 @@ export declare type MouseInteractionData = {
     readonly source: 2;
 } & MouseInteraction;
 /**
+ * Browser-specific. Schema of a MouseInteraction.
+ */
+export declare type MouseInteraction = {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+    /**
+     * X-axis coordinate for this MouseInteraction.
+     */
+    x: number;
+    /**
+     * Y-axis coordinate for this MouseInteraction.
+     */
+    y: number;
+} | {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 5 | 6;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+};
+/**
  * Browser-specific. Schema of a ScrollData.
  */
 export declare type ScrollData = {
@@ -554,27 +584,6 @@ export interface MousePosition {
      * Observed time offset for this MousePosition.
      */
     timeOffset: number;
-}
-/**
- * Browser-specific. Schema of a MouseInteraction.
- */
-export interface MouseInteraction {
-    /**
-     * The type of MouseInteraction.
-     */
-    readonly type: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 9;
-    /**
-     * Id for the target node for this MouseInteraction.
-     */
-    id: number;
-    /**
-     * X-axis coordinate for this MouseInteraction.
-     */
-    x: number;
-    /**
-     * Y-axis coordinate for this MouseInteraction.
-     */
-    y: number;
 }
 /**
  * Browser-specific. Schema of a ScrollPosition.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -111,6 +111,36 @@ export declare type MouseInteractionData = {
     readonly source: 2;
 } & MouseInteraction;
 /**
+ * Browser-specific. Schema of a MouseInteraction.
+ */
+export declare type MouseInteraction = {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+    /**
+     * X-axis coordinate for this MouseInteraction.
+     */
+    x: number;
+    /**
+     * Y-axis coordinate for this MouseInteraction.
+     */
+    y: number;
+} | {
+    /**
+     * The type of MouseInteraction.
+     */
+    readonly type: 5 | 6;
+    /**
+     * Id for the target node for this MouseInteraction.
+     */
+    id: number;
+};
+/**
  * Browser-specific. Schema of a ScrollData.
  */
 export declare type ScrollData = {
@@ -892,27 +922,6 @@ export interface MousePosition {
      * Observed time offset for this MousePosition.
      */
     timeOffset: number;
-}
-/**
- * Browser-specific. Schema of a MouseInteraction.
- */
-export interface MouseInteraction {
-    /**
-     * The type of MouseInteraction.
-     */
-    readonly type: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 9;
-    /**
-     * Id for the target node for this MouseInteraction.
-     */
-    id: number;
-    /**
-     * X-axis coordinate for this MouseInteraction.
-     */
-    x: number;
-    /**
-     * Y-axis coordinate for this MouseInteraction.
-     */
-    y: number;
 }
 /**
  * Browser-specific. Schema of a ScrollPosition.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -115,7 +115,7 @@ export declare type MouseInteractionData = {
  */
 export declare type MouseInteraction = {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
     readonly type: 0 | 1 | 2 | 3 | 4 | 7 | 9;
     /**
@@ -132,7 +132,7 @@ export declare type MouseInteraction = {
     y: number;
 } | {
     /**
-     * The type of MouseInteraction.
+     * The type of MouseInteraction: 5=focus, 6=blur
      */
     readonly type: 5 | 6;
     /**

--- a/schemas/session-replay/browser/mouse-interaction-schema.json
+++ b/schemas/session-replay/browser/mouse-interaction-schema.json
@@ -4,25 +4,44 @@
   "title": "MouseInteraction",
   "type": "object",
   "description": "Browser-specific. Schema of a MouseInteraction.",
-  "required": ["type", "id", "x", "y"],
-  "properties": {
-    "type": {
-      "type": "integer",
-      "enum": [0, 1, 2, 3, 4, 5, 6, 7, 9],
-      "description": "The type of MouseInteraction.",
-      "readOnly": true
+  "oneOf": [
+    {
+      "required": ["type", "id", "x", "y"],
+      "properties": {
+        "type": {
+          "type": "integer",
+          "enum": [0, 1, 2, 3, 4, 7, 9],
+          "description": "The type of MouseInteraction.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "integer",
+          "description": "Id for the target node for this MouseInteraction."
+        },
+        "x": {
+          "type": "number",
+          "description": "X-axis coordinate for this MouseInteraction."
+        },
+        "y": {
+          "type": "number",
+          "description": "Y-axis coordinate for this MouseInteraction."
+        }
+      }
     },
-    "id": {
-      "type": "integer",
-      "description": "Id for the target node for this MouseInteraction."
-    },
-    "x": {
-      "type": "number",
-      "description": "X-axis coordinate for this MouseInteraction."
-    },
-    "y": {
-      "type": "number",
-      "description": "Y-axis coordinate for this MouseInteraction."
+    {
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "type": "integer",
+          "enum": [5, 6],
+          "description": "The type of MouseInteraction.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "integer",
+          "description": "Id for the target node for this MouseInteraction."
+        }
+      }
     }
-  }
+  ]
 }

--- a/schemas/session-replay/browser/mouse-interaction-schema.json
+++ b/schemas/session-replay/browser/mouse-interaction-schema.json
@@ -11,7 +11,7 @@
         "type": {
           "type": "integer",
           "enum": [0, 1, 2, 3, 4, 7, 9],
-          "description": "The type of MouseInteraction.",
+          "description": "The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend",
           "readOnly": true
         },
         "id": {
@@ -34,7 +34,7 @@
         "type": {
           "type": "integer",
           "enum": [5, 6],
-          "description": "The type of MouseInteraction.",
+          "description": "The type of MouseInteraction: 5=focus, 6=blur",
           "readOnly": true
         },
         "id": {


### PR DESCRIPTION
# Motivation

Since  on focus and blur events x and y are not used by the player, browser-sdk will stop to compute them to avoid an issue on safari and useless computation.

# Changes

Split mouse interaction schema in two, with or without x/y depending on type.