### PR TITLE
🎨 [RUM-6567] Add new fields for Web Vitals attribution and other performance data

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -772,51 +772,51 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly time_spent: number;
         /**
-         * Duration in ns to the first rendering
+         * Duration in ns to the first rendering (deprecated in favor of `view.performance.fcp.timestamp`)
          */
         readonly first_contentful_paint?: number;
         /**
-         * Duration in ns to the largest contentful paint
+         * Duration in ns to the largest contentful paint (deprecated in favor of `view.performance.lcp.timestamp`)
          */
         readonly largest_contentful_paint?: number;
         /**
-         * CSS selector path of the largest contentful paint element
+         * CSS selector path of the largest contentful paint element (deprecated in favor of `view.performance.lcp.target_selector`)
          */
         readonly largest_contentful_paint_target_selector?: string;
         /**
-         * Duration in ns of the first input event delay
+         * Duration in ns of the first input event delay (deprecated in favor of `view.performance.fid.duration`)
          */
         readonly first_input_delay?: number;
         /**
-         * Duration in ns to the first input
+         * Duration in ns to the first input (deprecated in favor of `view.performance.fid.timestamp`)
          */
         readonly first_input_time?: number;
         /**
-         * CSS selector path of the first input target element
+         * CSS selector path of the first input target element (deprecated in favor of `view.performance.fid.target_selector`)
          */
         readonly first_input_target_selector?: string;
         /**
-         * Longest duration in ns between an interaction and the next paint
+         * Longest duration in ns between an interaction and the next paint (deprecated in favor of `view.performance.inp.duration`)
          */
         readonly interaction_to_next_paint?: number;
         /**
-         * Duration in ns between start of the view and start of the INP
+         * Duration in ns between start of the view and start of the INP (deprecated in favor of `view.performance.inp.timestamp`)
          */
         readonly interaction_to_next_paint_time?: number;
         /**
-         * CSS selector path of the interacted element corresponding to INP
+         * CSS selector path of the interacted element corresponding to INP (deprecated in favor of `view.performance.inp.target_selector`)
          */
         readonly interaction_to_next_paint_target_selector?: string;
         /**
-         * Total layout shift score that occurred on the view
+         * Total layout shift score that occurred on the view (deprecated in favor of `view.performance.cls.score`)
          */
         readonly cumulative_layout_shift?: number;
         /**
-         * Duration in ns between start of the view and start of the largest layout shift contributing to CLS
+         * Duration in ns between start of the view and start of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.timestamp`)
          */
         readonly cumulative_layout_shift_time?: number;
         /**
-         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
+         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.target_selector`)
          */
         readonly cumulative_layout_shift_target_selector?: string;
         /**
@@ -1085,6 +1085,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
+    /**
+     * Performance data. (Web Vitals, etc.)
+     */
+    performance?: ViewPerformanceData;
     [k: string]: unknown;
 };
 /**
@@ -1485,5 +1489,89 @@ export interface RumPerfMetric {
      * The maximum possible value we could see for this metric, if such a max is relevant and can vary from session to session.
      */
     readonly metric_max?: number;
