### PR TITLE
[RUM][Replay][Webviews] introduce webview wireframe and a nestedEnvId for record generated by a webview

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -31,12 +31,21 @@ export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrement
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserFullSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 2;
     data: BrowserNode;
+};
+/**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export declare type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Defines the unique ID of the nested replay environment that generated this record.
+     */
+    readonly nestedEnvId?: number;
 };
 /**
  * Serialized node contained by this Record.
@@ -51,7 +60,7 @@ export declare type SerializedNode = DocumentNode | DocumentFragmentNode | Docum
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserIncrementalSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -207,7 +216,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = CommonRecordSchema & {
+export declare type MetaRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -233,7 +242,7 @@ export declare type MetaRecord = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = CommonRecordSchema & {
+export declare type FocusRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -248,7 +257,7 @@ export declare type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = CommonRecordSchema & {
+export declare type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -257,7 +266,7 @@ export declare type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = CommonRecordSchema & {
+export declare type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -275,7 +284,7 @@ export declare type VisualViewportRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = CommonRecordSchema & {
+export declare type FrustrationRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -41,7 +41,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -188,6 +188,19 @@ export declare type PlaceholderWireframe = CommonWireframe & {
     label?: string;
 };
 /**
+ * Schema of all properties of a WebviewWireframe.
+ */
+export declare type WebviewWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -241,7 +254,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -308,6 +321,19 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
     label?: string;
 };
 /**
+ * Schema of all properties of a WebviewWireframeUpdate.
+ */
+export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
+};
+/**
  * Schema of a TouchData.
  */
 export declare type TouchData = {
@@ -358,7 +384,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = CommonRecordSchema & {
+export declare type MetaRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -382,9 +408,18 @@ export declare type MetaRecord = CommonRecordSchema & {
     };
 };
 /**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export declare type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Defines the unique ID of the nested replay environment that generated this record.
+     */
+    readonly nestedEnvId?: number;
+};
+/**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = CommonRecordSchema & {
+export declare type FocusRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -399,7 +434,7 @@ export declare type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = CommonRecordSchema & {
+export declare type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -408,7 +443,7 @@ export declare type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = CommonRecordSchema & {
+export declare type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -39,12 +39,21 @@ export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrement
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserFullSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 2;
     data: BrowserNode;
+};
+/**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export declare type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Defines the unique ID of the nested replay environment that generated this record.
+     */
+    readonly nestedEnvId?: number;
 };
 /**
  * Serialized node contained by this Record.
@@ -59,7 +68,7 @@ export declare type SerializedNode = DocumentNode | DocumentFragmentNode | Docum
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserIncrementalSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -215,7 +224,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = CommonRecordSchema & {
+export declare type MetaRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -241,7 +250,7 @@ export declare type MetaRecord = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = CommonRecordSchema & {
+export declare type FocusRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -256,7 +265,7 @@ export declare type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = CommonRecordSchema & {
+export declare type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -265,7 +274,7 @@ export declare type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = CommonRecordSchema & {
+export declare type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -283,7 +292,7 @@ export declare type VisualViewportRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = CommonRecordSchema & {
+export declare type FrustrationRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -342,7 +351,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -489,6 +498,19 @@ export declare type PlaceholderWireframe = CommonWireframe & {
     label?: string;
 };
 /**
+ * Schema of all properties of a WebviewWireframe.
+ */
+export declare type WebviewWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -542,7 +564,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -607,6 +629,19 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
      * Label of the placeholder
      */
     label?: string;
