### PR TITLE
RUMM-3162 Add os build number

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -906,6 +906,10 @@ export interface CommonProperties {
          */
         readonly version: string;
         /**
+         * Operating system build number, e.g. 15D21
+         */
+        readonly build?: string;
+        /**
          * Major operating system version, e.g. 8
          */
         readonly version_major: string;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -906,6 +906,10 @@ export interface CommonProperties {
          */
         readonly version: string;
         /**
+         * Operating system build number, e.g. 15D21
+         */
+        readonly build?: string;
+        /**
          * Major operating system version, e.g. 8
          */
         readonly version_major: string;

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -233,6 +233,11 @@
           "description": "Full operating system version, e.g. 8.1.1",
           "readOnly": true
         },
+        "build": {
+          "type": "string",
+          "description": "Operating system build number, e.g. 15D21",
+          "readOnly": true
+        },
         "version_major": {
           "type": "string",
           "description": "Major operating system version, e.g. 8",


### PR DESCRIPTION
## Add `os.build` Field

The build number is required for exporting a crash report to the Apple crash format, cf. [RFC-2977662661](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2977662661/Apple+Crash+Format+Export)