### PR TITLE
RUM-1507 Add image resource identifier

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -168,7 +168,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */
@@ -292,7 +292,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -166,6 +166,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     base64?: string;
     /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
+    /**
      * MIME type of the image file
      */
     mimeType?: string;
@@ -285,6 +289,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
     base64?: string;
+    /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -467,6 +467,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     base64?: string;
     /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
+    /**
      * MIME type of the image file
      */
     mimeType?: string;
@@ -586,6 +590,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
     base64?: string;
+    /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -469,7 +469,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */
@@ -593,7 +593,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -168,7 +168,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */
@@ -292,7 +292,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -166,6 +166,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     base64?: string;
     /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
+    /**
      * MIME type of the image file
      */
     mimeType?: string;
@@ -285,6 +289,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
     base64?: string;
+    /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -467,6 +467,10 @@ export declare type ImageWireframe = CommonShapeWireframe & {
      */
     base64?: string;
     /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
+    /**
      * MIME type of the image file
      */
     mimeType?: string;
@@ -586,6 +590,10 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
      * base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
      */
     base64?: string;
+    /**
+     * Unique identifier of the image resource
+     */
+    resourceIdentifier?: string;
     /**
      * MIME type of the image file
      */

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -469,7 +469,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */
@@ -593,7 +593,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * Unique identifier of the image resource
      */
-    resourceIdentifier?: string;
+    resourceId?: string;
     /**
      * MIME type of the image file
      */

--- a/samples/session-replay/mobile/record/full-snapshot-record.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record.json
@@ -26,6 +26,7 @@
         "height": 30,
         "type": "image",
         "base64": "base64Mock",
+        "resourceIdentifier": "resourceIdentifierMock",
         "mimeType": "image/jpeg"
       },
       {

--- a/samples/session-replay/mobile/record/full-snapshot-record.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record.json
@@ -26,7 +26,7 @@
         "height": 30,
         "type": "image",
         "base64": "base64Mock",
-        "resourceIdentifier": "resourceIdentifierMock",
+        "resourceId": "resourceIdMock",
         "mimeType": "image/jpeg"
       },
       {

--- a/samples/session-replay/mobile/record/incremental-snapshot-record.json
+++ b/samples/session-replay/mobile/record/incremental-snapshot-record.json
@@ -61,7 +61,7 @@
         "id": 12,
         "type": "image",
         "base64": "base64Mock",
-        "resourceIdentifier": "resourceIdentifierMock",
+        "resourceId": "resourceIdMock",
         "mimeType": "image/jpeg"
       },
       {

--- a/samples/session-replay/mobile/record/incremental-snapshot-record.json
+++ b/samples/session-replay/mobile/record/incremental-snapshot-record.json
@@ -61,6 +61,7 @@
         "id": 12,
         "type": "image",
         "base64": "base64Mock",
+        "resourceIdentifier": "resourceIdentifierMock",
         "mimeType": "image/jpeg"
       },
       {

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -22,6 +22,11 @@
           "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
+        "resourceIdentifier": {
+          "type": "string",
+          "description": "Unique identifier of the image file",
+          "readOnly": false
+        },
         "mimeType": {
           "type": "string",
           "description": "MIME type of the image file",

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -24,7 +24,7 @@
         },
         "resourceIdentifier": {
           "type": "string",
-          "description": "Unique identifier of the image file",
+          "description": "Unique identifier of the image resource",
           "readOnly": false
         },
         "mimeType": {

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -22,7 +22,7 @@
           "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
-        "resourceIdentifier": {
+        "resourceId": {
           "type": "string",
           "description": "Unique identifier of the image resource",
           "readOnly": false

--- a/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -22,6 +22,11 @@
           "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
+        "resourceIdentifier": {
+          "type": "string",
+          "description": "Unique identifier of the image file",
+          "readOnly": false
+        },
         "mimeType": {
           "type": "string",
           "description": "MIME type of the image file",

--- a/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -24,7 +24,7 @@
         },
         "resourceIdentifier": {
           "type": "string",
-          "description": "Unique identifier of the image file",
+          "description": "Unique identifier of the image resource",
           "readOnly": false
         },
         "mimeType": {

--- a/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -22,7 +22,7 @@
           "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
-        "resourceIdentifier": {
+        "resourceId": {
           "type": "string",
           "description": "Unique identifier of the image resource",
           "readOnly": false


### PR DESCRIPTION
Adds a new field that will be utilised in [Resource Endpoint](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3224240335/Replay+Resource+Service) work.

It also brings [significant optimisation to Diffing](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3189606163/RFC+-+Reducing+CPU+Pressure+-+iOS+Session+Replay) algorithms in mobile SDKs.