### PR TITLE
[RUM-7565] Add anonymous_id in common context

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1239,6 +1239,10 @@ export interface CommonProperties {
          * Email of the user
          */
         readonly email?: string;
+        /**
+         * Identifier of the user across sessions
+         */
+        readonly anonymous_id?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1239,6 +1239,10 @@ export interface CommonProperties {
          * Email of the user
          */
         readonly email?: string;
+        /**
+         * Identifier of the user across sessions
+         */
+        readonly anonymous_id?: string;
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -123,6 +123,11 @@
           "type": "string",
           "description": "Email of the user",
           "readOnly": true
+        },
+        "anonymous_id": {
+          "type": "string",
+          "description": "Identifier of the user across sessions",
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
We add `anonymous_id` in user context for future reference, following the [PR](https://github.com/DataDog/browser-sdk/pull/2985).