### PR TITLE
[RUMF-1577] _dd.page_states.start can be negative

### DIFF
--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -369,7 +369,6 @@
                   "start": {
                     "type": "integer",
                     "description": "Duration in ns between start of the view and start of the page state",
-                    "minimum": 0,
                     "readOnly": true
                   }
                 },


### PR DESCRIPTION
`_dd.page_states` was introduced in https://github.com/DataDog/rum-events-format/pull/135

To be consistent with `foreground_period` we made `_dd.page_states.start` relative  to the view start. Since the page state transition can happen before the view is created the page_states.start is negative. 
`foreground_period` didn't allow it and cap it to 0 if negative but we think it's a valuable information to keep as it is.