### PR TITLE
✨ [RUMF-1580] Configuration Telemetry: Add parameter allowFallbackToL…

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -150,7 +150,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Whether it is allowed to use LocalStorage when cookies are not available
              */
-            allowFallbackToLocalStorage?: boolean;
+            allow_fallback_to_local_storage?: boolean;
             /**
              * Attribute to be used to name actions
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -148,6 +148,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
+             * Whether it is allowed to use LocalStorage when cookies are not available
+             */
+            allowFallbackToLocalStorage?: boolean;
+            /**
              * Attribute to be used to name actions
              */
             action_name_attribute?: string;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -150,7 +150,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Whether it is allowed to use LocalStorage when cookies are not available
              */
-            allowFallbackToLocalStorage?: boolean;
+            allow_fallback_to_local_storage?: boolean;
             /**
              * Attribute to be used to name actions
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -148,6 +148,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
+             * Whether it is allowed to use LocalStorage when cookies are not available
+             */
+            allowFallbackToLocalStorage?: boolean;
+            /**
              * Attribute to be used to name actions
              */
             action_name_attribute?: string;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -39,6 +39,7 @@
       "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
+      "allowFallbackToLocalStorage": true,
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -39,7 +39,7 @@
       "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
-      "allowFallbackToLocalStorage": true,
+      "allow_fallback_to_local_storage": true,
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -108,6 +108,10 @@
                   "type": "boolean",
                   "description": "Whether a secure session cookie is used"
                 },
+                "allowFallbackToLocalStorage": {
+                  "type": "boolean",
+                  "description": "Whether it is allowed to use LocalStorage when cookies are not available"
+                },
                 "action_name_attribute": {
                   "type": "string",
                   "description": "Attribute to be used to name actions"

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -108,7 +108,7 @@
                   "type": "boolean",
                   "description": "Whether a secure session cookie is used"
                 },
-                "allowFallbackToLocalStorage": {
+                "allow_fallback_to_local_storage": {
                   "type": "boolean",
                   "description": "Whether it is allowed to use LocalStorage when cookies are not available"
                 },


### PR DESCRIPTION
Related to https://github.com/DataDog/browser-sdk/pull/2261
Monitor the usage of the new configuration parameter allowFallbackToLocalStorage, which enables LocalStorage to be used when cookies are not available to store session information.