### PR TITLE
[RUM-257] Add view.interaction_to_next_paint

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -524,6 +524,10 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
+         * Duration in ns of the longest interaction to the next paint
+         */
+        readonly interaction_to_next_paint?: number;
+        /**
          * Total layout shift score that occurred on the view
          */
         readonly cumulative_layout_shift?: number;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -524,7 +524,7 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
-         * Duration in ns of the longest interaction to the next paint
+         * Longest duration in ns between an interaction and the next paint
          */
         readonly interaction_to_next_paint?: number;
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -524,6 +524,10 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
+         * Duration in ns of the longest interaction to the next paint
+         */
+        readonly interaction_to_next_paint?: number;
+        /**
          * Total layout shift score that occurred on the view
          */
         readonly cumulative_layout_shift?: number;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -524,7 +524,7 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
-         * Duration in ns of the longest interaction to the next paint
+         * Longest duration in ns between an interaction and the next paint
          */
         readonly interaction_to_next_paint?: number;
         /**

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -22,6 +22,7 @@
     "dom_content_loaded": 951715000,
     "dom_interactive": 906695000,
     "load_event": 2154370000,
+    "interaction_to_next_paint": 20000000,
     "custom_timings": {
       "user-timing": 2154570000
     },

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -75,7 +75,7 @@
             },
             "interaction_to_next_paint": {
               "type": "integer",
-              "description": "Duration in ns of the longest interaction to the next paint",
+              "description": "Longest duration in ns between an interaction and the next paint",
               "minimum": 0,
               "readOnly": true
             },

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -73,6 +73,12 @@
               "minimum": 0,
               "readOnly": true
             },
+            "interaction_to_next_paint": {
+              "type": "integer",
+              "description": "Duration in ns of the longest interaction to the next paint",
+              "minimum": 0,
+              "readOnly": true
+            },
             "cumulative_layout_shift": {
               "type": "number",
               "description": "Total layout shift score that occurred on the view",


### PR DESCRIPTION
[Interaction to Next Paint (INP)](https://web.dev/inp/) is a Core Web Vital metric that will [replace First Input Delay (FID)](https://web.dev/inp-cwv/) in March 2024. 
We are planing to collect it like the other core web vitals.