### PR TITLE
[RUM-2889] Add vital schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -4,7 +4,7 @@
 /**
  * Schema of all properties of a RUM event
  */
-export declare type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent;
+export declare type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent | RumVitalEvent;
 /**
  * Schema of all properties of an Action event
  */
@@ -832,6 +832,36 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
              */
             readonly max_scroll_height_time: number;
             [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
+/**
+ * Schema of all properties of a Vital event
+ */
+export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
+    /**
+     * RUM event type
+     */
+    readonly type: 'vital';
+    /**
+     * Vital properties
+     */
+    readonly vital: {
+        /**
+         * Type of the vital
+         */
+        readonly type: 'duration';
+        /**
+         * UUID of the vital
+         */
+        readonly id: string;
+        /**
+         * User custom vital. As vital name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
+         */
+        readonly custom?: {
+            [k: string]: number;
         };
         [k: string]: unknown;
     };

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -4,7 +4,7 @@
 /**
  * Schema of all properties of a RUM event
  */
-export declare type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent;
+export declare type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent | RumVitalEvent;
 /**
  * Schema of all properties of an Action event
  */
@@ -832,6 +832,36 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
              */
             readonly max_scroll_height_time: number;
             [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
+/**
+ * Schema of all properties of a Vital event
+ */
+export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
+    /**
+     * RUM event type
+     */
+    readonly type: 'vital';
+    /**
+     * Vital properties
+     */
+    readonly vital: {
+        /**
+         * Type of the vital
+         */
+        readonly type: 'duration';
+        /**
+         * UUID of the vital
+         */
+        readonly id: string;
+        /**
+         * User custom vital. As vital name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
+         */
+        readonly custom?: {
+            [k: string]: number;
         };
         [k: string]: unknown;
     };

--- a/samples/rum-events/vital.json
+++ b/samples/rum-events/vital.json
@@ -1,0 +1,27 @@
+{
+  "type": "vital",
+  "date": 1706792746576,
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599",
+    "type": "user"
+  },
+  "source": "browser",
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
+    "referrer": "",
+    "url": "https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view"
+  },
+  "vital": {
+    "id": "47af0abb-3de1-4170-a491-4473716df979",
+    "type": "duration",
+    "custom": {
+      "user-timing": 100
+    }
+  },
+  "_dd": {
+    "format_version": 2
+  }
+}

--- a/schemas/rum-events-schema.json
+++ b/schemas/rum-events-schema.json
@@ -19,6 +19,9 @@
     },
     {
       "$ref": "rum/view-schema.json"
+    },
+    {
+      "$ref": "rum/vital-schema.json"
     }
   ]
 }

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-schema.json",
+  "title": "RumVitalEvent",
+  "type": "object",
+  "description": "Schema of all properties of a Vital event",
+  "allOf": [
+    {
+      "$ref": "_common-schema.json"
+    },
+    {
+      "$ref": "_view-container-schema.json"
+    },
+    {
+      "required": ["type", "vital"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "vital",
+          "readOnly": true
+        },
+        "vital": {
+          "type": "object",
+          "description": "Vital properties",
+          "required": ["id", "type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Type of the vital",
+              "enum": ["duration"],
+              "readOnly": true
+            },
+            "id": {
+              "type": "string",
+              "description": "UUID of the vital",
+              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+              "readOnly": true
+            },
+            "custom": {
+              "type": "object",
+              "description": "User custom vital. As vital name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $",
+              "additionalProperties": {
+                "type": "number",
+                "minimum": 0,
+                "readOnly": true
+              },
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Specify new vital event schema for the custom vital feature:

```js
{
  "date": number,
  "type": "vital",
  "vital" {
    "id": string,
    "type": "duration"
    "custom": {
      "my-timing": number,
    }
  }
}
```
