### PR TITLE
Add start_reason to session object

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -680,6 +680,16 @@ export declare type RumViewEvent = CommonProperties & {
         [k: string]: unknown;
     };
     /**
+     * Session properties
+     */
+    readonly session?: {
+        /**
+         * The precondition that led to the creation of the session
+         */
+        readonly start_reason?: 'app_start' | 'inactivity_timeout' | 'max_duration' | 'stop_api' | 'background_event';
+        [k: string]: unknown;
+    };
+    /**
      * Feature flags properties
      */
     readonly feature_flags?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -680,6 +680,16 @@ export declare type RumViewEvent = CommonProperties & {
         [k: string]: unknown;
     };
     /**
+     * Session properties
+     */
+    readonly session?: {
+        /**
+         * The precondition that led to the creation of the session
+         */
+        readonly start_reason?: 'app_start' | 'inactivity_timeout' | 'max_duration' | 'stop_api' | 'background_event';
+        [k: string]: unknown;
+    };
+    /**
      * Feature flags properties
      */
     readonly feature_flags?: {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -297,6 +297,20 @@
           },
           "readOnly": true
         },
+        "session": {
+          "type": "object",
+          "description": "Session properties",
+          "required": [],
+          "properties": {
+            "start_reason": {
+              "type": "string",
+              "description": "The precondition that led to the creation of the session",
+              "enum": ["app_start", "inactivity_timeout", "max_duration", "stop_api", "background_event"],
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        },
         "feature_flags": {
           "type": "object",
           "description": "Feature flags properties",


### PR DESCRIPTION
Adds `start_reason` field to sessions in order to bring clarity on the motives that lead to new sessions being created for a given app. 
The main motivation is to have this information easily queryable for support requests and customer questions on the amount of sessions they are seeing / being billed for. 