### PR TITLE
✨ [RUM-265] add telemetry configuration `store_contexts_across_pages`

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -152,6 +152,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             allow_fallback_to_local_storage?: boolean;
             /**
+             * Whether contexts are stored in local storage
+             */
+            store_contexts_across_pages?: boolean;
+            /**
              * Whether untrusted events are allowed
              */
             allow_untrusted_events?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -152,6 +152,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             allow_fallback_to_local_storage?: boolean;
             /**
+             * Whether contexts are stored in local storage
+             */
+            store_contexts_across_pages?: boolean;
+            /**
              * Whether untrusted events are allowed
              */
             allow_untrusted_events?: boolean;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -112,6 +112,10 @@
                   "type": "boolean",
                   "description": "Whether it is allowed to use LocalStorage when cookies are not available"
                 },
+                "store_contexts_across_pages": {
+                  "type": "boolean",
+                  "description": "Whether contexts are stored in local storage"
+                },
                 "allow_untrusted_events": {
                   "type": "boolean",
                   "description": "Whether untrusted events are allowed"


### PR DESCRIPTION
Add telemetry configuration for new configuration to store contexts in local storage.