### PR TITLE
✨[RUM-4029] bootstrap telemetry usage schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -118,7 +118,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * The initial tracking consent value
              */
-            tracking_consent?: string;
+            tracking_consent?: 'granted' | 'not-granted' | 'pending';
             /**
              * Whether the session replay start is handled manually
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -4,7 +4,7 @@
 /**
  * Schema of all properties of a telemetry event
  */
-export declare type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent;
+export declare type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent | TelemetryUsageEvent;
 /**
  * Schema of all properties of a telemetry error event
  */
@@ -335,6 +335,53 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
         };
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+};
+/**
+ * Schema of all properties of a telemetry usage event
+ */
+export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
+    /**
+     * The telemetry usage information
+     */
+    telemetry: {
+        /**
+         * Telemetry type
+         */
+        type: 'usage';
+        usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
+/**
+ * Schema of features usage common across SDKs
+ */
+export declare type TelemetryCommonFeaturesUsage = {
+    /**
+     * setTrackingConsent API
+     */
+    feature: 'set-tracking-consent';
+    /**
+     * The tracking consent value set by the user
+     */
+    tracking_consent: 'granted' | 'not-granted' | 'pending';
+    [k: string]: unknown;
+} | {
+    /**
+     * stopSession API
+     */
+    feature: 'stop-session';
+    [k: string]: unknown;
+};
+/**
+ * Schema of browser specific features usage
+ */
+export declare type TelemetryBrowserFeaturesUsage = {
+    /**
+     * startSessionReplayRecording API
+     */
+    feature: 'start-session-replay-recording';
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -118,7 +118,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * The initial tracking consent value
              */
-            tracking_consent?: string;
+            tracking_consent?: 'granted' | 'not-granted' | 'pending';
             /**
              * Whether the session replay start is handled manually
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -4,7 +4,7 @@
 /**
  * Schema of all properties of a telemetry event
  */
-export declare type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent;
+export declare type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent | TelemetryUsageEvent;
 /**
  * Schema of all properties of a telemetry error event
  */
@@ -335,6 +335,53 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
         };
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+};
+/**
+ * Schema of all properties of a telemetry usage event
+ */
+export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
+    /**
+     * The telemetry usage information
+     */
+    telemetry: {
+        /**
+         * Telemetry type
+         */
+        type: 'usage';
+        usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
+/**
+ * Schema of features usage common across SDKs
+ */
+export declare type TelemetryCommonFeaturesUsage = {
+    /**
+     * setTrackingConsent API
+     */
+    feature: 'set-tracking-consent';
+    /**
+     * The tracking consent value set by the user
+     */
+    tracking_consent: 'granted' | 'not-granted' | 'pending';
+    [k: string]: unknown;
+} | {
+    /**
+     * stopSession API
+     */
+    feature: 'stop-session';
+    [k: string]: unknown;
+};
+/**
+ * Schema of browser specific features usage
+ */
+export declare type TelemetryBrowserFeaturesUsage = {
+    /**
+     * startSessionReplayRecording API
+     */
+    feature: 'start-session-replay-recording';
     [k: string]: unknown;
 };
 /**

--- a/samples/telemetry-events/usage.json
+++ b/samples/telemetry-events/usage.json
@@ -1,0 +1,30 @@
+{
+  "_dd": {
+    "format_version": 2
+  },
+  "type": "telemetry",
+  "date": 1591284175342,
+  "service": "sample-sdk",
+  "source": "browser",
+  "version": "1.2.3",
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599"
+  },
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6"
+  },
+  "action": {
+    "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+  },
+  "experimental_features": ["foo"],
+  "telemetry": {
+    "type": "usage",
+    "usage": {
+      "feature": "set-tracking-consent",
+      "tracking_consent": "granted"
+    }
+  }
+}

--- a/schemas/telemetry-events-schema.json
+++ b/schemas/telemetry-events-schema.json
@@ -13,6 +13,9 @@
     },
     {
       "$ref": "telemetry/configuration-schema.json"
+    },
+    {
+      "$ref": "telemetry/usage-schema.json"
     }
   ]
 }

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -76,7 +76,8 @@
                 },
                 "tracking_consent": {
                   "type": "string",
-                  "description": "The initial tracking consent value"
+                  "description": "The initial tracking consent value",
+                  "enum": ["granted", "not-granted", "pending"]
                 },
                 "start_session_replay_recording_manually": {
                   "type": "boolean",

--- a/schemas/telemetry/usage-schema.json
+++ b/schemas/telemetry/usage-schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "telemetry/usage-schema.json",
+  "title": "TelemetryUsageEvent",
+  "type": "object",
+  "description": "Schema of all properties of a telemetry usage event",
+  "allOf": [
+    {
+      "$ref": "_common-schema.json"
+    },
+    {
+      "required": ["telemetry"],
+      "properties": {
+        "telemetry": {
+          "type": "object",
+          "description": "The telemetry usage information",
+          "required": ["type", "usage"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Telemetry type",
+              "const": "usage"
+            },
+            "usage": {
+              "oneOf": [
+                {
+                  "$ref": "usage/common-features-schema.json"
+                },
+                {
+                  "$ref": "usage/browser-features-schema.json"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "telemetry/usage/browser-features-schema.json",
+  "title": "TelemetryBrowserFeaturesUsage",
+  "type": "object",
+  "description": "Schema of browser specific features usage",
+  "oneOf": [
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "startSessionReplayRecording API",
+          "const": "start-session-replay-recording"
+        }
+      }
+    }
+  ]
+}

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "telemetry/usage/common-features-schema.json",
+  "title": "TelemetryCommonFeaturesUsage",
+  "type": "object",
+  "description": "Schema of features usage common across SDKs",
+  "oneOf": [
+    {
+      "required": ["feature", "tracking_consent"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setTrackingConsent API",
+          "const": "set-tracking-consent"
+        },
+        "tracking_consent": {
+          "type": "string",
+          "description": "The tracking consent value set by the user",
+          "enum": ["granted", "not-granted", "pending"]
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "stopSession API",
+          "const": "stop-session"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Motivation

Document schema of new telemetry event used to monitor SDKs feature usage.

# Changes

New schemas added:

- telemetry usage event
- feature usages split into common features and browser specific features 
 

**notes:** 
- mobile file could be added as soon as we will want to describe some mobile specific features
- only a couple of features described to bootstrap the schemas, more features to come