### PR TITLE
RUM-7110 Add the OOB mobile view loading metrics properties

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -734,6 +734,14 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly loading_time?: number;
         /**
+         * Duration in ns from the moment the view was started until all the initial network requests settled
+         */
+        readonly network_settled_time?: number;
+        /**
+         * Duration in ns to from the last interaction on previous view to the moment the current view was displayed
+         */
+        readonly interaction_to_next_view_time?: number;
+        /**
          * Type of the loading of the view
          */
         readonly loading_type?: 'initial_load' | 'route_change' | 'activity_display' | 'activity_redisplay' | 'fragment_display' | 'fragment_redisplay' | 'view_controller_display' | 'view_controller_redisplay';

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -734,6 +734,14 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly loading_time?: number;
         /**
+         * Duration in ns from the moment the view was started until all the initial network requests settled
+         */
+        readonly network_settled_time?: number;
+        /**
+         * Duration in ns to from the last interaction on previous view to the moment the current view was displayed
+         */
+        readonly interaction_to_next_view_time?: number;
+        /**
          * Type of the loading of the view
          */
         readonly loading_type?: 'initial_load' | 'route_change' | 'activity_display' | 'activity_redisplay' | 'fragment_display' | 'fragment_redisplay' | 'view_controller_display' | 'view_controller_redisplay';

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -15,6 +15,8 @@
     "referrer": "",
     "url": "https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view",
     "loading_time": 4115295000,
+    "network_settled_time": 10000,
+    "interaction_to_next_view_time": 20000,
     "loading_type": "initial_load",
     "time_spent": 245512755000,
     "first_contentful_paint": 420725000,

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -31,6 +31,18 @@
               "minimum": 0,
               "readOnly": true
             },
+            "network_settled_time": {
+              "type": "integer",
+              "description": "Duration in ns from the moment the view was started until all the initial network requests settled",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "interaction_to_next_view_time": {
+              "type": "integer",
+              "description": "Duration in ns to from the last interaction on previous view to the moment the current view was displayed",
+              "minimum": 0,
+              "readOnly": true
+            },
             "loading_type": {
               "type": "string",
               "description": "Type of the loading of the view",


### PR DESCRIPTION
Following our internal RFC we are adding 2 new properties on the `view-schema.json` to be used for the out-of-the-box view loading time metrics we propose for the our mobile RUM sdks. 