### PR TITLE
RUM-6852: floating points support

### DIFF
--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -94,7 +94,7 @@
       }
     },
     "effective_sample_rate": {
-      "type": "integer",
+      "type": "number",
       "description": "The actual percentage of telemetry usage per event",
       "minimum": 0,
       "maximum": 100


### PR DESCRIPTION
Improving [previous](https://github.com/DataDog/rum-events-format/pull/234) PR a bit  - `effective_sample_rate` should support floating point values