### PR TITLE
🏷️ [RUM-4469] add plugins to the configuration telemetry schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -347,6 +347,16 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether logs are sent after the session expiration
              */
             send_logs_after_session_expiration?: boolean;
+            /**
+             * The list of plugins enabled
+             */
+            plugins?: {
+                /**
+                 * The name of the plugin
+                 */
+                name: string;
+                [k: string]: unknown;
+            }[];
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -347,6 +347,16 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether logs are sent after the session expiration
              */
             send_logs_after_session_expiration?: boolean;
+            /**
+             * The list of plugins enabled
+             */
+            plugins?: {
+                /**
+                 * The name of the plugin
+                 */
+                name: string;
+                [k: string]: unknown;
+            }[];
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -56,7 +56,13 @@
       "view_tracking_strategy": "ActivityViewTrackingStrategy",
       "track_background_events": true,
       "mobile_vitals_update_period": 10,
-      "track_native_crashes": true
+      "track_native_crashes": true,
+      "plugins": [
+        {
+          "name": "foo",
+          "option_foo": "bar"
+        }
+      ]
     }
   }
 }

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -369,6 +369,21 @@
                   "type": "boolean",
                   "description": "Whether logs are sent after the session expiration",
                   "readOnly": false
+                },
+                "plugins": {
+                  "type": "array",
+                  "description": "The list of plugins enabled",
+                  "items": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The name of the plugin"
+                      }
+                    },
+                    "additionalProperties": true
+                  }
                 }
               }
             }


### PR DESCRIPTION
In the Browser SDK we want to experiment with a plugin concept. Add it to the configuration telemetry so we can be aware of plugins adoption.