### PR TITLE
[RUMF-1597] updates for browser billing changes

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -954,9 +954,9 @@ export interface CommonProperties {
          */
         session?: {
             /**
-             * Session plan: 1 is the plan without replay, 2 is the plan with replay
+             * Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
              */
-            plan: 1 | 2;
+            plan?: 1 | 2;
             [k: string]: unknown;
         };
         /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -695,6 +695,10 @@ export declare type RumViewEvent = CommonProperties & {
          * Whether this session is currently active. Set to false to manually stop a session
          */
         readonly is_active?: boolean;
+        /**
+         * Whether this session has been sampled for replay
+         */
+        readonly sampled_for_replay?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -954,9 +954,9 @@ export interface CommonProperties {
          */
         session?: {
             /**
-             * Session plan: 1 is the plan without replay, 2 is the plan with replay
+             * Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
              */
-            plan: 1 | 2;
+            plan?: 1 | 2;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -695,6 +695,10 @@ export declare type RumViewEvent = CommonProperties & {
          * Whether this session is currently active. Set to false to manually stop a session
          */
         readonly is_active?: boolean;
+        /**
+         * Whether this session has been sampled for replay
+         */
+        readonly sampled_for_replay?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/samples/rum-events/action.json
+++ b/samples/rum-events/action.json
@@ -36,9 +36,6 @@
   },
   "_dd": {
     "format_version": 2,
-    "session": {
-      "plan": 1
-    },
     "action": {
       "target": {
         "selector": "#options",

--- a/samples/rum-events/app_start.json
+++ b/samples/rum-events/app_start.json
@@ -25,9 +25,6 @@
     }
   },
   "_dd": {
-    "format_version": 2,
-    "session": {
-      "plan": 2
-    }
+    "format_version": 2
   }
 }

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -50,9 +50,6 @@
     "feature_four": { "foo": "bar" }
   },
   "_dd": {
-    "format_version": 2,
-    "session": {
-      "plan": 1
-    }
+    "format_version": 2
   }
 }

--- a/samples/rum-events/long_task.json
+++ b/samples/rum-events/long_task.json
@@ -22,9 +22,6 @@
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
   "_dd": {
-    "format_version": 2,
-    "session": {
-      "plan": 1
-    }
+    "format_version": 2
   }
 }

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -37,9 +37,6 @@
   "_dd": {
     "format_version": 2,
     "span_id": "12345",
-    "trace_id": "7890",
-    "session": {
-      "plan": 1
-    }
+    "trace_id": "7890"
   }
 }

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -6,7 +6,8 @@
   },
   "session": {
     "id": "cacbf45c-3a05-48ce-b066-d76349460599",
-    "type": "user"
+    "type": "user",
+    "sampled_for_replay": false
   },
   "source": "browser",
   "view": {

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -48,9 +48,6 @@
   "_dd": {
     "document_version": 9,
     "format_version": 2,
-    "session": {
-      "plan": 1
-    },
     "page_states": [
       {
         "state": "active",

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -287,11 +287,10 @@
         "session": {
           "type": "object",
           "description": "Session-related internal properties",
-          "required": ["plan"],
           "properties": {
             "plan": {
               "type": "number",
-              "description": "Session plan: 1 is the plan without replay, 2 is the plan with replay",
+              "description": "Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)",
               "enum": [1, 2]
             }
           }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -313,6 +313,11 @@
               "description": "Whether this session is currently active. Set to false to manually stop a session",
               "default": true,
               "readOnly": true
+            },
+            "sampled_for_replay": {
+              "type": "boolean",
+              "description": "Whether this session has been sampled for replay",
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
# Motivation 

Since billing will be based on `has_replay` field, SDKs could stop sending the `_dd.session.plan` with all events.
Sampling result can still be interesting for customers if they want to know why a session wasn’t recorded.

# Changes

- deprecate `_dd.session.plan`
- add `session.sampled_for_replay` on view event

