### PR TITLE
Add `error.fingerprint`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -202,6 +202,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
          */
         readonly is_crash?: boolean;
         /**
+         * Fingerprint used for Error Tracking custom grouping
+         */
+        fingerprint?: string;
+        /**
          * The type of the error
          */
         readonly type?: string;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -202,6 +202,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
          */
         readonly is_crash?: boolean;
         /**
+         * Fingerprint used for Error Tracking custom grouping
+         */
+        fingerprint?: string;
+        /**
          * The type of the error
          */
         readonly type?: string;

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -85,6 +85,11 @@
               "description": "Whether this error crashed the host application",
               "readOnly": true
             },
+            "fingerprint": {
+              "type": "string",
+              "description": "Fingerprint used for Error Tracking custom grouping",
+              "readOnly": false
+            },
             "type": {
               "type": "string",
               "description": "The type of the error",


### PR DESCRIPTION
To support Error Tracking custom grouping for RUM errors.

Put the field as `readOnly: false` to allow customer to update the content of this field.