### PR TITLE
RUMF-1592: Send the views session replay default privacy level

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -704,6 +704,16 @@ export declare type RumViewEvent = CommonProperties & {
         [k: string]: unknown;
     };
     /**
+     * Session Replay properties
+     */
+    replay?: {
+        /**
+         * Default Session Replay privacy level established for this view
+         */
+        readonly privacyLevel?: 'mask' | 'mask-user-input' | 'allow';
+        [k: string]: unknown;
+    };
+    /**
      * Internal properties
      */
     readonly _dd: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -704,6 +704,16 @@ export declare type RumViewEvent = CommonProperties & {
         [k: string]: unknown;
     };
     /**
+     * Session Replay properties
+     */
+    replay?: {
+        /**
+         * Default Session Replay privacy level established for this view
+         */
+        readonly privacyLevel?: 'mask' | 'mask-user-input' | 'allow';
+        [k: string]: unknown;
+    };
+    /**
      * Internal properties
      */
     readonly _dd: {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -323,6 +323,19 @@
           "additionalProperties": true,
           "readOnly": true
         },
+        "replay": {
+          "type": "object",
+          "description": "Session Replay properties",
+          "required": [],
+          "properties": {
+            "privacyLevel": {
+              "type": "string",
+              "description": "Default Session Replay privacy level established for this view",
+              "enum": ["mask", "mask-user-input", "allow"],
+              "readOnly": true
+            }
+          }
+        },
         "_dd": {
           "type": "object",
           "description": "Internal properties",


### PR DESCRIPTION
Addition in order to enable reporting Session Replay's `defaultPrivacyLevel` init configuration property on each view.