### PR TITLE
RUM-2925 Add error properties for iOS App Hangs and Android ANRs monitoring

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -210,6 +210,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
          */
         readonly type?: string;
         /**
+         * The specific category of the error. It provides a high-level grouping for different types of errors.
+         */
+        readonly category?: 'ANR' | 'App Hang';
+        /**
          * Whether the error has been handled manually in the source code or not
          */
         readonly handling?: 'handled' | 'unhandled';
@@ -347,6 +351,16 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             readonly path?: string;
             [k: string]: unknown;
         };
+        [k: string]: unknown;
+    };
+    /**
+     * Properties of App Hang and ANR errors
+     */
+    readonly freeze?: {
+        /**
+         * Duration of the main thread freeze (in ns)
+         */
+        readonly duration: number;
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -212,7 +212,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * The specific category of the error. It provides a high-level grouping for different types of errors.
          */
-        readonly category?: 'ANR' | 'App Hang';
+        readonly category?: 'ANR' | 'App Hang' | 'Exception';
         /**
          * Whether the error has been handled manually in the source code or not
          */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -307,6 +307,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The version of Unity used in a Unity application
              */
             unity_version?: string;
+            /**
+             * The threshold used for iOS App Hangs monitoring (in milliseconds)
+             */
+            app_hang_threshold?: number;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -210,6 +210,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
          */
         readonly type?: string;
         /**
+         * The specific category of the error. It provides a high-level grouping for different types of errors.
+         */
+        readonly category?: 'ANR' | 'App Hang';
+        /**
          * Whether the error has been handled manually in the source code or not
          */
         readonly handling?: 'handled' | 'unhandled';
@@ -347,6 +351,16 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             readonly path?: string;
             [k: string]: unknown;
         };
+        [k: string]: unknown;
+    };
+    /**
+     * Properties of App Hang and ANR errors
+     */
+    readonly freeze?: {
+        /**
+         * Duration of the main thread freeze (in ns)
+         */
+        readonly duration: number;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -212,7 +212,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * The specific category of the error. It provides a high-level grouping for different types of errors.
          */
-        readonly category?: 'ANR' | 'App Hang';
+        readonly category?: 'ANR' | 'App Hang' | 'Exception';
         /**
          * Whether the error has been handled manually in the source code or not
          */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -307,6 +307,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The version of Unity used in a Unity application
              */
             unity_version?: string;
+            /**
+             * The threshold used for iOS App Hangs monitoring (in milliseconds)
+             */
+            app_hang_threshold?: number;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -101,7 +101,7 @@
             "category": {
               "type": "string",
               "description": "The specific category of the error. It provides a high-level grouping for different types of errors.",
-              "enum": ["ANR", "App Hang"],
+              "enum": ["ANR", "App Hang", "Exception"],
               "readOnly": true
             },
             "handling": {

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -98,6 +98,12 @@
               "description": "The type of the error",
               "readOnly": true
             },
+            "category": {
+              "type": "string",
+              "description": "The specific category of the error. It provides a high-level grouping for different types of errors.",
+              "enum": ["ANR", "App Hang"],
+              "readOnly": true
+            },
             "handling": {
               "type": "string",
               "description": "Whether the error has been handled manually in the source code or not",
@@ -306,6 +312,19 @@
                   "readOnly": true
                 }
               },
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        },
+        "freeze": {
+          "type": "object",
+          "description": "Properties of App Hang and ANR errors",
+          "required": ["duration"],
+          "properties": {
+            "duration": {
+              "type": "integer",
+              "description": "Duration of the main thread freeze (in ns)",
               "readOnly": true
             }
           },

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -319,6 +319,10 @@
                   "type": "string",
                   "description": "The version of Unity used in a Unity application",
                   "readOnly": false
+                },
+                "app_hang_threshold": {
+                  "type": "integer",
+                  "description": "The threshold used for iOS App Hangs monitoring (in milliseconds)"
                 }
               }
             }


### PR DESCRIPTION
### What and Why?

📦 This PR updates error and configuration schemas for iOS App Hang and Android ANR errors monitoring.

### How?

Added following properties:

**`error.category`** - This is to categorize mobile errors and offer a facet for high-level grouping with certain categories. We start with 3 categories: `App Hang` | `ANR` | `Exception`, but more will come later. For more context see [this RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3475931379/RFC+-+ANR+and+App+Hangs+in+Mobile+RUM#Implement-distinct-error-category-for-hangs%3A-error.category-facet) (internal).

**`error.freeze.duration`** - To send the duration of the main thread freeze in ANR or App Hang. More context in [this fragment of the RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3475931379/RFC+-+ANR+and+App+Hangs+in+Mobile+RUM#Track-duration-of-non-fatal-hangs) (internal).

**`telemetry.app_hang_threshold`** - To measure the usage of App Hangs monitoring in iOS.