### PR TITLE
✨ [RUM-3542] Add trace context injection control in rum configuration

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -102,7 +102,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * The opt-in configuration to add trace context
              */
-            trace_context_injection?: number;
+            trace_context_injection?: string;
             /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -102,7 +102,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * The opt-in configuration to add trace context
              */
-            trace_context_injection?: string;
+            trace_context_injection?: 'all' | 'sampled';
             /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -100,6 +100,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             trace_sample_rate?: number;
             /**
+             * The opt-in configuration to add trace context
+             */
+            trace_context_injection?: number;
+            /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
              */
             premium_sample_rate?: number;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -102,7 +102,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * The opt-in configuration to add trace context
              */
-            trace_context_injection?: number;
+            trace_context_injection?: string;
             /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -102,7 +102,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * The opt-in configuration to add trace context
              */
-            trace_context_injection?: string;
+            trace_context_injection?: 'all' | 'sampled';
             /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -100,6 +100,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             trace_sample_rate?: number;
             /**
+             * The opt-in configuration to add trace context
+             */
+            trace_context_injection?: number;
+            /**
              * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
              */
             premium_sample_rate?: number;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -27,6 +27,7 @@
       "telemetry_sample_rate": 100,
       "telemetry_configuration_sample_rate": 5,
       "trace_sample_rate": 100,
+      "trace_context_injection": 1,
       "session_replay_sample_rate": 100,
       "start_session_replay_recording_manually": true,
       "premium_sample_rate": 100,

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -27,7 +27,7 @@
       "telemetry_sample_rate": 100,
       "telemetry_configuration_sample_rate": 5,
       "trace_sample_rate": 100,
-      "trace_context_injection": 1,
+      "trace_context_injection": "all",
       "session_replay_sample_rate": 100,
       "start_session_replay_recording_manually": true,
       "premium_sample_rate": 100,

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -50,10 +50,9 @@
                   "maximum": 100
                 },
                 "trace_context_injection": {
-                  "type": "integer",
+                  "type": "string",
                   "description": "The opt-in configuration to add trace context",
-                  "minimum": 0,
-                  "maximum": 1
+                  "readOnly": false
                 },
                 "premium_sample_rate": {
                   "type": "integer",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -52,6 +52,7 @@
                 "trace_context_injection": {
                   "type": "string",
                   "description": "The opt-in configuration to add trace context",
+                  "enum": ["all", "sampled"],
                   "readOnly": false
                 },
                 "premium_sample_rate": {

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -49,6 +49,12 @@
                   "minimum": 0,
                   "maximum": 100
                 },
+                "trace_context_injection": {
+                  "type": "integer",
+                  "description": "The opt-in configuration to add trace context",
+                  "minimum": 0,
+                  "maximum": 1
+                },
                 "premium_sample_rate": {
                   "type": "integer",
                   "description": "The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)",


### PR DESCRIPTION
## Motivation
APM is working on building more granular sampling control on the backend side which can't be applied if the sampling decision is already taken on the client side.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Added the configuration to control context injection.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Related PR

https://github.com/DataDog/browser-sdk/pull/2656