### PR TITLE
Add Kotlin Multiplatform as Session Replay source in lib folder

### DIFF
--- a/lib/cjs/src/session-replay-mobile.d.ts
+++ b/lib/cjs/src/session-replay-mobile.d.ts
@@ -5,6 +5,7 @@ export declare const MobileSource: {
     readonly Ios: "ios";
     readonly Flutter: "flutter";
     readonly ReactNative: "react-native";
+    readonly KotlinMultiplatform: "kotlin-multiplatform";
 };
 export declare type MobileSource = typeof MobileSource[keyof typeof MobileSource];
 export declare const RecordType: {

--- a/lib/cjs/src/session-replay-mobile.js
+++ b/lib/cjs/src/session-replay-mobile.js
@@ -21,6 +21,7 @@ exports.MobileSource = {
     Ios: 'ios',
     Flutter: 'flutter',
     ReactNative: 'react-native',
+    KotlinMultiplatform: 'kotlin-multiplatform',
 };
 exports.RecordType = {
     FullSnapshot: 10,

--- a/lib/esm/src/session-replay-mobile.d.ts
+++ b/lib/esm/src/session-replay-mobile.d.ts
@@ -5,6 +5,7 @@ export declare const MobileSource: {
     readonly Ios: "ios";
     readonly Flutter: "flutter";
     readonly ReactNative: "react-native";
+    readonly KotlinMultiplatform: "kotlin-multiplatform";
 };
 export declare type MobileSource = typeof MobileSource[keyof typeof MobileSource];
 export declare const RecordType: {

--- a/lib/esm/src/session-replay-mobile.js
+++ b/lib/esm/src/session-replay-mobile.js
@@ -4,6 +4,7 @@ export var MobileSource = {
     Ios: 'ios',
     Flutter: 'flutter',
     ReactNative: 'react-native',
+    KotlinMultiplatform: 'kotlin-multiplatform',
 };
 export var RecordType = {
     FullSnapshot: 10,

--- a/lib/src/session-replay-mobile.ts
+++ b/lib/src/session-replay-mobile.ts
@@ -7,6 +7,7 @@ export const MobileSource = {
   Ios: 'ios',
   Flutter: 'flutter',
   ReactNative: 'react-native',
+  KotlinMultiplatform: 'kotlin-multiplatform',
 } as const
 
 export type MobileSource = typeof MobileSource[keyof typeof MobileSource]


### PR DESCRIPTION
Follow-up for https://github.com/DataDog/rum-events-format/pull/223: it seems in order to be used in `web-ui`, KMP should be added as a possible source in the `lib` folder as well.