### PR TITLE
Add Kotlin Multiplatform to the Mobile Session Replay segment metadata schema

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -17,7 +17,7 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -327,7 +327,7 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -17,7 +17,7 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -327,7 +327,7 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/schemas/session-replay/mobile/segment-metadata-schema.json
+++ b/schemas/session-replay/mobile/segment-metadata-schema.json
@@ -17,7 +17,7 @@
         "source": {
           "type": "string",
           "description": "The source of this record",
-          "enum": ["android", "ios", "flutter", "react-native"]
+          "enum": ["android", "ios", "flutter", "react-native", "kotlin-multiplatform"]
         }
       }
     }


### PR DESCRIPTION
This PR adds Kotlin Multiplatform to the list of Mobile Session Replay segment metadata sources.