### PR TITLE
✨ [RUM-3965] make service and version fields modifiable

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1042,11 +1042,11 @@ export interface CommonProperties {
     /**
      * The service name for this application
      */
-    readonly service?: string;
+    service?: string;
     /**
      * The version for this application
      */
-    readonly version?: string;
+    version?: string;
     /**
      * The build version for this application
      */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1042,11 +1042,11 @@ export interface CommonProperties {
     /**
      * The service name for this application
      */
-    readonly service?: string;
+    service?: string;
     /**
      * The version for this application
      */
-    readonly version?: string;
+    version?: string;
     /**
      * The build version for this application
      */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -28,13 +28,11 @@
     },
     "service": {
       "type": "string",
-      "description": "The service name for this application",
-      "readOnly": true
+      "description": "The service name for this application"
     },
     "version": {
       "type": "string",
-      "description": "The version for this application",
-      "readOnly": true
+      "description": "The version for this application"
     },
     "build_version": {
       "type": "string",


### PR DESCRIPTION
As part of the microfrontend support initiative we want to allow customer to modify the `service` and `version` fields in `beforeSend`.

This PR remove the `readonly` modifier for those fields.