### PR TITLE
[RUMF-1489] Add view._dd.page_states attribute

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -702,7 +702,7 @@ export declare type RumViewEvent = CommonProperties & {
              */
             readonly state: 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated';
             /**
-             * Duration in ns to the start of the page state
+             * Duration in ns between start of the view and start of the page state
              */
             readonly start: number;
             [k: string]: unknown;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -693,6 +693,20 @@ export declare type RumViewEvent = CommonProperties & {
          * Version of the update of the view event
          */
         readonly document_version: number;
+        /**
+         * List of the page states during the view
+         */
+        readonly page_states?: {
+            /**
+             * Page state name
+             */
+            readonly state: 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated';
+            /**
+             * Duration in ns to the start of the page state
+             */
+            readonly start: number;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -702,7 +702,7 @@ export declare type RumViewEvent = CommonProperties & {
              */
             readonly state: 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated';
             /**
-             * Duration in ns to the start of the page state
+             * Duration in ns between start of the view and start of the page state
              */
             readonly start: number;
             [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -693,6 +693,20 @@ export declare type RumViewEvent = CommonProperties & {
          * Version of the update of the view event
          */
         readonly document_version: number;
+        /**
+         * List of the page states during the view
+         */
+        readonly page_states?: {
+            /**
+             * Page state name
+             */
+            readonly state: 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated';
+            /**
+             * Duration in ns to the start of the page state
+             */
+            readonly start: number;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -49,7 +49,13 @@
     "format_version": 2,
     "session": {
       "plan": 1
-    }
+    },
+    "page_states": [
+      {
+        "state": "active",
+        "start": 1345678
+      }
+    ]
   },
   "synthetics": {
     "test_id": "foo",

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -329,7 +329,7 @@
                   },
                   "start": {
                     "type": "integer",
-                    "description": "Duration in ns to the start of the page state",
+                    "description": "Duration in ns between start of the view and start of the page state",
                     "minimum": 0,
                     "readOnly": true
                   }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -313,6 +313,30 @@
               "description": "Version of the update of the view event",
               "minimum": 0,
               "readOnly": true
+            },
+            "page_states": {
+              "type": "array",
+              "description": "List of the page states during the view",
+              "items": {
+                "type": "object",
+                "description": "Properties of the page state",
+                "required": ["state", "start"],
+                "properties": {
+                  "state": {
+                    "enum": ["active", "passive", "hidden", "frozen", "terminated"],
+                    "description": "Page state name",
+                    "readOnly": true
+                  },
+                  "start": {
+                    "type": "integer",
+                    "description": "Duration in ns to the start of the page state",
+                    "minimum": 0,
+                    "readOnly": true
+                  }
+                },
+                "readOnly": true
+              },
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
Modern browsers today will sometimes suspend pages or discard them entirely when system resources are constrained, which can lead to unexpected behaviors. The [Page Lifecycle API](https://developer.chrome.com/blog/page-lifecycle-api/), provides lifecycle hooks so we can detect and handle these browser interventions.

This PR, collect page lifecycle state changes during a view to help Browser SDK issue investigations.