### PR TITLE
RUM-621: Add additional error properties for the native Mobile SDKs crash/error reporting

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -258,7 +258,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         };
         /**
-         * Description of the each thread in the process when error happened.
+         * Description of each thread in the process when error happened.
          */
         threads?: {
             /**
@@ -280,7 +280,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         }[];
         /**
-         * Description of the each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
+         * Description of each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
          */
         readonly binary_images?: {
             /**
@@ -300,7 +300,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
              */
             readonly load_address?: string;
             /**
-             * Max from the library address range (hexadecimal).
+             * Max value from the library address range (hexadecimal).
              */
             readonly max_address?: string;
             /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -257,6 +257,96 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             };
             [k: string]: unknown;
         };
+        /**
+         * Description of the each thread in the process when error happened.
+         */
+        threads?: {
+            /**
+             * Name of the thread (e.g. 'Thread 0').
+             */
+            readonly name: string;
+            /**
+             * Tells if the thread crashed.
+             */
+            readonly crashed: boolean;
+            /**
+             * Unsymbolicated stack trace of the given thread.
+             */
+            readonly stack: string;
+            /**
+             * Platform-specific state of the thread when its state was captured (CPU registers dump for iOS, thread state enum for Android, etc.).
+             */
+            readonly state?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Description of the each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
+         */
+        readonly binary_images?: {
+            /**
+             * Build UUID that uniquely identifies the binary image.
+             */
+            readonly uuid: string;
+            /**
+             * Name of the library.
+             */
+            readonly name: string;
+            /**
+             * Determines if it's a system or user library.
+             */
+            readonly is_system: boolean;
+            /**
+             * Library's load address (hexadecimal).
+             */
+            readonly load_address?: string;
+            /**
+             * Max from the library address range (hexadecimal).
+             */
+            readonly max_address?: string;
+            /**
+             * CPU architecture from the library.
+             */
+            readonly arch?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * A boolean value saying if any of the stack traces was truncated due to minification.
+         */
+        readonly was_truncated?: boolean;
+        /**
+         * Platform-specific metadata of the error event.
+         */
+        readonly meta?: {
+            /**
+             * The CPU architecture of the process that crashed.
+             */
+            readonly code_type?: string;
+            /**
+             * Parent process information.
+             */
+            readonly parent_process?: string;
+            /**
+             * A client-generated 16-byte UUID of the incident.
+             */
+            readonly incident_identifier?: string;
+            /**
+             * The name of the crashed process.
+             */
+            readonly process?: string;
+            /**
+             * The name of the corresponding BSD termination signal. (in case of iOS crash)
+             */
+            readonly exception_type?: string;
+            /**
+             * CPU specific information about the exception encoded into 64-bit hexadecimal number preceded by the signal code.
+             */
+            readonly exception_codes?: string;
+            /**
+             * The location of the executable.
+             */
+            readonly path?: string;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -258,7 +258,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         };
         /**
-         * Description of the each thread in the process when error happened.
+         * Description of each thread in the process when error happened.
          */
         threads?: {
             /**
@@ -280,7 +280,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         }[];
         /**
-         * Description of the each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
+         * Description of each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
          */
         readonly binary_images?: {
             /**
@@ -300,7 +300,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
              */
             readonly load_address?: string;
             /**
-             * Max from the library address range (hexadecimal).
+             * Max value from the library address range (hexadecimal).
              */
             readonly max_address?: string;
             /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -257,6 +257,96 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             };
             [k: string]: unknown;
         };
+        /**
+         * Description of the each thread in the process when error happened.
+         */
+        threads?: {
+            /**
+             * Name of the thread (e.g. 'Thread 0').
+             */
+            readonly name: string;
+            /**
+             * Tells if the thread crashed.
+             */
+            readonly crashed: boolean;
+            /**
+             * Unsymbolicated stack trace of the given thread.
+             */
+            readonly stack: string;
+            /**
+             * Platform-specific state of the thread when its state was captured (CPU registers dump for iOS, thread state enum for Android, etc.).
+             */
+            readonly state?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Description of the each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
+         */
+        readonly binary_images?: {
+            /**
+             * Build UUID that uniquely identifies the binary image.
+             */
+            readonly uuid: string;
+            /**
+             * Name of the library.
+             */
+            readonly name: string;
+            /**
+             * Determines if it's a system or user library.
+             */
+            readonly is_system: boolean;
+            /**
+             * Library's load address (hexadecimal).
+             */
+            readonly load_address?: string;
+            /**
+             * Max from the library address range (hexadecimal).
+             */
+            readonly max_address?: string;
+            /**
+             * CPU architecture from the library.
+             */
+            readonly arch?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * A boolean value saying if any of the stack traces was truncated due to minification.
+         */
+        readonly was_truncated?: boolean;
+        /**
+         * Platform-specific metadata of the error event.
+         */
+        readonly meta?: {
+            /**
+             * The CPU architecture of the process that crashed.
+             */
+            readonly code_type?: string;
+            /**
+             * Parent process information.
+             */
+            readonly parent_process?: string;
+            /**
+             * A client-generated 16-byte UUID of the incident.
+             */
+            readonly incident_identifier?: string;
+            /**
+             * The name of the crashed process.
+             */
+            readonly process?: string;
+            /**
+             * The name of the corresponding BSD termination signal. (in case of iOS crash)
+             */
+            readonly exception_type?: string;
+            /**
+             * CPU specific information about the exception encoded into 64-bit hexadecimal number preceded by the signal code.
+             */
+            readonly exception_codes?: string;
+            /**
+             * The location of the executable.
+             */
+            readonly path?: string;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -38,7 +38,33 @@
         "message": "504 Gateway Timeout",
         "source": "network"
       }
-    ]
+    ],
+    "threads": [
+      {
+        "name": "Thread 0",
+        "crashed": true,
+        "stack": "Failed to load",
+        "state": "STOPPED"
+      }
+    ],
+    "binary_images": [
+      {
+        "uuid": "be3a5d82-cdd1-468d-9bc9-040030c3765c",
+        "name": "libc.so",
+        "is_system": false,
+        "arch": "arm7l"
+      }
+    ],
+    "meta": {
+      "code_type": "arm64",
+      "parent_process": "launchd_sim [31584]",
+      "incident_identifier": "DAA6280F-F6A4-45C2-BA15-FC81DA0B6A4B",
+      "process": "Example iOS [92909]",
+      "exception_type": "SIGABRT",
+      "exception_codes": "#0",
+      "path": "/Application/121E89DC-4F9B-425D-B484-C6CC79FF3CA8/Example iOS.app/Example iOS"
+    },
+    "was_truncated": false
   },
   "action": {
     "id": ["ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c", "be3a5d82-cdd1-468d-9bc9-3aa9e54d953c"]

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -177,6 +177,126 @@
                 }
               },
               "readOnly": true
