### PR TITLE
[RUM-2885] Add disposition property to rum error

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -348,9 +348,15 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         };
         /**
-         * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
+         * Content Security Violation properties
          */
-        readonly csp_disposition?: 'enforce' | 'report';
+        readonly csp?: {
+            /**
+             * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
+             */
+            readonly disposition?: 'enforce' | 'report';
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -350,7 +350,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
          */
-        readonly disposition?: 'enforce' | 'report';
+        readonly csp_disposition?: 'enforce' | 'report';
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -348,7 +348,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         };
         /**
-         * Either 'enforce' or 'report' depending on whether the Content-Security-Policy header or the Content-Security-Policy-Report-Only header is used.
+         * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
          */
         readonly disposition?: 'enforce' | 'report';
         [k: string]: unknown;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -347,6 +347,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             readonly path?: string;
             [k: string]: unknown;
         };
+        /**
+         * Either 'enforce' or 'report' depending on whether the Content-Security-Policy header or the Content-Security-Policy-Report-Only header is used.
+         */
+        readonly disposition?: 'enforce' | 'report';
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -348,9 +348,15 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         };
         /**
-         * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
+         * Content Security Violation properties
          */
-        readonly csp_disposition?: 'enforce' | 'report';
+        readonly csp?: {
+            /**
+             * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
+             */
+            readonly disposition?: 'enforce' | 'report';
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -350,7 +350,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
          */
-        readonly disposition?: 'enforce' | 'report';
+        readonly csp_disposition?: 'enforce' | 'report';
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -348,7 +348,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             [k: string]: unknown;
         };
         /**
-         * Either 'enforce' or 'report' depending on whether the Content-Security-Policy header or the Content-Security-Policy-Report-Only header is used.
+         * In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.
          */
         readonly disposition?: 'enforce' | 'report';
         [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -347,6 +347,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             readonly path?: string;
             [k: string]: unknown;
         };
+        /**
+         * Either 'enforce' or 'report' depending on whether the Content-Security-Policy header or the Content-Security-Policy-Report-Only header is used.
+         */
+        readonly disposition?: 'enforce' | 'report';
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -308,7 +308,7 @@
               },
               "readOnly": true
             },
-            "disposition": {
+            "csp_disposition": {
               "type": "string",
               "description": "In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.",
               "enum": ["enforce", "report"],

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -310,7 +310,7 @@
             },
             "disposition": {
               "type": "string",
-              "description": "Either 'enforce' or 'report' depending on whether the Content-Security-Policy header or the Content-Security-Policy-Report-Only header is used.",
+              "description": "In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.",
               "enum": ["enforce", "report"],
               "readOnly": true
             }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -308,10 +308,17 @@
               },
               "readOnly": true
             },
-            "csp_disposition": {
-              "type": "string",
-              "description": "In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.",
-              "enum": ["enforce", "report"],
+            "csp": {
+              "type": "object",
+              "description": "Content Security Violation properties",
+              "properties": {
+                "disposition": {
+                  "type": "string",
+                  "description": "In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.",
+                  "enum": ["enforce", "report"],
+                  "readOnly": true
+                }
+              },
               "readOnly": true
             }
           },

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -307,6 +307,12 @@
                 }
               },
               "readOnly": true
+            },
+            "disposition": {
+              "type": "string",
+              "description": "Either 'enforce' or 'report' depending on whether the Content-Security-Policy header or the Content-Security-Policy-Report-Only header is used.",
+              "enum": ["enforce", "report"],
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
# Motivation

Collect `disposition` data for rum error in order to differenciate between blocking csp violation (`enforce` and report-only (`report`).

# Changes

- Add `disposition` to rum's error schema