### PR TITLE
RUM-6850: [iOS] Add "Effective Sample Rate" to telemetry events

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -487,6 +487,10 @@ export interface CommonTelemetryProperties {
         [k: string]: unknown;
     };
     /**
+     * The actual percentage of telemetry usage per event
+     */
+    effective_sample_rate?: number;
+    /**
      * Enabled experimental features
      */
     readonly experimental_features?: string[];

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -487,6 +487,10 @@ export interface CommonTelemetryProperties {
         [k: string]: unknown;
     };
     /**
+     * The actual percentage of telemetry usage per event
+     */
+    effective_sample_rate?: number;
+    /**
      * Enabled experimental features
      */
     readonly experimental_features?: string[];

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -93,6 +93,12 @@
         }
       }
     },
+    "effective_sample_rate": {
+      "type": "integer",
+      "description": "The actual percentage of telemetry usage per event",
+      "minimum": 0,
+      "maximum": 100
+    },
     "experimental_features": {
       "type": "array",
       "description": "Enabled experimental features",


### PR DESCRIPTION
Adds new `effective_sample_rate` parameter. 

It is common to:
- `configuration-schema`
- `debug-schema`
- `error-schema`
- `usage-schema`