### PR TITLE
✨ [RUM-3902] Add configuration for action name privacy control

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -192,6 +192,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             default_privacy_level?: string;
             /**
+             * Privacy control for action name
+             */
+            enabled_privacy_for_action_name?: boolean;
+            /**
              * Whether the request origins list to ignore when computing the page activity is used
              */
             use_excluded_activity_urls?: boolean;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -194,7 +194,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Privacy control for action name
              */
-            enabled_privacy_for_action_name?: boolean;
+            enable_privacy_for_action_name?: boolean;
             /**
              * Whether the request origins list to ignore when computing the page activity is used
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -192,6 +192,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             default_privacy_level?: string;
             /**
+             * Privacy control for action name
+             */
+            enabled_privacy_for_action_name?: boolean;
+            /**
              * Whether the request origins list to ignore when computing the page activity is used
              */
             use_excluded_activity_urls?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -194,7 +194,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Privacy control for action name
              */
-            enabled_privacy_for_action_name?: boolean;
+            enable_privacy_for_action_name?: boolean;
             /**
              * Whether the request origins list to ignore when computing the page activity is used
              */

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -44,7 +44,7 @@
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",
-      "enabled_privacy_for_action_name": false,
+      "enable_privacy_for_action_name": false,
       "use_excluded_activity_urls": false,
       "track_frustrations": true,
       "track_views_manually": true,

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -44,6 +44,7 @@
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",
+      "enabled_privacy_for_action_name": false,
       "use_excluded_activity_urls": false,
       "track_frustrations": true,
       "track_views_manually": true,

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -159,6 +159,11 @@
                   "description": "Session replay default privacy level",
                   "readOnly": false
                 },
+                "enabled_privacy_for_action_name": {
+                  "type": "boolean",
+                  "description": "Privacy control for action name",
+                  "readOnly": false
+                },
                 "use_excluded_activity_urls": {
                   "type": "boolean",
                   "description": "Whether the request origins list to ignore when computing the page activity is used"

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -159,7 +159,7 @@
                   "description": "Session replay default privacy level",
                   "readOnly": false
                 },
-                "enabled_privacy_for_action_name": {
+                "enable_privacy_for_action_name": {
                   "type": "boolean",
                   "description": "Privacy control for action name",
                   "readOnly": false


### PR DESCRIPTION
## Context
[RUM-3902 Add privacy control for action names ](https://github.com/DataDog/browser-sdk/pull/2707)

## Change
Add `enable_privacy_for_action_name` in the configuration schema.