### PR TITLE
✨ [RUM-5001] Enforce localStorage usage telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -168,9 +168,9 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Configure the storage strategy for sessions. Possible values: 'local-storage', 'cookie', or 'cookie-fallback-to-local-storage'.
+             * Configure the storage strategy for persisting sessions
              */
-            session_storage?: 'local-storage' | 'cookie' | 'cookie-fallback-to-local-storage';
+            session_storage?: 'local-storage' | 'cookie';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -168,9 +168,9 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Configure the storage strategy for sessions.
+             * Configure the storage strategy for sessions. Possible values: 'local-storage', 'cookie', or 'cookie-fallback-to-local-storage'.
              */
-            session_storage?: ('cookie' | 'local-storage')[];
+            session_storage?: 'local-storage' | 'cookie' | 'cookie-fallback-to-local-storage';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -168,6 +168,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
+             * Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_storage)
+             */
+            allow_fallback_to_local_storage?: boolean;
+            /**
              * Configure the storage strategy for persisting sessions
              */
             session_storage?: 'local-storage' | 'cookie';

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -168,13 +168,13 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_storage)
+             * Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_persistence)
              */
             allow_fallback_to_local_storage?: boolean;
             /**
              * Configure the storage strategy for persisting sessions
              */
-            session_storage?: 'local-storage' | 'cookie';
+            session_persistence?: 'local-storage' | 'cookie';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -168,9 +168,9 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Whether it is allowed to use LocalStorage when cookies are not available
+             * Configure the storage strategy for sessions.
              */
-            allow_fallback_to_local_storage?: boolean;
+            session_storage?: ('cookie' | 'local-storage')[];
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -168,9 +168,9 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Configure the storage strategy for sessions. Possible values: 'local-storage', 'cookie', or 'cookie-fallback-to-local-storage'.
+             * Configure the storage strategy for persisting sessions
              */
-            session_storage?: 'local-storage' | 'cookie' | 'cookie-fallback-to-local-storage';
+            session_storage?: 'local-storage' | 'cookie';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -168,9 +168,9 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Configure the storage strategy for sessions.
+             * Configure the storage strategy for sessions. Possible values: 'local-storage', 'cookie', or 'cookie-fallback-to-local-storage'.
              */
-            session_storage?: ('cookie' | 'local-storage')[];
+            session_storage?: 'local-storage' | 'cookie' | 'cookie-fallback-to-local-storage';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -168,6 +168,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
+             * Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_storage)
+             */
+            allow_fallback_to_local_storage?: boolean;
+            /**
              * Configure the storage strategy for persisting sessions
              */
             session_storage?: 'local-storage' | 'cookie';

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -168,13 +168,13 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_storage)
+             * Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_persistence)
              */
             allow_fallback_to_local_storage?: boolean;
             /**
              * Configure the storage strategy for persisting sessions
              */
-            session_storage?: 'local-storage' | 'cookie';
+            session_persistence?: 'local-storage' | 'cookie';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -168,9 +168,9 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_secure_session_cookie?: boolean;
             /**
-             * Whether it is allowed to use LocalStorage when cookies are not available
+             * Configure the storage strategy for sessions.
              */
-            allow_fallback_to_local_storage?: boolean;
+            session_storage?: ('cookie' | 'local-storage')[];
             /**
              * Whether contexts are stored in local storage
              */

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -41,7 +41,7 @@
       "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
-      "session_storage": ["cookie", "local-storage"],
+      "session_storage": "cookie",
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -41,7 +41,7 @@
       "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
-      "session_storage": "cookie",
+      "session_persistence": "cookie",
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -41,7 +41,7 @@
       "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
-      "allow_fallback_to_local_storage": true,
+      "session_storage": ["cookie", "local_storage"],
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -41,7 +41,7 @@
       "track_long_task": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
-      "session_storage": ["cookie", "local_storage"],
+      "session_storage": ["cookie", "local-storage"],
       "action_name_attribute": "foo",
       "use_allowed_tracing_origins": false,
       "default_privacy_level": "mask",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -136,9 +136,9 @@
                 },
                 "allow_fallback_to_local_storage": {
                   "type": "boolean",
-                  "description": "Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_storage)"
+                  "description": "Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_persistence)"
                 },
-                "session_storage": {
+                "session_persistence": {
                   "type": "string",
                   "enum": ["local-storage", "cookie"],
                   "description": "Configure the storage strategy for persisting sessions"

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -136,8 +136,8 @@
                 },
                 "session_storage": {
                   "type": "string",
-                  "enum": ["local-storage", "cookie", "cookie-fallback-to-local-storage"],
-                  "description": "Configure the storage strategy for sessions. Possible values: 'local-storage', 'cookie', or 'cookie-fallback-to-local-storage'."
+                  "enum": ["local-storage", "cookie"],
+                  "description": "Configure the storage strategy for persisting sessions"
                 },
                 "store_contexts_across_pages": {
                   "type": "boolean",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -134,9 +134,13 @@
                   "type": "boolean",
                   "description": "Whether a secure session cookie is used"
                 },
-                "allow_fallback_to_local_storage": {
-                  "type": "boolean",
-                  "description": "Whether it is allowed to use LocalStorage when cookies are not available"
+                "session_storage": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["cookie", "local-storage"]
+                  },
+                  "description": "Configure the storage strategy for sessions."
                 },
                 "store_contexts_across_pages": {
                   "type": "boolean",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -135,12 +135,9 @@
                   "description": "Whether a secure session cookie is used"
                 },
                 "session_storage": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": ["cookie", "local-storage"]
-                  },
-                  "description": "Configure the storage strategy for sessions."
+                  "type": "string",
+                  "enum": ["local-storage", "cookie", "cookie-fallback-to-local-storage"],
+                  "description": "Configure the storage strategy for sessions. Possible values: 'local-storage', 'cookie', or 'cookie-fallback-to-local-storage'."
                 },
                 "store_contexts_across_pages": {
                   "type": "boolean",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -134,6 +134,10 @@
                   "type": "boolean",
                   "description": "Whether a secure session cookie is used"
                 },
+                "allow_fallback_to_local_storage": {
+                  "type": "boolean",
+                  "description": "Whether it is allowed to use LocalStorage when cookies are not available (deprecated in favor of session_storage)"
+                },
                 "session_storage": {
                   "type": "string",
                   "enum": ["local-storage", "cookie"],


### PR DESCRIPTION
As discussed we would like to enforce localstorage by allowing to select session storage

sessionStorage: ["cookie", "local-storage"] → use cookie, fallback to local storage

sessionStorage: ["local-storage"] → never use cookies

sessionStorage: [] → disable session storage

So deprecate old allow_fallback_to_local_storage and add session_storage property for telemetry