### PR TITLE
✨[RUM-4179] vital: add `computed_value` property

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1003,6 +1003,22 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Internal vital properties
+         */
+        readonly vital?: {
+            /**
+             * Whether the value of the vital is computed by the SDK (as opposed to directly provided by the customer)
+             */
+            readonly computed_value?: boolean;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1003,6 +1003,22 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Internal vital properties
+         */
+        readonly vital?: {
+            /**
+             * Whether the value of the vital is computed by the SDK (as opposed to directly provided by the customer)
+             */
+            readonly computed_value?: boolean;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**

--- a/samples/rum-events/vital.json
+++ b/samples/rum-events/vital.json
@@ -23,6 +23,9 @@
     }
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "vital": {
+      "computed_value": true
+    }
   }
 }

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -54,6 +54,25 @@
             }
           },
           "readOnly": true
+        },
+        "_dd": {
+          "type": "object",
+          "description": "Internal properties",
+          "properties": {
+            "vital": {
+              "type": "object",
+              "description": "Internal vital properties",
+              "properties": {
+                "computed_value": {
+                  "type": "boolean",
+                  "description": "Whether the value of the vital is computed by the SDK (as opposed to directly provided by the customer)",
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            }
+          },
+          "readOnly": true
         }
       }
     }


### PR DESCRIPTION
Add `_dd.vital.computed_value` to vital schema to indicate that a vital value has been computed by the SDK.

Allow to make assomption on the unit of the vital on the backend or app side to have a more specific display.