### PR TITLE
Add new error source types

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -220,7 +220,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */
-        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku';
+        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku' | 'ndk' | 'ios+il2cpp' | 'ndk+il2cpp';
         /**
          * Resource properties of the error
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -220,7 +220,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */
-        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku';
+        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku' | 'ndk' | 'ios+il2cpp' | 'ndk+il2cpp';
         /**
          * Resource properties of the error
          */

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -112,7 +112,7 @@
             "source_type": {
               "type": "string",
               "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
-              "enum": ["android", "browser", "ios", "react-native", "flutter", "roku"],
+              "enum": ["android", "browser", "ios", "react-native", "flutter", "roku", "ndk", "ios+il2cpp", "ndk+il2cpp"],
               "readOnly": true
             },
             "resource": {

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -112,7 +112,17 @@
             "source_type": {
               "type": "string",
               "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
-              "enum": ["android", "browser", "ios", "react-native", "flutter", "roku", "ndk", "ios+il2cpp", "ndk+il2cpp"],
+              "enum": [
+                "android",
+                "browser",
+                "ios",
+                "react-native",
+                "flutter",
+                "roku",
+                "ndk",
+                "ios+il2cpp",
+                "ndk+il2cpp"
+              ],
               "readOnly": true
             },
             "resource": {


### PR DESCRIPTION
New source types for native crashes in the Android NDK and in Unity

`ios+il2cpp` and `ndk+il2cpp` will instruct symbolication to perform a second mass to do a second mapping pass using information from IL2CPP.