### PR TITLE
rename `max_depth_time` and `max_depth_scroll_height` fields

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -814,17 +814,17 @@ export declare type RumViewEvent = CommonProperties & {
              */
             readonly max_depth: number;
             /**
-             * Page scroll height (total height) when the maximum scroll depth was reached for this view (in pixels)
-             */
-            readonly max_depth_scroll_height: number;
-            /**
              * Page scroll top (scrolled distance) when the maximum scroll depth was reached for this view (in pixels)
              */
             readonly max_depth_scroll_top: number;
             /**
-             * Duration between the view start and the scroll event that reached the maximum scroll depth for this view (in nanoseconds)
+             * Maximum page scroll height (total height) for this view (in pixels)
              */
-            readonly max_depth_time: number;
+            readonly max_scroll_height: number;
+            /**
+             * Duration between the view start and the time the max scroll height was reached for this view (in nanoseconds)
+             */
+            readonly max_scroll_height_time: number;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -814,17 +814,17 @@ export declare type RumViewEvent = CommonProperties & {
              */
             readonly max_depth: number;
             /**
-             * Page scroll height (total height) when the maximum scroll depth was reached for this view (in pixels)
-             */
-            readonly max_depth_scroll_height: number;
-            /**
              * Page scroll top (scrolled distance) when the maximum scroll depth was reached for this view (in pixels)
              */
             readonly max_depth_scroll_top: number;
             /**
-             * Duration between the view start and the scroll event that reached the maximum scroll depth for this view (in nanoseconds)
+             * Maximum page scroll height (total height) for this view (in pixels)
              */
-            readonly max_depth_time: number;
+            readonly max_scroll_height: number;
+            /**
+             * Duration between the view start and the time the max scroll height was reached for this view (in nanoseconds)
+             */
+            readonly max_scroll_height_time: number;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -437,16 +437,11 @@
             "scroll": {
               "type": "object",
               "description": "Scroll properties",
-              "required": ["max_depth", "max_depth_scroll_height", "max_depth_scroll_top", "max_depth_time"],
+              "required": ["max_depth", "max_depth_scroll_top", "max_scroll_height", "max_scroll_height_time"],
               "properties": {
                 "max_depth": {
                   "type": "number",
                   "description": "Distance between the top and the lowest point reached on this view (in pixels)",
-                  "readOnly": true
-                },
-                "max_depth_scroll_height": {
-                  "type": "number",
-                  "description": "Page scroll height (total height) when the maximum scroll depth was reached for this view (in pixels)",
                   "readOnly": true
                 },
                 "max_depth_scroll_top": {
@@ -454,9 +449,14 @@
                   "description": "Page scroll top (scrolled distance) when the maximum scroll depth was reached for this view (in pixels)",
                   "readOnly": true
                 },
-                "max_depth_time": {
+                "max_scroll_height": {
                   "type": "number",
-                  "description": "Duration between the view start and the scroll event that reached the maximum scroll depth for this view (in nanoseconds)",
+                  "description": "Maximum page scroll height (total height) for this view (in pixels)",
+                  "readOnly": true
+                },
+                "max_scroll_height_time": {
+                  "type": "number",
+                  "description": "Duration between the view start and the time the max scroll height was reached for this view (in nanoseconds)",
                   "readOnly": true
                 }
               },


### PR DESCRIPTION
We changed the implementation behind those fields. The new name better reflects the reported values.