+    [k: string]: unknown;
+}
+/**
+ * Schema for view-level RUM performance data (Web Vitals, etc.)
+ */
+export interface ViewPerformanceData {
+    /**
+     * Cumulative Layout Shift
+     */
+    readonly cls?: {
+        /**
+         * Total layout shift score that occurred on the view
+         */
+        readonly score: number;
+        /**
+         * Timestamp in ns of the largest layout shift contributing to CLS
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
+    /**
+     * First Contentful Paint
+     */
+    readonly fcp?: {
+        /**
+         * Timestamp in ns of the first rendering
+         */
+        readonly timestamp: number;
+        [k: string]: unknown;
+    };
+    /**
+     * First Input Delay
+     */
+    readonly fid?: {
+        /**
+         * Duration in ns of the first input event delay
+         */
+        readonly duration: number;
+        /**
+         * Timestamp in ns of the first input event
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the first input target element
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Interaction to Next Paint
+     */
+    readonly inp?: {
+        /**
+         * Longest duration in ns between an interaction and the next paint
+         */
+        readonly duration: number;
+        /**
+         * Timestamp in ns of the start of the INP interaction
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the interacted element for the INP interaction
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Largest Contentful Paint
+     */
+    readonly lcp?: {
+        /**
+         * Timestamp in ns of the largest contentful paint
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the largest contentful paint element
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 }

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -772,51 +772,51 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly time_spent: number;
         /**
-         * Duration in ns to the first rendering
+         * Duration in ns to the first rendering (deprecated in favor of `view.performance.fcp.timestamp`)
          */
         readonly first_contentful_paint?: number;
         /**
-         * Duration in ns to the largest contentful paint
+         * Duration in ns to the largest contentful paint (deprecated in favor of `view.performance.lcp.timestamp`)
          */
         readonly largest_contentful_paint?: number;
         /**
-         * CSS selector path of the largest contentful paint element
+         * CSS selector path of the largest contentful paint element (deprecated in favor of `view.performance.lcp.target_selector`)
          */
         readonly largest_contentful_paint_target_selector?: string;
         /**
-         * Duration in ns of the first input event delay
+         * Duration in ns of the first input event delay (deprecated in favor of `view.performance.fid.duration`)
          */
         readonly first_input_delay?: number;
         /**
-         * Duration in ns to the first input
+         * Duration in ns to the first input (deprecated in favor of `view.performance.fid.timestamp`)
          */
         readonly first_input_time?: number;
         /**
-         * CSS selector path of the first input target element
+         * CSS selector path of the first input target element (deprecated in favor of `view.performance.fid.target_selector`)
          */
         readonly first_input_target_selector?: string;
         /**
-         * Longest duration in ns between an interaction and the next paint
+         * Longest duration in ns between an interaction and the next paint (deprecated in favor of `view.performance.inp.duration`)
          */
         readonly interaction_to_next_paint?: number;
         /**
-         * Duration in ns between start of the view and start of the INP
+         * Duration in ns between start of the view and start of the INP (deprecated in favor of `view.performance.inp.timestamp`)
          */
         readonly interaction_to_next_paint_time?: number;
         /**
-         * CSS selector path of the interacted element corresponding to INP
+         * CSS selector path of the interacted element corresponding to INP (deprecated in favor of `view.performance.inp.target_selector`)
          */
         readonly interaction_to_next_paint_target_selector?: string;
         /**
-         * Total layout shift score that occurred on the view
+         * Total layout shift score that occurred on the view (deprecated in favor of `view.performance.cls.score`)
          */
         readonly cumulative_layout_shift?: number;
         /**
-         * Duration in ns between start of the view and start of the largest layout shift contributing to CLS
+         * Duration in ns between start of the view and start of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.timestamp`)
          */
         readonly cumulative_layout_shift_time?: number;
         /**
-         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
+         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.target_selector`)
          */
         readonly cumulative_layout_shift_target_selector?: string;
         /**
@@ -1085,6 +1085,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
+    /**
+     * Performance data. (Web Vitals, etc.)
+     */
+    performance?: ViewPerformanceData;
     [k: string]: unknown;
 };
 /**
@@ -1485,5 +1489,89 @@ export interface RumPerfMetric {
      * The maximum possible value we could see for this metric, if such a max is relevant and can vary from session to session.
      */
     readonly metric_max?: number;
+    [k: string]: unknown;
+}
+/**
+ * Schema for view-level RUM performance data (Web Vitals, etc.)
+ */
+export interface ViewPerformanceData {
+    /**
+     * Cumulative Layout Shift
+     */
+    readonly cls?: {
+        /**
+         * Total layout shift score that occurred on the view
+         */
+        readonly score: number;
+        /**
+         * Timestamp in ns of the largest layout shift contributing to CLS
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
+    /**
+     * First Contentful Paint
+     */
+    readonly fcp?: {
+        /**
+         * Timestamp in ns of the first rendering
+         */
+        readonly timestamp: number;
+        [k: string]: unknown;
+    };
+    /**
+     * First Input Delay
+     */
+    readonly fid?: {
+        /**
+         * Duration in ns of the first input event delay
+         */
+        readonly duration: number;
+        /**
+         * Timestamp in ns of the first input event
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the first input target element
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Interaction to Next Paint
+     */
+    readonly inp?: {
+        /**
+         * Longest duration in ns between an interaction and the next paint
+         */
+        readonly duration: number;
+        /**
+         * Timestamp in ns of the start of the INP interaction
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the interacted element for the INP interaction
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Largest Contentful Paint
+     */
+    readonly lcp?: {
+        /**
+         * Timestamp in ns of the largest contentful paint
+         */
+        readonly timestamp: number;
+        /**
+         * CSS selector path of the largest contentful paint element
+         */
+        readonly target_selector: string;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 }

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -99,5 +99,29 @@
   },
   "privacy": {
     "replay_level": "mask"
+  },
+  "performance": {
+    "cls": {
+      "score": 0.1,
+      "timestamp": 2000,
+      "target_selector": "#foo"
+    },
+    "fcp": {
+      "timestamp": 420725000
+    },
+    "fid": {
+      "duration": 20000000,
+      "timestamp": 20000000,
+      "target_selector": "#foo"
+    },
+    "inp": {
+      "duration": 20000000,
+      "timestamp": 20000000,
+      "target_selector": "#foo"
+    },
+    "lcp": {
+      "timestamp": 20000000,
+      "target_selector": "#foo"
+    }
   }
 }

--- a/schemas/rum/_view-performance-schema.json
+++ b/schemas/rum/_view-performance-schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_view-performance-schema.json",
+  "title": "ViewPerformanceData",
+  "type": "object",
+  "description": "Schema for view-level RUM performance data (Web Vitals, etc.)",
+  "properties": {
+    "cls": {
+      "type": "object",
+      "description": "Cumulative Layout Shift",
+      "required": ["score", "timestamp", "target_selector"],
+      "properties": {
+        "score": {
+          "type": "number",
+          "description": "Total layout shift score that occurred on the view",
+          "$comment": "Replaces the deprecated `view.cumulative_layout_shift`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the largest layout shift contributing to CLS",
+          "$comment": "Replaces the deprecated `view.cumulative_layout_shift_time`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS",
+          "$comment": "Replaces the deprecated `view.cumulative_layout_shift_target_selector`",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "fcp": {
+      "type": "object",
+      "description": "First Contentful Paint",
+      "required": ["timestamp"],
+      "properties": {
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the first rendering",
+          "$comment": "Replaces the deprecated `view.first_contentful_paint`",
+          "minimum": 0,
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "fid": {
+      "type": "object",
+      "description": "First Input Delay",
+      "required": ["duration", "timestamp", "target_selector"],
+      "properties": {
+        "duration": {
+          "type": "integer",
+          "description": "Duration in ns of the first input event delay",
+          "$comment": "Replaces the deprecated `view.first_input_delay`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the first input event",
+          "$comment": "Replaces the deprecated `view.first_input_time`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the first input target element",
+          "$comment": "Replaces the deprecated `view.first_input_target_selector`",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "inp": {
+      "type": "object",
+      "description": "Interaction to Next Paint",
+      "required": ["duration", "timestamp", "target_selector"],
+      "properties": {
+        "duration": {
+          "type": "integer",
+          "description": "Longest duration in ns between an interaction and the next paint",
+          "$comment": "Replaces the deprecated `view.interaction_to_next_paint`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the start of the INP interaction",
+          "$comment": "Replaces the deprecated `view.interaction_to_next_paint_time`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the interacted element for the INP interaction",
+          "$comment": "Replaces the deprecated `view.interaction_to_next_paint_target_selector`",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "lcp": {
+      "type": "object",
+      "description": "Largest Contentful Paint",
+      "required": ["timestamp", "target_selector"],
+      "properties": {
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the largest contentful paint",
+          "$comment": "Replaces the deprecated `view.largest_contentful_paint`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the largest contentful paint element",
+          "$comment": "Replaces the deprecated `view.largest_contentful_paint_target_selector`",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -66,70 +66,82 @@
             },
             "first_contentful_paint": {
               "type": "integer",
-              "description": "Duration in ns to the first rendering",
+              "description": "Duration in ns to the first rendering (deprecated in favor of `view.performance.fcp.timestamp`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "largest_contentful_paint": {
               "type": "integer",
-              "description": "Duration in ns to the largest contentful paint",
+              "description": "Duration in ns to the largest contentful paint (deprecated in favor of `view.performance.lcp.timestamp`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "largest_contentful_paint_target_selector": {
               "type": "string",
-              "description": "CSS selector path of the largest contentful paint element",
+              "description": "CSS selector path of the largest contentful paint element (deprecated in favor of `view.performance.lcp.target_selector`)",
+              "deprecated": true,
               "readOnly": true
             },
             "first_input_delay": {
               "type": "integer",
-              "description": "Duration in ns of the first input event delay",
+              "description": "Duration in ns of the first input event delay (deprecated in favor of `view.performance.fid.duration`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "first_input_time": {
               "type": "integer",
-              "description": "Duration in ns to the first input",
+              "description": "Duration in ns to the first input (deprecated in favor of `view.performance.fid.timestamp`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "first_input_target_selector": {
               "type": "string",
-              "description": "CSS selector path of the first input target element",
+              "description": "CSS selector path of the first input target element (deprecated in favor of `view.performance.fid.target_selector`)",
+              "deprecated": true,
               "readOnly": true
             },
             "interaction_to_next_paint": {
               "type": "integer",
-              "description": "Longest duration in ns between an interaction and the next paint",
+              "description": "Longest duration in ns between an interaction and the next paint (deprecated in favor of `view.performance.inp.duration`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "interaction_to_next_paint_time": {
               "type": "integer",
-              "description": "Duration in ns between start of the view and start of the INP",
+              "description": "Duration in ns between start of the view and start of the INP (deprecated in favor of `view.performance.inp.timestamp`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "interaction_to_next_paint_target_selector": {
               "type": "string",
-              "description": "CSS selector path of the interacted element corresponding to INP",
+              "description": "CSS selector path of the interacted element corresponding to INP (deprecated in favor of `view.performance.inp.target_selector`)",
+              "deprecated": true,
               "readOnly": true
             },
             "cumulative_layout_shift": {
               "type": "number",
-              "description": "Total layout shift score that occurred on the view",
+              "description": "Total layout shift score that occurred on the view (deprecated in favor of `view.performance.cls.score`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "cumulative_layout_shift_time": {
               "type": "integer",
-              "description": "Duration in ns between start of the view and start of the largest layout shift contributing to CLS",
+              "description": "Duration in ns between start of the view and start of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.timestamp`)",
+              "deprecated": true,
               "minimum": 0,
               "readOnly": true
             },
             "cumulative_layout_shift_target_selector": {
               "type": "string",
-              "description": "CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS",
+              "description": "CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.target_selector`)",
+              "deprecated": true,
               "readOnly": true
             },
             "dom_complete": {
@@ -496,6 +508,10 @@
               "readOnly": true
             }
           }
+        },
+        "performance": {
+          "description": "Performance data. (Web Vitals, etc.)",
+          "allOf": [{ "$ref": "_view-performance-schema.json" }]
         }
       }
     }


### PR DESCRIPTION
This PR adds a new `RumPerformanceData` subobject within `RumViewEvent`. We'll gradually migrate performance-related fields from `RumViewEvent` into this subobject, taking the opportunity to reorganize them in a cleaner, more hierarchical fashion.

We begin the migration process within this PR by creating new versions of the Web-Vitals-related fields on `RumViewEvent` that live in `RumViewEvent`. In the new structure, these fields are organized hierarchically, so that all of the fields for each Web Vital live on a subobject and attribution data for each Web Vital is cleanly tied to the Web Vital's primary metric.