### PR TITLE
[RUMF-1499] resource.duration is no longer required

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -350,7 +350,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
         /**
          * Duration of the resource
          */
-        readonly duration: number;
+        readonly duration?: number;
         /**
          * Size in octet of the resource response body
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -350,7 +350,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
         /**
          * Duration of the resource
          */
-        readonly duration: number;
+        readonly duration?: number;
         /**
          * Size in octet of the resource response body
          */

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -23,7 +23,7 @@
         "resource": {
           "type": "object",
           "description": "Resource properties",
-          "required": ["type", "url", "duration"],
+          "required": ["type", "url"],
           "properties": {
             "id": {
               "type": "string",


### PR DESCRIPTION
A recent investigation on Page lifecycle state impacts revealed that the frozen lifecycle state can make the browser SDK wrongly compute durations. In these cases the browser SDK will now send resources without duration. The front-end will also display a message to warn the user why there is no duration.
