### PR TITLE
RUM-5841 feat: setup addViewLoadingTime usage telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -399,113 +399,15 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = {
-    /**
-     * setTrackingConsent API
-     */
-    feature: 'set-tracking-consent';
-    /**
-     * The tracking consent value set by the user
-     */
-    tracking_consent: 'granted' | 'not-granted' | 'pending';
-    [k: string]: unknown;
-} | {
-    /**
-     * stopSession API
-     */
-    feature: 'stop-session';
-    [k: string]: unknown;
-} | {
-    /**
-     * startView API
-     */
-    feature: 'start-view';
-    [k: string]: unknown;
-} | {
-    /**
-     * addAction API
-     */
-    feature: 'add-action';
-    [k: string]: unknown;
-} | {
-    /**
-     * addError API
-     */
-    feature: 'add-error';
-    [k: string]: unknown;
-} | {
-    /**
-     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
-     */
-    feature: 'set-global-context';
-    [k: string]: unknown;
-} | {
-    /**
-     * setUser, setUserProperty, setUserInfo APIs
-     */
-    feature: 'set-user';
-    [k: string]: unknown;
-} | {
-    /**
-     * addFeatureFlagEvaluation API
-     */
-    feature: 'add-feature-flag-evaluation';
-    [k: string]: unknown;
-};
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | AddAction | AddError | SetGlobalContext | SetUser | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
-export declare type TelemetryBrowserFeaturesUsage = {
-    /**
-     * startSessionReplayRecording API
-     */
-    feature: 'start-session-replay-recording';
-    /**
-     * Whether the recording is allowed to start even on sessions sampled out of replay
-     */
-    is_forced?: boolean;
-    [k: string]: unknown;
-} | {
-    /**
-     * startDurationVital API
-     */
-    feature: 'start-duration-vital';
-    [k: string]: unknown;
-} | {
-    /**
-     * stopDurationVital API
-     */
-    feature: 'stop-duration-vital';
-    [k: string]: unknown;
-} | {
-    /**
-     * addDurationVital API
-     */
-    feature: 'add-duration-vital';
-    [k: string]: unknown;
-};
+export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
 /**
  * Schema of mobile specific features usage
  */
-export declare type TelemetryMobileFeaturesUsage = {
-    /**
-     * addViewLoadingTime API
-     */
-    feature: 'addViewLoadingTime';
-    /**
-     * Whether the view is not available
-     */
-    no_view: boolean;
-    /**
-     * Whether the available view is not active
-     */
-    no_active_view: boolean;
-    /**
-     * Whether the loading time was overwritten
-     */
-    overwritten: boolean;
-    [k: string]: unknown;
-};
+export declare type TelemetryMobileFeaturesUsage = AddViewLoadingTime;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -623,5 +525,116 @@ export interface CommonTelemetryProperties {
         };
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+export interface SetTrackingConsent {
+    /**
+     * setTrackingConsent API
+     */
+    feature: 'set-tracking-consent';
+    /**
+     * The tracking consent value set by the user
+     */
+    tracking_consent: 'granted' | 'not-granted' | 'pending';
+    [k: string]: unknown;
+}
+export interface StopSession {
+    /**
+     * stopSession API
+     */
+    feature: 'stop-session';
+    [k: string]: unknown;
+}
+export interface StartView {
+    /**
+     * startView API
+     */
+    feature: 'start-view';
+    [k: string]: unknown;
+}
+export interface AddAction {
+    /**
+     * addAction API
+     */
+    feature: 'add-action';
+    [k: string]: unknown;
+}
+export interface AddError {
+    /**
+     * addError API
+     */
+    feature: 'add-error';
+    [k: string]: unknown;
+}
+export interface SetGlobalContext {
+    /**
+     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+     */
+    feature: 'set-global-context';
+    [k: string]: unknown;
+}
+export interface SetUser {
+    /**
+     * setUser, setUserProperty, setUserInfo APIs
+     */
+    feature: 'set-user';
+    [k: string]: unknown;
+}
+export interface AddFeatureFlagEvaluation {
+    /**
+     * addFeatureFlagEvaluation API
+     */
+    feature: 'add-feature-flag-evaluation';
+    [k: string]: unknown;
+}
+export interface StartSessionReplayRecording {
+    /**
+     * startSessionReplayRecording API
+     */
+    feature: 'start-session-replay-recording';
+    /**
+     * Whether the recording is allowed to start even on sessions sampled out of replay
+     */
+    is_forced?: boolean;
+    [k: string]: unknown;
+}
+export interface StartDurationVital {
+    /**
+     * startDurationVital API
+     */
+    feature: 'start-duration-vital';
+    [k: string]: unknown;
+}
+export interface StopDurationVital {
+    /**
+     * stopDurationVital API
+     */
+    feature: 'stop-duration-vital';
+    [k: string]: unknown;
+}
+export interface AddDurationVital {
+    /**
+     * addDurationVital API
+     */
+    feature: 'add-duration-vital';
+    [k: string]: unknown;
+}
+export interface AddViewLoadingTime {
+    /**
+     * addViewLoadingTime API
+     */
+    feature: 'addViewLoadingTime';
+    /**
+     * Whether the view is not available
+     */
+    no_view: boolean;
+    /**
+     * Whether the available view is not active
+     */
+    no_active_view: boolean;
+    /**
+     * Whether the loading time was overwritten
+     */
+    overwritten: boolean;
     [k: string]: unknown;
 }

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -391,7 +391,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
          * Telemetry type
          */
         type: 'usage';
