### PR TITLE
Add is_active property to common session schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -739,6 +739,10 @@ export interface CommonProperties {
          * Whether this session has a replay
          */
         readonly has_replay?: boolean;
+        /**
+         * Whether this session is currently active. Set to false to manually stop a session
+         */
+        readonly is_active?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -739,6 +739,10 @@ export interface CommonProperties {
          * Whether this session has a replay
          */
         readonly has_replay?: boolean;
+        /**
+         * Whether this session is currently active. Set to false to manually stop a session
+         */
+        readonly is_active?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -57,6 +57,12 @@
           "type": "boolean",
           "description": "Whether this session has a replay",
           "readOnly": true
+        },
+        "is_active": {
+          "type": "boolean",
+          "description": "Whether this session is currently active. Set to false to manually stop a session",
+          "default": true,
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
Add `is_active` as a property of the session.  SDKs can set this parameter to `false` to manually end a session.