### PR TITLE
[RUMM-3449] Remove session_replay_sample_rate from required attributes

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1034,7 +1034,7 @@ export interface CommonProperties {
             /**
              * The percentage of sessions with RUM & Session Replay pricing tracked
              */
-            readonly session_replay_sample_rate: number;
+            readonly session_replay_sample_rate?: number;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1034,7 +1034,7 @@ export interface CommonProperties {
             /**
              * The percentage of sessions with RUM & Session Replay pricing tracked
              */
-            readonly session_replay_sample_rate: number;
+            readonly session_replay_sample_rate?: number;
             [k: string]: unknown;
         };
         /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -304,7 +304,7 @@
           "type": "object",
           "description": "Subset of the SDK configuration options in use during its execution",
           "readOnly": true,
-          "required": ["session_sample_rate", "session_replay_sample_rate"],
+          "required": ["session_sample_rate"],
           "properties": {
             "session_sample_rate": {
               "type": "number",


### PR DESCRIPTION
Due to the way the Mobile SDK is architected RUM and SR modules are completely decoupled.
Because the RUM module can be initialized sooner than the SR module we maybe have several RUM events created before a Session Replay sample rate is set. 

In order to not provide an incorrect `session_replay_sample_rate` value that may change at a later moment during the session, we propose to make it optional. 