### PR TITLE
[RUM-2436] telemetry: add `usePartitionedCrossSiteSessionCookie` config parameter

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -140,9 +140,13 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_long_task?: boolean;
             /**
-             * Whether a secure cross-site session cookie is used
+             * Whether a secure cross-site session cookie is used (deprecated)
              */
             use_cross_site_session_cookie?: boolean;
+            /**
+             * Whether a partitioned secure cross-site session cookie is used
+             */
+            use_partitioned_cross_site_session_cookie?: boolean;
             /**
              * Whether a secure session cookie is used
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -140,9 +140,13 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_long_task?: boolean;
             /**
-             * Whether a secure cross-site session cookie is used
+             * Whether a secure cross-site session cookie is used (deprecated)
              */
             use_cross_site_session_cookie?: boolean;
+            /**
+             * Whether a partitioned secure cross-site session cookie is used
+             */
+            use_partitioned_cross_site_session_cookie?: boolean;
             /**
              * Whether a secure session cookie is used
              */

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -102,7 +102,11 @@
                 },
                 "use_cross_site_session_cookie": {
                   "type": "boolean",
-                  "description": "Whether a secure cross-site session cookie is used"
+                  "description": "Whether a secure cross-site session cookie is used (deprecated)"
+                },
+                "use_partitioned_cross_site_session_cookie": {
+                  "type": "boolean",
+                  "description": "Whether a partitioned secure cross-site session cookie is used"
                 },
                 "use_secure_session_cookie": {
                   "type": "boolean",


### PR DESCRIPTION
# Motivation

To address the phasing out of third-party cookies by google, introduce a new browser SDK config parameter: `usePartitionedCrossSiteSessionCookie`

# Changes

Add the corresponding parameter in telemetry configuration schema 