### PR TITLE
[RUM-1335] Add `_dd.session_precondition`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -730,10 +730,6 @@ export declare type RumViewEvent = CommonProperties & {
      */
     readonly session?: {
         /**
-         * The precondition that led to the creation of the session
-         */
-        readonly start_precondition?: 'app_launch' | 'inactivity_timeout' | 'max_duration' | 'explicit_stop' | 'background_event';
-        /**
          * Whether this session is currently active. Set to false to manually stop a session
          */
         readonly is_active?: boolean;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1073,6 +1073,10 @@ export interface CommonProperties {
              * Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
              */
             plan?: 1 | 2;
+            /**
+             * The precondition that led to the creation of the session
+             */
+            readonly session_precondition?: 'user_app_launch' | 'inactivity_timeout' | 'max_duration' | 'background_launch' | 'prewarm' | 'from_non_interactive_session' | 'explicit_stop';
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -730,10 +730,6 @@ export declare type RumViewEvent = CommonProperties & {
      */
     readonly session?: {
         /**
-         * The precondition that led to the creation of the session
-         */
-        readonly start_precondition?: 'app_launch' | 'inactivity_timeout' | 'max_duration' | 'explicit_stop' | 'background_event';
-        /**
          * Whether this session is currently active. Set to false to manually stop a session
          */
         readonly is_active?: boolean;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1073,6 +1073,10 @@ export interface CommonProperties {
              * Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
              */
             plan?: 1 | 2;
+            /**
+             * The precondition that led to the creation of the session
+             */
+            readonly session_precondition?: 'user_app_launch' | 'inactivity_timeout' | 'max_duration' | 'background_launch' | 'prewarm' | 'from_non_interactive_session' | 'explicit_stop';
             [k: string]: unknown;
         };
         /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -302,6 +302,20 @@
               "type": "number",
               "description": "Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)",
               "enum": [1, 2]
+            },
+            "session_precondition": {
+              "type": "string",
+              "description": "The precondition that led to the creation of the session",
+              "enum": [
+                "user_app_launch",
+                "inactivity_timeout",
+                "max_duration",
+                "background_launch",
+                "prewarm",
+                "from_non_interactive_session",
+                "explicit_stop"
+              ],
+              "readOnly": true
             }
           }
         },

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -328,12 +328,6 @@
           "description": "Session properties",
           "required": [],
           "properties": {
-            "start_precondition": {
-              "type": "string",
-              "description": "The precondition that led to the creation of the session",
-              "enum": ["app_launch", "inactivity_timeout", "max_duration", "explicit_stop", "background_event"],
-              "readOnly": true
-            },
             "is_active": {
               "type": "boolean",
               "description": "Whether this session is currently active. Set to false to manually stop a session",


### PR DESCRIPTION
Following the _Session Standarization_ project, we introduce `_dd.session.session_precondition` field to track reason of starting each RUM session.

⚠️ It will replace the `view.start_precondition` that was [added earlier](https://github.com/DataDog/rum-events-format/pull/136) and then [renamed](https://github.com/DataDog/rum-events-format/pull/139). Because `start_precondition` had no use, we don't consider this a breaking change and we decided to erase this field from schema.