### PR TITLE
[RUM-311] Add graphql property to resources

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -466,13 +466,17 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
              */
             readonly operationType: 'query' | 'mutation' | 'subscription';
             /**
-             * Content of the GraphQL operation
-             */
-            query: string;
-            /**
              * Name of the GraphQL operation
              */
             readonly operationName?: string;
+            /**
+             * Content of the GraphQL operation
+             */
+            payload?: string;
+            /**
+             * String representation of the operation variables
+             */
+            variables?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -457,6 +457,24 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             readonly type?: 'ad' | 'advertising' | 'analytics' | 'cdn' | 'content' | 'customer-success' | 'first party' | 'hosting' | 'marketing' | 'other' | 'social' | 'tag-manager' | 'utility' | 'video';
             [k: string]: unknown;
         };
+        /**
+         * GraphQL requests parameters
+         */
+        readonly graphql?: {
+            /**
+             * Type of the GraphQL operation
+             */
+            readonly operationType: 'query' | 'mutation' | 'subscription';
+            /**
+             * Content of the GraphQL operation
+             */
+            query: string;
+            /**
+             * Name of the GraphQL operation
+             */
+            readonly operationName?: string;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -466,13 +466,17 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
              */
             readonly operationType: 'query' | 'mutation' | 'subscription';
             /**
-             * Content of the GraphQL operation
-             */
-            query: string;
-            /**
              * Name of the GraphQL operation
              */
             readonly operationName?: string;
+            /**
+             * Content of the GraphQL operation
+             */
+            payload?: string;
+            /**
+             * String representation of the operation variables
+             */
+            variables?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -457,6 +457,24 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             readonly type?: 'ad' | 'advertising' | 'analytics' | 'cdn' | 'content' | 'customer-success' | 'first party' | 'hosting' | 'marketing' | 'other' | 'social' | 'tag-manager' | 'utility' | 'video';
             [k: string]: unknown;
         };
+        /**
+         * GraphQL requests parameters
+         */
+        readonly graphql?: {
+            /**
+             * Type of the GraphQL operation
+             */
+            readonly operationType: 'query' | 'mutation' | 'subscription';
+            /**
+             * Content of the GraphQL operation
+             */
+            query: string;
+            /**
+             * Name of the GraphQL operation
+             */
+            readonly operationName?: string;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -223,6 +223,30 @@
                 }
               },
               "readOnly": true
+            },
+            "graphql": {
+              "type": "object",
+              "description": "GraphQL requests parameters",
+              "required": ["operationType", "query"],
+              "properties": {
+                "operationType": {
+                  "type": "string",
+                  "description": "Type of the GraphQL operation",
+                  "enum": ["query", "mutation", "subscription"],
+                  "readOnly": true
+                },
+                "query": {
+                  "type": "string",
+                  "description": "Content of the GraphQL operation",
+                  "readOnly": false
+                },
+                "operationName": {
+                  "type": "string",
+                  "description": "Name of the GraphQL operation",
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
             }
           },
           "readOnly": true

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -227,7 +227,7 @@
             "graphql": {
               "type": "object",
               "description": "GraphQL requests parameters",
-              "required": ["operationType", "query"],
+              "required": ["operationType"],
               "properties": {
                 "operationType": {
                   "type": "string",
@@ -235,15 +235,20 @@
                   "enum": ["query", "mutation", "subscription"],
                   "readOnly": true
                 },
-                "query": {
-                  "type": "string",
-                  "description": "Content of the GraphQL operation",
-                  "readOnly": false
-                },
                 "operationName": {
                   "type": "string",
                   "description": "Name of the GraphQL operation",
                   "readOnly": true
+                },
+                "payload": {
+                  "type": "string",
+                  "description": "Content of the GraphQL operation",
+                  "readOnly": false
+                },
+                "variables": {
+                  "type": "string",
+                  "description": "String representation of the operation variables",
+                  "readOnly": false
                 }
               },
               "readOnly": true


### PR DESCRIPTION
This PR adds a `"graphql"` property for better supporting resources calling a graphql endpoint.

The following properties are added in `"graphql"`:
- `operationType`: the type of GraphQL operation (can be `query`, `mutation` or `subscription`)
  - `subscription` will not be reported by SDKs and frontend in the first iteration
- `payload` (optional): the actual content of the operation as a string
  - optional as it might actually contain a lot of data
  - `readonly: false` as it could potentially contain sensitive information (if used in an improper way) so we should enable users to overwrite it 
- `operationName` (optional): the name of the operation if any
  - optional as developers have the choice to name of the GraphQL operation or not
- `variables` (optional): the variables passed to the graphql operation
  - optional as they might not be defined
  - `readonly: false` as they could potentially contain sensitive information so we should enable users to overwrite it 


Link to full internal RFC: https://datadoghq.atlassian.net/l/cp/iyo7Bg1P