-        usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage;
+        usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage | TelemetryMobileFeaturesUsage;
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -482,6 +482,28 @@ export declare type TelemetryBrowserFeaturesUsage = {
      * addDurationVital API
      */
     feature: 'add-duration-vital';
+    [k: string]: unknown;
+};
+/**
+ * Schema of mobile specific features usage
+ */
+export declare type TelemetryMobileFeaturesUsage = {
+    /**
+     * addViewLoadingTime API
+     */
+    feature: 'addViewLoadingTime';
+    /**
+     * Whether the view is not available
+     */
+    no_view: boolean;
+    /**
+     * Whether the available view is not active
+     */
+    no_active_view: boolean;
+    /**
+     * Whether the loading time was overwritten
+     */
+    overwritten: boolean;
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -399,113 +399,15 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = {
-    /**
-     * setTrackingConsent API
-     */
-    feature: 'set-tracking-consent';
-    /**
-     * The tracking consent value set by the user
-     */
-    tracking_consent: 'granted' | 'not-granted' | 'pending';
-    [k: string]: unknown;
-} | {
-    /**
-     * stopSession API
-     */
-    feature: 'stop-session';
-    [k: string]: unknown;
-} | {
-    /**
-     * startView API
-     */
-    feature: 'start-view';
-    [k: string]: unknown;
-} | {
-    /**
-     * addAction API
-     */
-    feature: 'add-action';
-    [k: string]: unknown;
-} | {
-    /**
-     * addError API
-     */
-    feature: 'add-error';
-    [k: string]: unknown;
-} | {
-    /**
-     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
-     */
-    feature: 'set-global-context';
-    [k: string]: unknown;
-} | {
-    /**
-     * setUser, setUserProperty, setUserInfo APIs
-     */
-    feature: 'set-user';
-    [k: string]: unknown;
-} | {
-    /**
-     * addFeatureFlagEvaluation API
-     */
-    feature: 'add-feature-flag-evaluation';
-    [k: string]: unknown;
-};
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | AddAction | AddError | SetGlobalContext | SetUser | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
-export declare type TelemetryBrowserFeaturesUsage = {
-    /**
-     * startSessionReplayRecording API
-     */
-    feature: 'start-session-replay-recording';
-    /**
-     * Whether the recording is allowed to start even on sessions sampled out of replay
-     */
-    is_forced?: boolean;
-    [k: string]: unknown;
-} | {
-    /**
-     * startDurationVital API
-     */
-    feature: 'start-duration-vital';
-    [k: string]: unknown;
-} | {
-    /**
-     * stopDurationVital API
-     */
-    feature: 'stop-duration-vital';
-    [k: string]: unknown;
-} | {
-    /**
-     * addDurationVital API
-     */
-    feature: 'add-duration-vital';
-    [k: string]: unknown;
-};
+export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
 /**
  * Schema of mobile specific features usage
  */
-export declare type TelemetryMobileFeaturesUsage = {
-    /**
-     * addViewLoadingTime API
-     */
-    feature: 'addViewLoadingTime';
-    /**
-     * Whether the view is not available
-     */
-    no_view: boolean;
-    /**
-     * Whether the available view is not active
-     */
-    no_active_view: boolean;
-    /**
-     * Whether the loading time was overwritten
-     */
-    overwritten: boolean;
-    [k: string]: unknown;
-};
+export declare type TelemetryMobileFeaturesUsage = AddViewLoadingTime;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -623,5 +525,116 @@ export interface CommonTelemetryProperties {
         };
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+export interface SetTrackingConsent {
+    /**
+     * setTrackingConsent API
+     */
+    feature: 'set-tracking-consent';
+    /**
+     * The tracking consent value set by the user
+     */
+    tracking_consent: 'granted' | 'not-granted' | 'pending';
+    [k: string]: unknown;
+}
+export interface StopSession {
+    /**
+     * stopSession API
+     */
+    feature: 'stop-session';
+    [k: string]: unknown;
+}
+export interface StartView {
+    /**
+     * startView API
+     */
+    feature: 'start-view';
+    [k: string]: unknown;
+}
+export interface AddAction {
+    /**
+     * addAction API
+     */
+    feature: 'add-action';
+    [k: string]: unknown;
+}
+export interface AddError {
+    /**
+     * addError API
+     */
+    feature: 'add-error';
+    [k: string]: unknown;
+}
+export interface SetGlobalContext {
+    /**
+     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+     */
+    feature: 'set-global-context';
+    [k: string]: unknown;
+}
+export interface SetUser {
+    /**
+     * setUser, setUserProperty, setUserInfo APIs
+     */
+    feature: 'set-user';
+    [k: string]: unknown;
+}
+export interface AddFeatureFlagEvaluation {
+    /**
+     * addFeatureFlagEvaluation API
+     */
+    feature: 'add-feature-flag-evaluation';
+    [k: string]: unknown;
+}
+export interface StartSessionReplayRecording {
+    /**
+     * startSessionReplayRecording API
+     */
+    feature: 'start-session-replay-recording';
+    /**
+     * Whether the recording is allowed to start even on sessions sampled out of replay
+     */
+    is_forced?: boolean;
+    [k: string]: unknown;
+}
+export interface StartDurationVital {
+    /**
+     * startDurationVital API
+     */
+    feature: 'start-duration-vital';
+    [k: string]: unknown;
+}
+export interface StopDurationVital {
+    /**
+     * stopDurationVital API
+     */
+    feature: 'stop-duration-vital';
+    [k: string]: unknown;
+}
+export interface AddDurationVital {
+    /**
+     * addDurationVital API
+     */
+    feature: 'add-duration-vital';
+    [k: string]: unknown;
+}
+export interface AddViewLoadingTime {
+    /**
+     * addViewLoadingTime API
+     */
+    feature: 'addViewLoadingTime';
+    /**
+     * Whether the view is not available
+     */
+    no_view: boolean;
+    /**
+     * Whether the available view is not active
+     */
+    no_active_view: boolean;
+    /**
+     * Whether the loading time was overwritten
+     */
+    overwritten: boolean;
     [k: string]: unknown;
 }

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -391,7 +391,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
          * Telemetry type
          */
         type: 'usage';
-        usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage;
+        usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage | TelemetryMobileFeaturesUsage;
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -482,6 +482,28 @@ export declare type TelemetryBrowserFeaturesUsage = {
      * addDurationVital API
      */
     feature: 'add-duration-vital';
+    [k: string]: unknown;
+};
+/**
+ * Schema of mobile specific features usage
+ */
+export declare type TelemetryMobileFeaturesUsage = {
+    /**
+     * addViewLoadingTime API
+     */
+    feature: 'addViewLoadingTime';
+    /**
+     * Whether the view is not available
+     */
+    no_view: boolean;
+    /**
+     * Whether the available view is not active
+     */
+    no_active_view: boolean;
+    /**
+     * Whether the loading time was overwritten
+     */
+    overwritten: boolean;
     [k: string]: unknown;
 };
 /**

--- a/schemas/telemetry/usage-schema.json
+++ b/schemas/telemetry/usage-schema.json
@@ -28,6 +28,9 @@
                 },
                 {
                   "$ref": "usage/browser-features-schema.json"
+                },
+                {
+                  "$ref": "usage/mobile-features-schema.json"
                 }
               ]
             }

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -7,6 +7,7 @@
   "oneOf": [
     {
       "required": ["feature"],
+      "title": "StartSessionReplayRecording",
       "properties": {
         "feature": {
           "type": "string",
@@ -21,6 +22,7 @@
     },
     {
       "required": ["feature"],
+      "title": "StartDurationVital",
       "properties": {
         "feature": {
           "type": "string",
@@ -31,6 +33,7 @@
     },
     {
       "required": ["feature"],
+      "title": "StopDurationVital",
       "properties": {
         "feature": {
           "type": "string",
@@ -41,6 +44,7 @@
     },
     {
       "required": ["feature"],
+      "title": "AddDurationVital",
       "properties": {
         "feature": {
           "type": "string",

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -7,6 +7,7 @@
   "oneOf": [
     {
       "required": ["feature", "tracking_consent"],
+      "title": "SetTrackingConsent",
       "properties": {
         "feature": {
           "type": "string",
@@ -22,6 +23,7 @@
     },
     {
       "required": ["feature"],
+      "title": "StopSession",
       "properties": {
         "feature": {
           "type": "string",
@@ -32,6 +34,7 @@
     },
     {
       "required": ["feature"],
+      "title": "StartView",
       "properties": {
         "feature": {
           "type": "string",
@@ -42,6 +45,7 @@
     },
     {
       "required": ["feature"],
+      "title": "AddAction",
       "properties": {
         "feature": {
           "type": "string",
@@ -52,6 +56,7 @@
     },
     {
       "required": ["feature"],
+      "title": "AddError",
       "properties": {
         "feature": {
           "type": "string",
@@ -62,6 +67,7 @@
     },
     {
       "required": ["feature"],
+      "title": "SetGlobalContext",
       "properties": {
         "feature": {
           "type": "string",
@@ -72,6 +78,7 @@
     },
     {
       "required": ["feature"],
+      "title": "SetUser",
       "properties": {
         "feature": {
           "type": "string",
@@ -82,6 +89,7 @@
     },
     {
       "required": ["feature"],
+      "title": "AddFeatureFlagEvaluation",
       "properties": {
         "feature": {
           "type": "string",

--- a/schemas/telemetry/usage/mobile-features-schema.json
+++ b/schemas/telemetry/usage/mobile-features-schema.json
@@ -7,6 +7,7 @@
   "oneOf": [
     {
       "required": ["feature", "no_view", "no_active_view", "overwritten"],
+      "title": "AddViewLoadingTime",
       "properties": {
         "feature": {
           "type": "string",

--- a/schemas/telemetry/usage/mobile-features-schema.json
+++ b/schemas/telemetry/usage/mobile-features-schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "telemetry/usage/mobile-features-schema.json",
+  "title": "TelemetryMobileFeaturesUsage",
+  "type": "object",
+  "description": "Schema of mobile specific features usage",
+  "oneOf": [
+    {
+      "required": ["feature", "no_view", "no_active_view", "overwritten"],
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "addViewLoadingTime API",
+          "const": "addViewLoadingTime"
+        },
+        "no_view": {
+          "type": "boolean",
+          "description": "Whether the view is not available"
+        },
+        "no_active_view": {
+          "type": "boolean",
+          "description": "Whether the available view is not active"
+        },
+        "overwritten": {
+          "type": "boolean",
+          "description": "Whether the loading time was overwritten"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
There are different cases we want to track per https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3951001790/RFC+View+loading+time+manual+API

- when API is used
- when there is no view to report
- when there is a view but not active
- when there is view, active and already has the timing

More context on https://github.com/DataDog/dd-sdk-ios/pull/2022