### PR TITLE
RUM-5073: Add Kotlin Multiplatform source to the RUM events schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1092,7 +1092,7 @@ export interface CommonProperties {
     /**
      * The source of this event
      */
-    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity';
+    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform';
     /**
      * View properties
      */
@@ -1332,7 +1332,7 @@ export interface ViewContainerSchema {
         /**
          * Source of the parent view
          */
-        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity';
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -491,7 +491,7 @@ export interface CommonTelemetryProperties {
     /**
      * The source of this event
      */
-    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity';
+    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform';
     /**
      * The version of the SDK generating the telemetry event
      */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1092,7 +1092,7 @@ export interface CommonProperties {
     /**
      * The source of this event
      */
-    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity';
+    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform';
     /**
      * View properties
      */
@@ -1332,7 +1332,7 @@ export interface ViewContainerSchema {
         /**
          * Source of the parent view
          */
-        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity';
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -491,7 +491,7 @@ export interface CommonTelemetryProperties {
     /**
      * The source of this event
      */
-    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity';
+    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform';
     /**
      * The version of the SDK generating the telemetry event
      */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -72,7 +72,7 @@
     "source": {
       "type": "string",
       "description": "The source of this event",
-      "enum": ["android", "ios", "browser", "flutter", "react-native", "roku", "unity"],
+      "enum": ["android", "ios", "browser", "flutter", "react-native", "roku", "unity", "kotlin-multiplatform"],
       "readOnly": true
     },
     "view": {

--- a/schemas/rum/_view-container-schema.json
+++ b/schemas/rum/_view-container-schema.json
@@ -27,7 +27,7 @@
         "source": {
           "type": "string",
           "description": "Source of the parent view",
-          "enum": ["android", "ios", "browser", "flutter", "react-native", "roku", "unity"],
+          "enum": ["android", "ios", "browser", "flutter", "react-native", "roku", "unity", "kotlin-multiplatform"],
           "readOnly": true
         }
       },

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -37,7 +37,7 @@
     "source": {
       "type": "string",
       "description": "The source of this event",
-      "enum": ["android", "ios", "browser", "flutter", "react-native", "unity"],
+      "enum": ["android", "ios", "browser", "flutter", "react-native", "unity", "kotlin-multiplatform"],
       "readOnly": true
     },
     "version": {


### PR DESCRIPTION
This PR adds Kotlin Multiplatform as a possible source for RUM events.