### PR TITLE
RUM-1844: Add device and os info to telemetry events

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -474,5 +474,44 @@ export interface CommonTelemetryProperties {
      * Enabled experimental features
      */
     readonly experimental_features?: string[];
+    telemetry?: {
+        /**
+         * Device properties
+         */
+        device?: {
+            /**
+             * Architecture of the device
+             */
+            architecture?: string;
+            /**
+             * Brand of the device
+             */
+            brand?: string;
+            /**
+             * Model of the device
+             */
+            model?: string;
+            [k: string]: unknown;
+        };
+        /**
+         * OS properties
+         */
+        os?: {
+            /**
+             * Build of the OS
+             */
+            build?: string;
+            /**
+             * Name of the OS
+             */
+            name?: string;
+            /**
+             * Version of the OS
+             */
+            version?: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 }

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -474,5 +474,44 @@ export interface CommonTelemetryProperties {
      * Enabled experimental features
      */
     readonly experimental_features?: string[];
+    telemetry?: {
+        /**
+         * Device properties
+         */
+        device?: {
+            /**
+             * Architecture of the device
+             */
+            architecture?: string;
+            /**
+             * Brand of the device
+             */
+            brand?: string;
+            /**
+             * Model of the device
+             */
+            model?: string;
+            [k: string]: unknown;
+        };
+        /**
+         * OS properties
+         */
+        os?: {
+            /**
+             * Build of the OS
+             */
+            build?: string;
+            /**
+             * Name of the OS
+             */
+            name?: string;
+            /**
+             * Version of the OS
+             */
+            version?: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 }

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -100,6 +100,48 @@
         "type": "string"
       },
       "readOnly": true
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "device": {
+          "type": "object",
+          "description": "Device properties",
+          "properties": {
+            "architecture": {
+              "type": "string",
+              "description": "Architecture of the device"
+            },
+            "brand": {
+              "type": "string",
+              "description": "Brand of the device"
+            },
+            "model": {
+              "type": "string",
+              "description": "Model of the device"
+            }
+          }
+        },
+        "os": {
+          "type": "object",
+          "description": "OS properties",
+          "properties": {
+            "build": {
+              "type": "string",
+              "description": "Build of the OS"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the OS"
+            },
+            "version": {
+              "type": "string",
+              "description": "Version of the OS"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds device and OS information to telemetry events. While we have some device and os information inside http_agent, we require this set of properties for performance metrics