+};
+/**
+ * Schema of all properties of a WebviewWireframeUpdate.
+ */
+export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
 };
 /**
  * Schema of a TouchData.

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -31,12 +31,21 @@ export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrement
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserFullSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 2;
     data: BrowserNode;
+};
+/**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export declare type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Defines the unique ID of the nested replay environment that generated this record.
+     */
+    readonly nestedEnvId?: number;
 };
 /**
  * Serialized node contained by this Record.
@@ -51,7 +60,7 @@ export declare type SerializedNode = DocumentNode | DocumentFragmentNode | Docum
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserIncrementalSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -207,7 +216,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = CommonRecordSchema & {
+export declare type MetaRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -233,7 +242,7 @@ export declare type MetaRecord = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = CommonRecordSchema & {
+export declare type FocusRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -248,7 +257,7 @@ export declare type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = CommonRecordSchema & {
+export declare type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -257,7 +266,7 @@ export declare type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = CommonRecordSchema & {
+export declare type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -275,7 +284,7 @@ export declare type VisualViewportRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = CommonRecordSchema & {
+export declare type FrustrationRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -41,7 +41,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -188,6 +188,19 @@ export declare type PlaceholderWireframe = CommonWireframe & {
     label?: string;
 };
 /**
+ * Schema of all properties of a WebviewWireframe.
+ */
+export declare type WebviewWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -241,7 +254,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -308,6 +321,19 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
     label?: string;
 };
 /**
+ * Schema of all properties of a WebviewWireframeUpdate.
+ */
+export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
+};
+/**
  * Schema of a TouchData.
  */
 export declare type TouchData = {
@@ -358,7 +384,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = CommonRecordSchema & {
+export declare type MetaRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -382,9 +408,18 @@ export declare type MetaRecord = CommonRecordSchema & {
     };
 };
 /**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export declare type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Defines the unique ID of the nested replay environment that generated this record.
+     */
+    readonly nestedEnvId?: number;
+};
+/**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = CommonRecordSchema & {
+export declare type FocusRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -399,7 +434,7 @@ export declare type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = CommonRecordSchema & {
+export declare type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -408,7 +443,7 @@ export declare type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = CommonRecordSchema & {
+export declare type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -39,12 +39,21 @@ export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrement
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserFullSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 2;
     data: BrowserNode;
+};
+/**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export declare type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Defines the unique ID of the nested replay environment that generated this record.
+     */
+    readonly nestedEnvId?: number;
 };
 /**
  * Serialized node contained by this Record.
@@ -59,7 +68,7 @@ export declare type SerializedNode = DocumentNode | DocumentFragmentNode | Docum
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = CommonRecordSchema & {
+export declare type BrowserIncrementalSnapshotRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -215,7 +224,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = CommonRecordSchema & {
+export declare type MetaRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -241,7 +250,7 @@ export declare type MetaRecord = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = CommonRecordSchema & {
+export declare type FocusRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -256,7 +265,7 @@ export declare type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = CommonRecordSchema & {
+export declare type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -265,7 +274,7 @@ export declare type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = CommonRecordSchema & {
+export declare type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -283,7 +292,7 @@ export declare type VisualViewportRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = CommonRecordSchema & {
+export declare type FrustrationRecord = WebviewSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -342,7 +351,7 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe;
+export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
@@ -489,6 +498,19 @@ export declare type PlaceholderWireframe = CommonWireframe & {
     label?: string;
 };
 /**
+ * Schema of all properties of a WebviewWireframe.
+ */
+export declare type WebviewWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
+};
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -542,7 +564,7 @@ export declare type MobileMutationPayload = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate;
+export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -607,6 +629,19 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
      * Label of the placeholder
      */
     label?: string;
