### PR TITLE
[RUM-2729] Update connectivity model with browser support

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -946,6 +946,10 @@ export interface CommonProperties {
          */
         readonly interfaces?: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
         /**
+         * Effective type of the network connection
+         */
+        readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g';
+        /**
          * Cellular connectivity properties
          */
         readonly cellular?: {

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -946,7 +946,7 @@ export interface CommonProperties {
          */
         readonly interfaces?: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
         /**
-         * Effective type of the network connection
+         * Cellular connection type reflecting the measured network performance
          */
         readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g';
         /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -944,7 +944,7 @@ export interface CommonProperties {
         /**
          * The list of available network interfaces
          */
-        readonly interfaces: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
+        readonly interfaces?: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
         /**
          * Cellular connectivity properties
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -946,6 +946,10 @@ export interface CommonProperties {
          */
         readonly interfaces?: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
         /**
+         * Effective type of the network connection
+         */
+        readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g';
+        /**
          * Cellular connectivity properties
          */
         readonly cellular?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -946,7 +946,7 @@ export interface CommonProperties {
          */
         readonly interfaces?: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
         /**
-         * Effective type of the network connection
+         * Cellular connection type reflecting the measured network performance
          */
         readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g';
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -944,7 +944,7 @@ export interface CommonProperties {
         /**
          * The list of available network interfaces
          */
-        readonly interfaces: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
+        readonly interfaces?: ('bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'mixed' | 'other' | 'unknown' | 'none')[];
         /**
          * Cellular connectivity properties
          */

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -49,6 +49,10 @@
     "feature_three": 2,
     "feature_four": { "foo": "bar" }
   },
+  "connectivity": {
+    "status": "connected",
+    "effective_type": "4g"
+  },
   "_dd": {
     "format_version": 2
   }

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -132,7 +132,7 @@
     "connectivity": {
       "type": "object",
       "description": "Device connectivity properties",
-      "required": ["status", "interfaces"],
+      "required": ["status"],
       "properties": {
         "status": {
           "type": "string",

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -149,6 +149,12 @@
           },
           "readOnly": true
         },
+        "effective_type": {
+          "type": "string",
+          "description": "Effective type of the network connection",
+          "enum": ["slow_2g", "2g", "3g", "4g"],
+          "readOnly": true
+        },
         "cellular": {
           "type": "object",
           "description": "Cellular connectivity properties",

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -151,7 +151,7 @@
         },
         "effective_type": {
           "type": "string",
-          "description": "Effective type of the network connection",
+          "description": "Cellular connection type reflecting the measured network performance",
           "enum": ["slow_2g", "2g", "3g", "4g"],
           "readOnly": true
         },


### PR DESCRIPTION
# Motivation

Collect connectivity data for RUM browser

# Changes

- Make `connectivity.interfaces` optional: not supported by every browser
- Add `connectivity.effective_type` (`slow-2g`, `2g`, `3g`, `4g`) 