### PR TITLE
RUM-2162: Add parent view id to event schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -8,7 +8,7 @@ export declare type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent
 /**
  * Schema of all properties of an Action event
  */
-export declare type RumActionEvent = CommonProperties & {
+export declare type RumActionEvent = CommonProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -150,7 +150,7 @@ export declare type RumActionEvent = CommonProperties & {
 /**
  * Schema of all properties of an Error event
  */
-export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
+export declare type RumErrorEvent = CommonProperties & ActionChildProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -280,7 +280,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
 /**
  * Schema of all properties of a Long Task event
  */
-export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties & {
+export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -318,7 +318,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a Resource event
  */
-export declare type RumResourceEvent = CommonProperties & ActionChildProperties & {
+export declare type RumResourceEvent = CommonProperties & ActionChildProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -508,7 +508,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a View event
  */
-export declare type RumViewEvent = CommonProperties & {
+export declare type RumViewEvent = CommonProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -1099,6 +1099,26 @@ export interface CommonProperties {
      * User provided context
      */
     context?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/**
+ * Parent view schema for views that are nested (webviews in mobile)
+ */
+export interface ParentViewSchema {
+    /**
+     * Parent view properties (view wrapping the current view)
+     */
+    readonly parent_view?: {
+        /**
+         * ID of the parent view
+         */
+        readonly id: string;
+        /**
+         * Source of the parent view
+         */
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -8,7 +8,7 @@ export declare type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent
 /**
  * Schema of all properties of an Action event
  */
-export declare type RumActionEvent = CommonProperties & {
+export declare type RumActionEvent = CommonProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -150,7 +150,7 @@ export declare type RumActionEvent = CommonProperties & {
 /**
  * Schema of all properties of an Error event
  */
-export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
+export declare type RumErrorEvent = CommonProperties & ActionChildProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -280,7 +280,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & {
 /**
  * Schema of all properties of a Long Task event
  */
-export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties & {
+export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -318,7 +318,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a Resource event
  */
-export declare type RumResourceEvent = CommonProperties & ActionChildProperties & {
+export declare type RumResourceEvent = CommonProperties & ActionChildProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -508,7 +508,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a View event
  */
-export declare type RumViewEvent = CommonProperties & {
+export declare type RumViewEvent = CommonProperties & ParentViewSchema & {
     /**
      * RUM event type
      */
@@ -1099,6 +1099,26 @@ export interface CommonProperties {
      * User provided context
      */
     context?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/**
+ * Parent view schema for views that are nested (webviews in mobile)
+ */
+export interface ParentViewSchema {
+    /**
+     * Parent view properties (view wrapping the current view)
+     */
+    readonly parent_view?: {
+        /**
+         * ID of the parent view
+         */
+        readonly id: string;
+        /**
+         * Source of the parent view
+         */
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/schemas/rum/_parent-view-schema.json
+++ b/schemas/rum/_parent-view-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_parent-view-schema.json",
+  "title": "ParentViewSchema",
+  "type": "object",
+  "description": "Parent view schema for views that are nested (webviews in mobile)",
+  "properties": {
+    "parent_view": {
+      "type": "object",
+      "description": "Parent view properties (view wrapping the current view)",
+      "required": ["id", "source"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the parent view",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "source": {
+          "type": "string",
+          "description": "Source of the parent view",
+          "enum": ["android", "ios", "browser", "flutter", "react-native", "roku"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -9,6 +9,9 @@
       "$ref": "_common-schema.json"
     },
     {
+      "$ref": "_parent-view-schema.json"
+    },
+    {
       "required": ["type", "action"],
       "properties": {
         "type": {

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -12,6 +12,9 @@
       "$ref": "_action-child-schema.json"
     },
     {
+      "$ref": "_parent-view-schema.json"
+    },
+    {
       "required": ["type", "error"],
       "properties": {
         "type": {

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -12,6 +12,9 @@
       "$ref": "_action-child-schema.json"
     },
     {
+      "$ref": "_parent-view-schema.json"
+    },
+    {
       "required": ["type", "long_task"],
       "properties": {
         "type": {

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -12,6 +12,9 @@
       "$ref": "_action-child-schema.json"
     },
     {
+      "$ref": "_parent-view-schema.json"
+    },
+    {
       "required": ["type", "resource"],
       "properties": {
         "type": {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -9,6 +9,9 @@
       "$ref": "_common-schema.json"
     },
     {
+      "$ref": "_parent-view-schema.json"
+    },
+    {
       "required": ["type", "view", "_dd"],
       "properties": {
         "type": {


### PR DESCRIPTION
### Changes
Adding a new optional field that contains data about the parent view of RUM Events.
This new field is added on all RUM Events except SessionRumEvent.
This field has two attributes:

```typescript
parent_view: {
    id: string // uuid
    source: string // source of the parent view
}