+};
+/**
+ * Schema of all properties of a WebviewWireframeUpdate.
+ */
+export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'webview';
+    /**
+     * Defines the unique ID of the replayed webview environment that will be nested in this container.
+     */
+    readonly nestedEnvId: number;
 };
 /**
  * Schema of a TouchData.

--- a/schemas/session-replay/browser/frustration-record-schema.json
+++ b/schemas/session-replay/browser/frustration-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Schema of a Record which signifies a collection of frustration signals.",
   "allOf": [
     {
-      "$ref": "../common/_common-record-schema.json"
+      "$ref": "../common/_webview-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/schemas/session-replay/browser/full-snapshot-record-schema.json
+++ b/schemas/session-replay/browser/full-snapshot-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Browser-specific. Schema of a Record type which contains the full snapshot of a screen.",
   "allOf": [
     {
-      "$ref": "../common/_common-record-schema.json"
+      "$ref": "../common/_webview-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/schemas/session-replay/browser/incremental-snapshot-record-schema.json
+++ b/schemas/session-replay/browser/incremental-snapshot-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Browser-specific. Schema of a Record type which contains mutations of a screen.",
   "allOf": [
     {
-      "$ref": "../common/_common-record-schema.json"
+      "$ref": "../common/_webview-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/schemas/session-replay/common/_webview-supported-common-record-schema.json
+++ b/schemas/session-replay/common/_webview-supported-common-record-schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/common/_webview-supported-common-record-schema.json",
+  "title": "WebviewSupportedCommonRecordSchema",
+  "type": "object",
+  "description": "Schema of common properties for a Record event type that is supported by webviews.",
+  "allOf": [
+    {
+      "$ref": "_common-record-schema.json"
+    },
+    {
+      "properties": {
+        "nestedEnvId": {
+          "type": "integer",
+          "description": "Defines the unique ID of the nested replay environment that generated this record.",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/session-replay/common/focus-record-schema.json
+++ b/schemas/session-replay/common/focus-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Schema of a Record type which contains focus information.",
   "allOf": [
     {
-      "$ref": "_common-record-schema.json"
+      "$ref": "_webview-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/schemas/session-replay/common/meta-record-schema.json
+++ b/schemas/session-replay/common/meta-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Schema of a Record which contains the screen properties.",
   "allOf": [
     {
-      "$ref": "_common-record-schema.json"
+      "$ref": "_webview-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/schemas/session-replay/common/view-end-record-schema.json
+++ b/schemas/session-replay/common/view-end-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Schema of a Record which signifies that view lifecycle ended.",
   "allOf": [
     {
-      "$ref": "_common-record-schema.json"
+      "$ref": "_webview-supported-common-record-schema.json"
     },
     {
       "required": ["type"],

--- a/schemas/session-replay/common/visual-viewport-record-schema.json
+++ b/schemas/session-replay/common/visual-viewport-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Schema of a Record which signifies that the viewport properties have changed.",
   "allOf": [
     {
-      "$ref": "_common-record-schema.json"
+      "$ref": "_webview-supported-common-record-schema.json"
     },
     {
       "required": ["data", "type"],

--- a/schemas/session-replay/mobile/webview-wireframe-schema.json
+++ b/schemas/session-replay/mobile/webview-wireframe-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/webview-wireframe-schema.json",
+  "title": "WebviewWireframe",
+  "type": "object",
+  "description": "Schema of all properties of a WebviewWireframe.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-schema.json"
+    },
+    {
+      "required": ["type", "nestedEnvId"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "webview",
+          "readOnly": true
+        },
+        "nestedEnvId": {
+          "type": "integer",
+          "description": "Defines the unique ID of the replayed webview environment that will be nested in this container.",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/session-replay/mobile/webview-wireframe-update-schema.json
+++ b/schemas/session-replay/mobile/webview-wireframe-update-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/webview-wireframe-update-schema.json",
+  "title": "WebviewWireframeUpdate",
+  "type": "object",
+  "description": "Schema of all properties of a WebviewWireframeUpdate.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-update-schema.json"
+    },
+    {
+      "required": ["type", "nestedEnvId"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "webview",
+          "readOnly": true
+        },
+        "nestedEnvId": {
+          "type": "integer",
+          "description": "Defines the unique ID of the replayed webview environment that will be nested in this container.",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/session-replay/mobile/wireframe-schema.json
+++ b/schemas/session-replay/mobile/wireframe-schema.json
@@ -16,6 +16,9 @@
     },
     {
       "$ref": "placeholder-wireframe-schema.json"
+    },
+    {
+      "$ref": "webview-wireframe-schema.json"
     }
   ]
 }

--- a/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
+++ b/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
@@ -16,6 +16,9 @@
     },
     {
       "$ref": "placeholder-wireframe-update-schema.json"
+    },
+    {
+      "$ref": "webview-wireframe-update-schema.json"
     }
   ]
 }


### PR DESCRIPTION
### What

As part of the webview support efforts, records need to be tagged if they were produced from an instrumented webview so we can stream them to the right encapsulation replay environment.
The record that are supported by webviews will then have an optional field `nestedEnvId` that describe the id of the webview that generated the records.
As in the future, we could also support the replaying of other encapsulated environments such as Iframes, it's safer to leverage an agnostic `nestedEnvId` rather than a `webViewId`

On top of that, the new `WebviewWireframe` schema need to be created. It inherits all the fields of a `ShapeWireframe` with an added `nestedEnvId` that describe the unique replayed webview environment that will be encapsulated in this container.

### Then

All the browser specific records as well as the common records such as `MetaRecord`, `FocusRecord`, `VisualViewportRecord`... that are supported by webviews inherit the new and optional `nestedEnvId` field.

The `webview-wireframe-schema.json` and its update schemas are defined