### PR TITLE
RUM-2863: Add more HTTP methods to the schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -228,7 +228,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             /**
              * HTTP method of the resource
              */
-            readonly method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH';
+            readonly method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'OPTIONS' | 'CONNECT';
             /**
              * HTTP Status code of the resource
              */
@@ -338,7 +338,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
         /**
          * HTTP method of the resource
          */
-        readonly method?: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH';
+        readonly method?: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'OPTIONS' | 'CONNECT';
         /**
          * URL of the resource
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -228,7 +228,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             /**
              * HTTP method of the resource
              */
-            readonly method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH';
+            readonly method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'OPTIONS' | 'CONNECT';
             /**
              * HTTP Status code of the resource
              */
@@ -338,7 +338,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
         /**
          * HTTP method of the resource
          */
-        readonly method?: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH';
+        readonly method?: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'OPTIONS' | 'CONNECT';
         /**
          * URL of the resource
          */

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -123,7 +123,7 @@
                 "method": {
                   "type": "string",
                   "description": "HTTP method of the resource",
-                  "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH"],
+                  "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH", "TRACE", "OPTIONS", "CONNECT"],
                   "readOnly": true
                 },
                 "status_code": {

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -43,7 +43,7 @@
             "method": {
               "type": "string",
               "description": "HTTP method of the resource",
-              "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH"],
+              "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH", "TRACE", "OPTIONS", "CONNECT"],
               "readOnly": true
             },
             "url": {


### PR DESCRIPTION
We need to add more HTTP methods to the RUM event schema. All the new methods added are part of the [following RFC](https://www.rfc-editor.org/rfc/rfc9110.html#section-9).

There is no limitation for the value of the `http.method` tag on the APM side (considering RUM2APM functionality), and RUM resources / APM spans are created and displayed without any issues with these new values.