### PR TITLE
[RUM-5598] [Session Replay] Add start_recording_immediately field to Configuration Telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -128,6 +128,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             start_session_replay_recording_manually?: boolean;
             /**
+             * Whether Session Replay should automatically start a recording when enabled
+             */
+            start_recording_immediately?: boolean;
+            /**
              * Whether a proxy is used
              */
             use_proxy?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -128,6 +128,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             start_session_replay_recording_manually?: boolean;
             /**
+             * Whether Session Replay should automatically start a recording when enabled
+             */
+            start_recording_immediately?: boolean;
+            /**
              * Whether a proxy is used
              */
             use_proxy?: boolean;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -30,6 +30,7 @@
       "trace_context_injection": "all",
       "session_replay_sample_rate": 100,
       "start_session_replay_recording_manually": true,
+      "start_recording_immediately": true,
       "premium_sample_rate": 100,
       "replay_sample_rate": 100,
       "use_proxy": true,

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -90,6 +90,11 @@
                   "description": "Whether the session replay start is handled manually",
                   "readOnly": false
                 },
+                "start_recording_immediately": {
+                  "type": "boolean",
+                  "description": "Whether Session Replay should automatically start a recording when enabled",
+                  "readOnly": false
+                },
                 "use_proxy": {
                   "type": "boolean",
                   "description": "Whether a proxy is used",


### PR DESCRIPTION
Updating the telemetry configuration schema with the new `startRecordingImmediately` parameter, which allows to automatically start a recording when enabling Session Replay on mobile SDKs.

[RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3897426405/RFC+-+Session+Replay+Start+Stop+API)