### PR TITLE
[RUM-235] add configured sample rates fields to all RUM events

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1020,6 +1020,20 @@ export interface CommonProperties {
             [k: string]: unknown;
         };
         /**
+         * Subset of the configuration options used to initialize the SDK
+         */
+        readonly configuration?: {
+            /**
+             * The percentage of sessions tracked
+             */
+            readonly session_sample_rate?: number;
+            /**
+             * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+             */
+            readonly session_replay_sample_rate?: number;
+            [k: string]: unknown;
+        };
+        /**
          * Browser SDK version
          */
         readonly browser_sdk_version?: string;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1020,17 +1020,17 @@ export interface CommonProperties {
             [k: string]: unknown;
         };
         /**
-         * Subset of the configuration options used to initialize the SDK
+         * Subset of the SDK configuration options in use during its execution
          */
         readonly configuration?: {
             /**
              * The percentage of sessions tracked
              */
-            readonly session_sample_rate?: number;
+            readonly session_sample_rate: number;
             /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked
              */
-            readonly session_replay_sample_rate?: number;
+            readonly session_replay_sample_rate: number;
             [k: string]: unknown;
         };
         /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1028,7 +1028,7 @@ export interface CommonProperties {
              */
             readonly session_sample_rate: number;
             /**
-             * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+             * The percentage of sessions with RUM & Session Replay pricing tracked
              */
             readonly session_replay_sample_rate: number;
             [k: string]: unknown;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -108,7 +108,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             replay_sample_rate?: number;
             /**
-             * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+             * The percentage of sessions with RUM & Session Replay pricing tracked
              */
             session_replay_sample_rate?: number;
             /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1020,6 +1020,20 @@ export interface CommonProperties {
             [k: string]: unknown;
         };
         /**
+         * Subset of the configuration options used to initialize the SDK
+         */
+        readonly configuration?: {
+            /**
+             * The percentage of sessions tracked
+             */
+            readonly session_sample_rate?: number;
+            /**
+             * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+             */
+            readonly session_replay_sample_rate?: number;
+            [k: string]: unknown;
+        };
+        /**
          * Browser SDK version
          */
         readonly browser_sdk_version?: string;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1020,17 +1020,17 @@ export interface CommonProperties {
             [k: string]: unknown;
         };
         /**
-         * Subset of the configuration options used to initialize the SDK
+         * Subset of the SDK configuration options in use during its execution
          */
         readonly configuration?: {
             /**
              * The percentage of sessions tracked
              */
-            readonly session_sample_rate?: number;
+            readonly session_sample_rate: number;
             /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked
              */
-            readonly session_replay_sample_rate?: number;
+            readonly session_replay_sample_rate: number;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1028,7 +1028,7 @@ export interface CommonProperties {
              */
             readonly session_sample_rate: number;
             /**
-             * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+             * The percentage of sessions with RUM & Session Replay pricing tracked
              */
             readonly session_replay_sample_rate: number;
             [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -108,7 +108,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             replay_sample_rate?: number;
             /**
-             * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+             * The percentage of sessions with RUM & Session Replay pricing tracked
              */
             session_replay_sample_rate?: number;
             /**

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -53,7 +53,11 @@
         "state": "active",
         "start": 1345678
       }
-    ]
+    ],
+    "configuration": {
+      "session_sample_rate": 12.45,
+      "session_replay_sample_rate": 100
+    }
   },
   "synthetics": {
     "test_id": "foo",

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -300,6 +300,27 @@
             }
           }
         },
+        "configuration": {
+          "type": "object",
+          "description": "Subset of the configuration options used to initialize the SDK",
+          "readOnly": true,
+          "properties": {
+            "session_sample_rate": {
+              "type": "integer",
+              "description": "The percentage of sessions tracked",
+              "minimum": 0,
+              "maximum": 100,
+              "readOnly": true
+            },
+            "session_replay_sample_rate": {
+              "type": "integer",
+              "description": "The percentage of sessions with Browser RUM & Session Replay pricing tracked",
+              "minimum": 0,
+              "maximum": 100,
+              "readOnly": true
+            }
+          }
+        },
         "browser_sdk_version": {
           "type": "string",
           "description": "Browser SDK version",

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -307,14 +307,14 @@
           "required": ["session_sample_rate", "session_replay_sample_rate"],
           "properties": {
             "session_sample_rate": {
-              "type": "integer",
+              "type": "number",
               "description": "The percentage of sessions tracked",
               "minimum": 0,
               "maximum": 100,
               "readOnly": true
             },
             "session_replay_sample_rate": {
-              "type": "integer",
+              "type": "number",
               "description": "The percentage of sessions with RUM & Session Replay pricing tracked",
               "minimum": 0,
               "maximum": 100,

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -315,7 +315,7 @@
             },
             "session_replay_sample_rate": {
               "type": "integer",
-              "description": "The percentage of sessions with Browser RUM & Session Replay pricing tracked",
+              "description": "The percentage of sessions with RUM & Session Replay pricing tracked",
               "minimum": 0,
               "maximum": 100,
               "readOnly": true

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -302,8 +302,9 @@
         },
         "configuration": {
           "type": "object",
-          "description": "Subset of the configuration options used to initialize the SDK",
+          "description": "Subset of the SDK configuration options in use during its execution",
           "readOnly": true,
+          "required": ["session_sample_rate", "session_replay_sample_rate"],
           "properties": {
             "session_sample_rate": {
               "type": "integer",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -63,7 +63,7 @@
                 },
                 "session_replay_sample_rate": {
                   "type": "integer",
-                  "description": "The percentage of sessions with Browser RUM & Session Replay pricing tracked",
+                  "description": "The percentage of sessions with RUM & Session Replay pricing tracked",
                   "minimum": 0,
                   "maximum": 100,
                   "readOnly": false


### PR DESCRIPTION
This PR adds the following fields to all RUM events:

* `@_dd.configuration.session_sample_rate`
* `@_dd.configuration.session_replay_sample_rate`

Those fields are private and should not be used by customers. They will reflect the corresponding initialization parameter values.