### PR TITLE
add missing configuration telemetry properties

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -112,6 +112,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             session_replay_sample_rate?: number;
             /**
+             * The initial tracking consent value
+             */
+            tracking_consent?: string;
+            /**
              * Whether the session replay start is handled manually
              */
             start_session_replay_recording_manually?: boolean;
@@ -191,6 +195,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the Worker is loaded from an external URL
              */
             use_worker_url?: boolean;
+            /**
+             * Whether intake requests are compressed
+             */
+            compress_intake_requests?: boolean;
             /**
              * Whether user frustrations are tracked
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -112,6 +112,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             session_replay_sample_rate?: number;
             /**
+             * The initial tracking consent value
+             */
+            tracking_consent?: string;
+            /**
              * Whether the session replay start is handled manually
              */
             start_session_replay_recording_manually?: boolean;
@@ -191,6 +195,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the Worker is loaded from an external URL
              */
             use_worker_url?: boolean;
+            /**
+             * Whether intake requests are compressed
+             */
+            compress_intake_requests?: boolean;
             /**
              * Whether user frustrations are tracked
              */

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -68,6 +68,10 @@
                   "maximum": 100,
                   "readOnly": false
                 },
+                "tracking_consent": {
+                  "type": "string",
+                  "description": "The initial tracking consent value"
+                },
                 "start_session_replay_recording_manually": {
                   "type": "boolean",
                   "description": "Whether the session replay start is handled manually",
@@ -156,6 +160,10 @@
                 "use_worker_url": {
                   "type": "boolean",
                   "description": "Whether the Worker is loaded from an external URL"
+                },
+                "compress_intake_requests": {
+                  "type": "boolean",
+                  "description": "Whether intake requests are compressed"
                 },
                 "track_frustrations": {
                   "type": "boolean",


### PR DESCRIPTION
Telemetry Configuration events are missing two properties recently added in the Browser SDK:
* `compress_intake_requests`
* `tracking_consent`