### PR TITLE
✨ Add sendLogsAfterSessionExpiration configuration

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -343,6 +343,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The version of the tracer API used by the SDK. Eg. '0.1.0'
              */
             tracer_api_version?: string;
+            /**
+             * Whether logs are sent after the session expiration
+             */
+            send_logs_after_session_expiration?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -343,6 +343,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The version of the tracer API used by the SDK. Eg. '0.1.0'
              */
             tracer_api_version?: string;
+            /**
+             * Whether logs are sent after the session expiration
+             */
+            send_logs_after_session_expiration?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -364,6 +364,11 @@
                   "type": "string",
                   "description": "The version of the tracer API used by the SDK. Eg. '0.1.0'",
                   "readOnly": false
+                },
+                "send_logs_after_session_expiration": {
+                  "type": "boolean",
+                  "description": "Whether logs are sent after the session expiration",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
## Motivation
Tracking usage of `send_logs_after_session_expiration` allowing to send logs on expired tracked sessions.

## Changes
Adding `send-logs-after-session-expiration` option.