### PR TITLE
RUM-3772: Add error property specifying time since application start

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -361,6 +361,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             readonly disposition?: 'enforce' | 'report';
             [k: string]: unknown;
         };
+        /**
+         * Time since application start when error happened (in milliseconds)
+         */
+        readonly time_since_app_start?: number;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -361,6 +361,10 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
             readonly disposition?: 'enforce' | 'report';
             [k: string]: unknown;
         };
+        /**
+         * Time since application start when error happened (in milliseconds)
+         */
+        readonly time_since_app_start?: number;
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -326,6 +326,11 @@
                 }
               },
               "readOnly": true
+            },
+            "time_since_app_start": {
+              "type": "integer",
+              "description": "Time since application start when error happened (in milliseconds)",
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
This PR adds `error.time_since_app_start` property (in milliseconds) which specifies time since application start.

It is necessary to track crashes which may happen during the application startup time (exact timeframe could be specified by the user).