### PR TITLE
🔧 use node 20 to run SDK tests

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Yarn 4 doesn't support Node 16 anymore: https://github.com/DataDog/rum-events-format/actions/runs/9092245487/job/24988545919#step:4:13