### PR TITLE
[RUMM] Add telemetry properties for third party library versions

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -259,6 +259,18 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The upload frequency of batches (in milliseconds)
              */
             batch_upload_frequency?: number;
+            /**
+             * The version of React used in a ReactNative application
+             */
+            react_version?: string;
+            /**
+             * The version of ReactNative used in a ReactNative application
+             */
+            react_native_version?: string;
+            /**
+             * The version of Dart used in a Flutter application
+             */
+            dart_version?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -259,6 +259,18 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The upload frequency of batches (in milliseconds)
              */
             batch_upload_frequency?: number;
+            /**
+             * The version of React used in a ReactNative application
+             */
+            react_version?: string;
+            /**
+             * The version of ReactNative used in a ReactNative application
+             */
+            react_native_version?: string;
+            /**
+             * The version of Dart used in a Flutter application
+             */
+            dart_version?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -266,6 +266,21 @@
                 "batch_upload_frequency": {
                   "type": "integer",
                   "description": "The upload frequency of batches (in milliseconds)"
+                },
+                "react_version": {
+                  "type": "string",
+                  "description": "The version of React used in a ReactNative application",
+                  "readOnly": false
+                },
+                "react_native_version": {
+                  "type": "string",
+                  "description": "The version of ReactNative used in a ReactNative application",
+                  "readOnly": false
+                },
+                "dart_version": {
+                  "type": "string",
+                  "description": "The version of Dart used in a Flutter application",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
Adding versions for ReactNative and Flutter, which will inform us of what versions of those libraries we need to continue providing support for.

Part of RUMM-3083 and RUMM-3079