### PR TITLE
[RUM-1020] Add core web vitals target selectors

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -516,6 +516,10 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly largest_contentful_paint?: number;
         /**
+         * CSS selector path of the largest contentful paint element
+         */
+        readonly largest_contentful_paint_target_selector?: string;
+        /**
          * Duration in ns of the first input event delay
          */
         readonly first_input_delay?: number;
@@ -524,13 +528,25 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
+         * CSS selector path of the first input target element
+         */
+        readonly first_input_target_selector?: string;
+        /**
          * Longest duration in ns between an interaction and the next paint
          */
         readonly interaction_to_next_paint?: number;
         /**
+         * CSS selector path of the interacted element corresponding to INP
+         */
+        readonly interaction_to_next_paint_target_selector?: string;
+        /**
          * Total layout shift score that occurred on the view
          */
         readonly cumulative_layout_shift?: number;
+        /**
+         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
+         */
+        readonly cumulative_layout_shift_target_selector?: string;
         /**
          * Duration in ns to the complete parsing and loading of the document and its sub resources
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -516,6 +516,10 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly largest_contentful_paint?: number;
         /**
+         * CSS selector path of the largest contentful paint element
+         */
+        readonly largest_contentful_paint_target_selector?: string;
+        /**
          * Duration in ns of the first input event delay
          */
         readonly first_input_delay?: number;
@@ -524,13 +528,25 @@ export declare type RumViewEvent = CommonProperties & {
          */
         readonly first_input_time?: number;
         /**
+         * CSS selector path of the first input target element
+         */
+        readonly first_input_target_selector?: string;
+        /**
          * Longest duration in ns between an interaction and the next paint
          */
         readonly interaction_to_next_paint?: number;
         /**
+         * CSS selector path of the interacted element corresponding to INP
+         */
+        readonly interaction_to_next_paint_target_selector?: string;
+        /**
          * Total layout shift score that occurred on the view
          */
         readonly cumulative_layout_shift?: number;
+        /**
+         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
+         */
+        readonly cumulative_layout_shift_target_selector?: string;
         /**
          * Duration in ns to the complete parsing and loading of the document and its sub resources
          */

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -18,11 +18,18 @@
     "loading_type": "initial_load",
     "time_spent": 245512755000,
     "first_contentful_paint": 420725000,
+    "first_contentful_paint_target_selector": "#foo",
     "dom_complete": 2144660000,
     "dom_content_loaded": 951715000,
     "dom_interactive": 906695000,
     "load_event": 2154370000,
     "interaction_to_next_paint": 20000000,
+    "interaction_to_next_paint_target_selector": "#foo",
+    "largest_contentful_paint": 20000000,
+    "largest_contentful_paint_target_selector": "#foo",
+    "first_input_delay": 20000000,
+    "first_input_time": 20000000,
+    "first_input_target_selector": "#foo",
     "custom_timings": {
       "user-timing": 2154570000
     },

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -61,6 +61,11 @@
               "minimum": 0,
               "readOnly": true
             },
+            "largest_contentful_paint_target_selector": {
+              "type": "string",
+              "description": "CSS selector path of the largest contentful paint element",
+              "readOnly": true
+            },
             "first_input_delay": {
               "type": "integer",
               "description": "Duration in ns of the first input event delay",
@@ -73,16 +78,31 @@
               "minimum": 0,
               "readOnly": true
             },
+            "first_input_target_selector": {
+              "type": "string",
+              "description": "CSS selector path of the first input target element",
+              "readOnly": true
+            },
             "interaction_to_next_paint": {
               "type": "integer",
               "description": "Longest duration in ns between an interaction and the next paint",
               "minimum": 0,
               "readOnly": true
             },
+            "interaction_to_next_paint_target_selector": {
+              "type": "string",
+              "description": "CSS selector path of the interacted element corresponding to INP",
+              "readOnly": true
+            },
             "cumulative_layout_shift": {
               "type": "number",
               "description": "Total layout shift score that occurred on the view",
               "minimum": 0,
+              "readOnly": true
+            },
+            "cumulative_layout_shift_target_selector": {
+              "type": "string",
+              "description": "CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS",
               "readOnly": true
             },
             "dom_complete": {


### PR DESCRIPTION
Currently the web vitals are reported with a single value representing the vital score. However, to effectively improve them, it is crucial to identify the specific component to which a vital refers. We are planning to collect the CSS selector of these components.

