### PR TITLE
[RUMF-1551] disable Browser SDK e2e tests for now

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -7,7 +7,7 @@ jobs:
   browser-sdk-test:
     strategy:
       matrix:
-        test_type: [unit, e2e]
+        test_type: [unit] # e2e should be added back, see RUMF-1551
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* E2E tests are randomly failing midway when run in a Github action
* Since we [upgraded to Chrome 112][1], the [GitHub action fails][2] because Ubuntu only provides Chrome 111 for now.

We'll try to make it work when tackling RUMF-1551

[1]: https://github.com/DataDog/browser-sdk/pull/2139
[2]: https://github.com/DataDog/rum-events-format/actions/runs/4679017179/jobs/8288467842#step:6:215