### PR TITLE
[RUM-233] add a `use_worker_url` field to telemetry configuration events

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -116,7 +116,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             start_session_replay_recording_manually?: boolean;
             /**
-             * Whether a proxy configured is used
+             * Whether a proxy is used
              */
             use_proxy?: boolean;
             /**
@@ -175,6 +175,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the request origins list to ignore when computing the page activity is used
              */
             use_excluded_activity_urls?: boolean;
+            /**
+             * Whether the Worker is loaded from an external URL
+             */
+            use_worker_url?: boolean;
             /**
              * Whether user frustrations are tracked
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -116,7 +116,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             start_session_replay_recording_manually?: boolean;
             /**
-             * Whether a proxy configured is used
+             * Whether a proxy is used
              */
             use_proxy?: boolean;
             /**
@@ -175,6 +175,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the request origins list to ignore when computing the page activity is used
              */
             use_excluded_activity_urls?: boolean;
+            /**
+             * Whether the Worker is loaded from an external URL
+             */
+            use_worker_url?: boolean;
             /**
              * Whether user frustrations are tracked
              */

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -75,7 +75,7 @@
                 },
                 "use_proxy": {
                   "type": "boolean",
-                  "description": "Whether a proxy configured is used",
+                  "description": "Whether a proxy is used",
                   "readOnly": false
                 },
                 "use_before_send": {
@@ -140,6 +140,10 @@
                 "use_excluded_activity_urls": {
                   "type": "boolean",
                   "description": "Whether the request origins list to ignore when computing the page activity is used"
+                },
+                "use_worker_url": {
+                  "type": "boolean",
+                  "description": "Whether the Worker is loaded from an external URL"
                 },
                 "track_frustrations": {
                   "type": "boolean",


### PR DESCRIPTION
We are planning to introduce a new `workerUrl` initialization parameter to the Browser SDK (RUM only at first, then Logs/RUM-slim). This option will let customers provide a workerUrl that is hosted on their domain. We want to report its usage through telemetry.