### PR TITLE
✨[RUM 3351] Update resrouce schema with detailed size and renderblockingstatus

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -470,6 +470,22 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly size?: number;
         /**
+         * Size in octet of the resource before removing any applied content encodings
+         */
+        readonly encoded_body_size?: number;
+        /**
+         * Size in octet of the resource after removing any applied encoding
+         */
+        readonly decoded_body_size?: number;
+        /**
+         * Size in octet of the fetched resource
+         */
+        readonly transfer_size?: number;
+        /**
+         * Render blocking status of the resource
+         */
+        readonly render_blocking_status?: 'blocking' | 'non-blocking';
+        /**
          * Redirect phase properties
          */
         readonly redirect?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -470,6 +470,22 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly size?: number;
         /**
+         * Size in octet of the resource before removing any applied content encodings
+         */
+        readonly encoded_body_size?: number;
+        /**
+         * Size in octet of the resource after removing any applied encoding
+         */
+        readonly decoded_body_size?: number;
+        /**
+         * Size in octet of the fetched resource
+         */
+        readonly transfer_size?: number;
+        /**
+         * Render blocking status of the resource
+         */
+        readonly render_blocking_status?: 'blocking' | 'non-blocking';
+        /**
          * Redirect phase properties
          */
         readonly redirect?: {

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -22,6 +22,10 @@
     "status_code": 200,
     "duration": 246580000,
     "size": 3599,
+    "encoded_body_size": 1599,
+    "decoded_body_size": 3599,
+    "transfer_size": 3699,
+    "render_blocking_status": "non-blocking",
     "download": {
       "duration": 545000,
       "start": 246035000

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -69,6 +69,30 @@
               "minimum": 0,
               "readOnly": true
             },
+            "encodedBodySize": {
+              "type": "integer",
+              "description": "Size in octet of the resource before removing any applied content encodings",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "decodedBodySize": {
+              "type": "integer",
+              "description": "Size in octet of the resource after removing any applied encoding",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "transferSize": {
+              "type": "integer",
+              "description": "Size in octet of the fetched resource",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "renderBlockingStatus": {
+              "type": "string",
+              "description": "Render blocking status of the resource",
+              "enum": ["blocking", "non-blocking"],
+              "readOnly": true
+            },
             "redirect": {
               "type": "object",
               "description": "Redirect phase properties",

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -69,25 +69,25 @@
               "minimum": 0,
               "readOnly": true
             },
-            "encodedBodySize": {
+            "encoded_body_size": {
               "type": "integer",
               "description": "Size in octet of the resource before removing any applied content encodings",
               "minimum": 0,
               "readOnly": true
             },
-            "decodedBodySize": {
+            "decoded_body_size": {
               "type": "integer",
               "description": "Size in octet of the resource after removing any applied encoding",
               "minimum": 0,
               "readOnly": true
             },
-            "transferSize": {
+            "transfer_size": {
               "type": "integer",
               "description": "Size in octet of the fetched resource",
               "minimum": 0,
               "readOnly": true
             },
-            "renderBlockingStatus": {
+            "render_blocking_status": {
               "type": "string",
               "description": "Render blocking status of the resource",
               "enum": ["blocking", "non-blocking"],


### PR DESCRIPTION
Added the following attributes to our data collection for resources to help for performance investigations:

[renderBlockingStatus](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus)

[transferSize](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize)

[encodedBodySize](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/encodedBodySize)

[decodedBodySize](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/decodedBodySize)