### PR TITLE
[RUM][MOBILE REPLAY] add isEmpty flag to image wireframe schemas

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -169,6 +169,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -272,6 +276,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Schema of a TouchData.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -470,6 +470,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -573,6 +577,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -169,6 +169,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -272,6 +276,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -470,6 +470,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -573,6 +577,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * MIME type of the image file
      */
     mimeType?: string;
+    /**
+     * Flag describing an image wireframe that should render an empty state placeholder
+     */
+    isEmpty?: boolean;
 };
 /**
  * Schema of a TouchData.

--- a/samples/session-replay/mobile/record/full-snapshot-record.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record.json
@@ -35,6 +35,15 @@
         "width": 20,
         "height": 30,
         "type": "image"
+      },
+      {
+        "id": 4,
+        "x": 10,
+        "y": 10,
+        "width": 20,
+        "height": 30,
+        "type": "image",
+        "isEmpty": true
       }
     ]
   }

--- a/samples/session-replay/mobile/record/incremental-snapshot-record.json
+++ b/samples/session-replay/mobile/record/incremental-snapshot-record.json
@@ -62,6 +62,11 @@
         "type": "image",
         "base64": "base64Mock",
         "mimeType": "image/jpeg"
+      },
+      {
+        "id": 12,
+        "type": "image",
+        "isEmpty": true
       }
     ]
   }

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -26,6 +26,11 @@
           "type": "string",
           "description": "MIME type of the image file",
           "readOnly": false
+        },
+        "isEmpty": {
+          "type": "boolean",
+          "description": "Flag describing an image wireframe that should render an empty state placeholder",
+          "readOnly": false
         }
       }
     }

--- a/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -26,6 +26,11 @@
           "type": "string",
           "description": "MIME type of the image file",
           "readOnly": false
+        },
+        "isEmpty": {
+          "type": "boolean",
+          "description": "Flag describing an image wireframe that should render an empty state placeholder",
+          "readOnly": false
         }
       }
     }


### PR DESCRIPTION
# Motivation

Introduce a new `isEmpty` boolean field to `ImageWireframe` in [rum-events-format](https://github.com/DataDog/rum-events-format)

# Changes

- update  `image-wireframe-schema.json` and `image-wireframe-update-schema.json` files
- Generate the associated TS
