### PR TITLE
Monitor more feature usages

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -385,6 +385,42 @@ export declare type TelemetryCommonFeaturesUsage = {
      */
     feature: 'stop-session';
     [k: string]: unknown;
+} | {
+    /**
+     * startView API
+     */
+    feature: 'start-view';
+    [k: string]: unknown;
+} | {
+    /**
+     * addAction API
+     */
+    feature: 'add-action';
+    [k: string]: unknown;
+} | {
+    /**
+     * addError API
+     */
+    feature: 'add-error';
+    [k: string]: unknown;
+} | {
+    /**
+     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+     */
+    feature: 'set-global-context';
+    [k: string]: unknown;
+} | {
+    /**
+     * setUser, setUserProperty, setUserInfo APIs
+     */
+    feature: 'set-user';
+    [k: string]: unknown;
+} | {
+    /**
+     * addFeatureFlagEvaluation API
+     */
+    feature: 'add-feature-flag-evaluation';
+    [k: string]: unknown;
 };
 /**
  * Schema of browser specific features usage

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -385,6 +385,42 @@ export declare type TelemetryCommonFeaturesUsage = {
      */
     feature: 'stop-session';
     [k: string]: unknown;
+} | {
+    /**
+     * startView API
+     */
+    feature: 'start-view';
+    [k: string]: unknown;
+} | {
+    /**
+     * addAction API
+     */
+    feature: 'add-action';
+    [k: string]: unknown;
+} | {
+    /**
+     * addError API
+     */
+    feature: 'add-error';
+    [k: string]: unknown;
+} | {
+    /**
+     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+     */
+    feature: 'set-global-context';
+    [k: string]: unknown;
+} | {
+    /**
+     * setUser, setUserProperty, setUserInfo APIs
+     */
+    feature: 'set-user';
+    [k: string]: unknown;
+} | {
+    /**
+     * addFeatureFlagEvaluation API
+     */
+    feature: 'add-feature-flag-evaluation';
+    [k: string]: unknown;
 };
 /**
  * Schema of browser specific features usage

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -29,6 +29,66 @@
           "const": "stop-session"
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "startView API",
+          "const": "start-view"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "addAction API",
+          "const": "add-action"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "addError API",
+          "const": "add-error"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setGlobalContext, setGlobalContextProperty, addAttribute APIs",
+          "const": "set-global-context"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setUser, setUserProperty, setUserInfo APIs",
+          "const": "set-user"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "addFeatureFlagEvaluation API",
+          "const": "add-feature-flag-evaluation"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Following https://github.com/DataDog/rum-events-format/pull/197, add more features to monitor:

- startView
- addAction
- addError
- setGlobalContext
- setUser
- addFeatureFlagEvaluation