### PR TITLE
[RUM-1658] Add extra field to identify sessions recorded manually

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -799,6 +799,16 @@ export declare type RumViewEvent = CommonProperties & {
             segments_total_raw_size?: number;
             [k: string]: unknown;
         };
+        /**
+         * Subset of the SDK configuration options in use during its execution
+         */
+        readonly configuration?: {
+            /**
+             * Whether session replay recording configured to start manually
+             */
+            readonly start_session_replay_recording_manually?: boolean;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -799,6 +799,16 @@ export declare type RumViewEvent = CommonProperties & {
             segments_total_raw_size?: number;
             [k: string]: unknown;
         };
+        /**
+         * Subset of the SDK configuration options in use during its execution
+         */
+        readonly configuration?: {
+            /**
+             * Whether session replay recording configured to start manually
+             */
+            readonly start_session_replay_recording_manually?: boolean;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -64,7 +64,8 @@
     ],
     "configuration": {
       "session_sample_rate": 12.45,
-      "session_replay_sample_rate": 100
+      "session_replay_sample_rate": 100,
+      "start_session_replay_recording_manually": true
     }
   },
   "synthetics": {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -425,6 +425,18 @@
                   "default": 0
                 }
               }
+            },
+            "configuration": {
+              "type": "object",
+              "description": "Subset of the SDK configuration options in use during its execution",
+              "readOnly": true,
+              "properties": {
+                "start_session_replay_recording_manually": {
+                  "type": "boolean",
+                  "description": "Whether session replay recording configured to start manually",
+                  "readOnly": true
+                }
+              }
             }
           },
           "readOnly": true


### PR DESCRIPTION
# Motivation

we would want to have metrics on:

1. sessions recorded automatically

1. sessions recorded manually

1. sessions sampled for replay but no recorded

So we need to add an extra field on RUM data to differentiate between 1 and 2.

# Changes

Similar to how we [attach sample rates](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/_common-schema.json#L308-L329), add an extra `_dd.configuration.start_session_replay_recording_manually` matching the SDK configuration.
Only on `view` events though, since we want monitor sessions.
