### PR TITLE
[RUM] Add force session replay option to telemetry usage features

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -395,7 +395,7 @@ export declare type TelemetryBrowserFeaturesUsage = {
      */
     feature: 'start-session-replay-recording';
     /**
-     * Whether the API was forced to record sampled out sessions
+     * Whether the recording is allowed to start even on sessions sampled out of replay
      */
     is_forced: boolean;
     [k: string]: unknown;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -394,6 +394,10 @@ export declare type TelemetryBrowserFeaturesUsage = {
      * startSessionReplayRecording API
      */
     feature: 'start-session-replay-recording';
+    /**
+     * Whether the recording was started normally or forced
+     */
+    start_type: 'normal' | 'forced';
     [k: string]: unknown;
 };
 /**

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -395,9 +395,9 @@ export declare type TelemetryBrowserFeaturesUsage = {
      */
     feature: 'start-session-replay-recording';
     /**
-     * Whether the recording was started normally or forced
+     * Whether the API was forced to record sampled out sessions
      */
-    start_type: 'normal' | 'forced';
+    is_forced: boolean;
     [k: string]: unknown;
 };
 /**

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -397,7 +397,7 @@ export declare type TelemetryBrowserFeaturesUsage = {
     /**
      * Whether the recording is allowed to start even on sessions sampled out of replay
      */
-    is_forced: boolean;
+    is_forced?: boolean;
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -395,7 +395,7 @@ export declare type TelemetryBrowserFeaturesUsage = {
      */
     feature: 'start-session-replay-recording';
     /**
-     * Whether the API was forced to record sampled out sessions
+     * Whether the recording is allowed to start even on sessions sampled out of replay
      */
     is_forced: boolean;
     [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -394,6 +394,10 @@ export declare type TelemetryBrowserFeaturesUsage = {
      * startSessionReplayRecording API
      */
     feature: 'start-session-replay-recording';
+    /**
+     * Whether the recording was started normally or forced
+     */
+    start_type: 'normal' | 'forced';
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -395,9 +395,9 @@ export declare type TelemetryBrowserFeaturesUsage = {
      */
     feature: 'start-session-replay-recording';
     /**
-     * Whether the recording was started normally or forced
+     * Whether the API was forced to record sampled out sessions
      */
-    start_type: 'normal' | 'forced';
+    is_forced: boolean;
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -397,7 +397,7 @@ export declare type TelemetryBrowserFeaturesUsage = {
     /**
      * Whether the recording is allowed to start even on sessions sampled out of replay
      */
-    is_forced: boolean;
+    is_forced?: boolean;
     [k: string]: unknown;
 };
 /**

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -6,7 +6,7 @@
   "description": "Schema of browser specific features usage",
   "oneOf": [
     {
-      "required": ["feature", "is_forced"],
+      "required": ["feature"],
       "properties": {
         "feature": {
           "type": "string",

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -6,12 +6,17 @@
   "description": "Schema of browser specific features usage",
   "oneOf": [
     {
-      "required": ["feature"],
+      "required": ["feature", "start_type"],
       "properties": {
         "feature": {
           "type": "string",
           "description": "startSessionReplayRecording API",
           "const": "start-session-replay-recording"
+        },
+        "start_type": {
+          "type": "string",
+          "description": "Whether the recording was started normally or forced",
+          "enum": ["normal", "forced"]
         }
       }
     }

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -6,17 +6,16 @@
   "description": "Schema of browser specific features usage",
   "oneOf": [
     {
-      "required": ["feature", "start_type"],
+      "required": ["feature", "is_forced"],
       "properties": {
         "feature": {
           "type": "string",
           "description": "startSessionReplayRecording API",
           "const": "start-session-replay-recording"
         },
-        "start_type": {
-          "type": "string",
-          "description": "Whether the recording was started normally or forced",
-          "enum": ["normal", "forced"]
+        "is_forced": {
+          "type": "boolean",
+          "description": "Whether the API was forced to record sampled out sessions"
         }
       }
     }

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -15,7 +15,7 @@
         },
         "is_forced": {
           "type": "boolean",
-          "description": "Whether the API was forced to record sampled out sessions"
+          "description": "Whether the recording is allowed to start even on sessions sampled out of replay"
         }
       }
     }


### PR DESCRIPTION
## Motivation
Since we are adding a new way to force the recording of sampled out sessions, it would be useful to keep track of the usage of this API.

## Changes
Adding a new `force-session-replay-recording` option to report when the recorder is forced to start on a sampled out session.