### PR TITLE
[RUMF-1485] Add page frozen segment creation reason

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -23,7 +23,7 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden';
+export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -31,7 +31,7 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden';
+export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -23,7 +23,7 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden';
+export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -31,7 +31,7 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden';
+export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */

--- a/schemas/session-replay/browser/creation-reason-schema.json
+++ b/schemas/session-replay/browser/creation-reason-schema.json
@@ -10,7 +10,8 @@
     "segment_bytes_limit",
     "view_change",
     "before_unload",
-    "visibility_hidden"
+    "visibility_hidden",
+    "page_frozen"
   ],
   "default": "init"
 }


### PR DESCRIPTION
When the browser freezes the page to preserve resources beforeunload is not triggered and we may lose the last batch.  Therefore the browser SDK now flush segment when the page freezes.

This PR adds `page_frozen` as a segment creation reason