### PR TITLE
[RUMF-1592] Add privacy.replay_level in view event

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -708,6 +708,16 @@ export declare type RumViewEvent = CommonProperties & {
         [k: string]: unknown;
     };
     /**
+     * Privacy properties
+     */
+    readonly privacy?: {
+        /**
+         * The replay privacy level
+         */
+        readonly replay_level?: 'allow' | 'mask' | 'mask-user-input';
+        [k: string]: unknown;
+    };
+    /**
      * Internal properties
      */
     readonly _dd: {

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -714,7 +714,7 @@ export declare type RumViewEvent = CommonProperties & {
         /**
          * The replay privacy level
          */
-        readonly replay_level?: 'allow' | 'mask' | 'mask-user-input';
+        readonly replay_level: 'allow' | 'mask' | 'mask-user-input';
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -708,6 +708,16 @@ export declare type RumViewEvent = CommonProperties & {
         [k: string]: unknown;
     };
     /**
+     * Privacy properties
+     */
+    readonly privacy?: {
+        /**
+         * The replay privacy level
+         */
+        readonly replay_level?: 'allow' | 'mask' | 'mask-user-input';
+        [k: string]: unknown;
+    };
+    /**
      * Internal properties
      */
     readonly _dd: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -714,7 +714,7 @@ export declare type RumViewEvent = CommonProperties & {
         /**
          * The replay privacy level
          */
-        readonly replay_level?: 'allow' | 'mask' | 'mask-user-input';
+        readonly replay_level: 'allow' | 'mask' | 'mask-user-input';
         [k: string]: unknown;
     };
     /**

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -78,5 +78,8 @@
     "feature_two": "foo",
     "feature_three": 2,
     "feature_four": { "foo": "bar" }
+  },
+  "privacy": {
+    "replay_level": "mask"
   }
 }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -331,6 +331,7 @@
         "privacy": {
           "type": "object",
           "description": "Privacy properties",
+          "required": ["replay_level"],
           "properties": {
             "replay_level": {
               "type": "string",

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -328,6 +328,19 @@
           "additionalProperties": true,
           "readOnly": true
         },
+        "privacy": {
+          "type": "object",
+          "description": "Privacy properties",
+          "properties": {
+            "replay_level": {
+              "type": "string",
+              "description": "The replay privacy level",
+              "enum": ["allow", "mask", "mask-user-input"],
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        },
         "_dd": {
           "type": "object",
           "description": "Internal properties",


### PR DESCRIPTION
In order for customers to be able to monitor what is their Replay privacy level use in their applications, we want to collect it, to be used for reporting purposes and in monitors.