### PR TITLE
RUM-3237 Add unity version to telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -303,6 +303,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The version of Dart used in a Flutter application
              */
             dart_version?: string;
+            /**
+             * The version of Unity used in a Unity application
+             */
+            unity_version?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -303,6 +303,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The version of Dart used in a Flutter application
              */
             dart_version?: string;
+            /**
+             * The version of Unity used in a Unity application
+             */
+            unity_version?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -314,6 +314,11 @@
                   "type": "string",
                   "description": "The version of Dart used in a Flutter application",
                   "readOnly": false
+                },
+                "unity_version": {
+                  "type": "string",
+                  "description": "The version of Unity used in a Unity application",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
We want to know what version of Unity users are using with the new Unity SDK, so we'd like to add it to the telemetry.