### PR TITLE
RUM-4367: Allow additional properties for Telemetry Error events

### DIFF
--- a/samples/telemetry-events/error.json
+++ b/samples/telemetry-events/error.json
@@ -26,6 +26,7 @@
     "error": {
       "stack": "Failed to load",
       "kind": "TypeError"
-    }
+    },
+    "custom": "property"
   }
 }

--- a/schemas/telemetry/error-schema.json
+++ b/schemas/telemetry/error-schema.json
@@ -15,6 +15,7 @@
           "type": "object",
           "description": "The telemetry log information",
           "required": ["status", "message"],
+          "additionalProperties": true,
           "properties": {
             "type": {
               "type": "string",


### PR DESCRIPTION
Similar to the change made in https://github.com/DataDog/rum-events-format/pull/154, we need to allow additional properties in Telemetry Error events. They are handy for attaching custom attributes.