### PR TITLE
✨[RUMF-1589] telemetry configuration: add `start_session_replay_recording_manually`

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -112,6 +112,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             session_replay_sample_rate?: number;
             /**
+             * Whether the session replay start is handled manually
+             */
+            start_session_replay_recording_manually?: boolean;
+            /**
              * Whether a proxy configured is used
              */
             use_proxy?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -112,6 +112,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             session_replay_sample_rate?: number;
             /**
+             * Whether the session replay start is handled manually
+             */
+            start_session_replay_recording_manually?: boolean;
+            /**
              * Whether a proxy configured is used
              */
             use_proxy?: boolean;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -28,6 +28,7 @@
       "telemetry_configuration_sample_rate": 5,
       "trace_sample_rate": 100,
       "session_replay_sample_rate": 100,
+      "start_session_replay_recording_manually": true,
       "premium_sample_rate": 100,
       "replay_sample_rate": 100,
       "use_proxy": true,

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -68,6 +68,11 @@
                   "maximum": 100,
                   "readOnly": false
                 },
+                "start_session_replay_recording_manually": {
+                  "type": "boolean",
+                  "description": "Whether the session replay start is handled manually",
+                  "readOnly": false
+                },
                 "use_proxy": {
                   "type": "boolean",
                   "description": "Whether a proxy configured is used",


### PR DESCRIPTION
# Motivation

New configuration parameter to allow to opt out of automatic session replay recording

# Changes

Update telemetry configuration schema with the new parameter