+            },
+            "threads": {
+              "type": "array",
+              "description": "Description of the each thread in the process when error happened.",
+              "items": {
+                "type": "object",
+                "description": "Description of the thread in the process when error happened.",
+                "required": ["name", "crashed", "stack"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the thread (e.g. 'Thread 0').",
+                    "readOnly": true
+                  },
+                  "crashed": {
+                    "type": "boolean",
+                    "description": "Tells if the thread crashed.",
+                    "readOnly": true
+                  },
+                  "stack": {
+                    "type": "string",
+                    "description": "Unsymbolicated stack trace of the given thread.",
+                    "readOnly": true
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "Platform-specific state of the thread when its state was captured (CPU registers dump for iOS, thread state enum for Android, etc.).",
+                    "readOnly": true
+                  }
+                }
+              }
+            },
+            "binary_images": {
+              "type": "array",
+              "description": "Description of the each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.",
+              "items": {
+                "type": "object",
+                "description": "Description of the binary image (native library; for Android: .so file) loaded or referenced by the process/application.",
+                "required": ["uuid", "name", "is_system"],
+                "properties": {
+                  "uuid": {
+                    "type": "string",
+                    "description": "Build UUID that uniquely identifies the binary image.",
+                    "readOnly": true
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the library.",
+                    "readOnly": true
+                  },
+                  "is_system": {
+                    "type": "boolean",
+                    "description": "Determines if it's a system or user library.",
+                    "readOnly": true
+                  },
+                  "load_address": {
+                    "type": "string",
+                    "description": "Library's load address (hexadecimal).",
+                    "readOnly": true
+                  },
+                  "max_address": {
+                    "type": "string",
+                    "description": "Max from the library address range (hexadecimal).",
+                    "readOnly": true
+                  },
+                  "arch": {
+                    "type": "string",
+                    "description": "CPU architecture from the library.",
+                    "readOnly": true
+                  }
+                }
+              },
+              "readOnly": true
+            },
+            "was_truncated": {
+              "type": "boolean",
+              "description": "A boolean value saying if any of the stack traces was truncated due to minification.",
+              "readOnly": true
+            },
+            "meta": {
+              "type": "object",
+              "description": "Platform-specific metadata of the error event.",
+              "properties": {
+                "code_type": {
+                  "type": "string",
+                  "description": "The CPU architecture of the process that crashed.",
+                  "readOnly": true
+                },
+                "parent_process": {
+                  "type": "string",
+                  "description": "Parent process information.",
+                  "readOnly": true
+                },
+                "incident_identifier": {
+                  "type": "string",
+                  "description": "A client-generated 16-byte UUID of the incident.",
+                  "readOnly": true
+                },
+                "process": {
+                  "type": "string",
+                  "description": "The name of the crashed process.",
+                  "readOnly": true
+                },
+                "exception_type": {
+                  "type": "string",
+                  "description": "The name of the corresponding BSD termination signal. (in case of iOS crash)",
+                  "readOnly": true
+                },
+                "exception_codes": {
+                  "type": "string",
+                  "description": "CPU specific information about the exception encoded into 64-bit hexadecimal number preceded by the signal code.",
+                  "readOnly": true
+                },
+                "path": {
+                  "type": "string",
+                  "description": "The location of the executable.",
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
             }
           },
           "readOnly": true

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -180,7 +180,7 @@
             },
             "threads": {
               "type": "array",
-              "description": "Description of the each thread in the process when error happened.",
+              "description": "Description of each thread in the process when error happened.",
               "items": {
                 "type": "object",
                 "description": "Description of the thread in the process when error happened.",
@@ -211,7 +211,7 @@
             },
             "binary_images": {
               "type": "array",
-              "description": "Description of the each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.",
+              "description": "Description of each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.",
               "items": {
                 "type": "object",
                 "description": "Description of the binary image (native library; for Android: .so file) loaded or referenced by the process/application.",
@@ -239,7 +239,7 @@
                   },
                   "max_address": {
                     "type": "string",
-                    "description": "Max from the library address range (hexadecimal).",
+                    "description": "Max value from the library address range (hexadecimal).",
                     "readOnly": true
                   },
                   "arch": {


### PR DESCRIPTION
This PR adds more fields to the `error` object in order to describe the data needed for the native Mobile SDKs crash reporting.

This data is **already sent by iOS SDK for a long time**, just it wasn't a part of the schema. Some of the properties (like `load_address`, `max_address`) are iOS-specific, but others will be re-used later by Android SDK for ANR reporting improvement/NDK symbolication.

The properties in `error.meta` are organized as part of the same object, but it is possible to use `oneOf` if needed (it just doesn't play well with statically-typed languages).