### PR TITLE
✨ [RUM-7019] Add Account properties

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1246,6 +1246,20 @@ export interface CommonProperties {
         [k: string]: unknown;
     };
     /**
+     * Account properties
+     */
+    readonly account?: {
+        /**
+         * Identifier of the account
+         */
+        readonly id: string;
+        /**
+         * Name of the account
+         */
+        readonly name?: string;
+        [k: string]: unknown;
+    };
+    /**
      * Device connectivity properties
      */
     connectivity?: {

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -407,7 +407,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | AddAction | AddError | SetGlobalContext | SetUser | AddFeatureFlagEvaluation;
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | AddAction | AddError | SetGlobalContext | SetUser | SetAccount | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
@@ -590,6 +590,13 @@ export interface SetUser {
      * setUser, setUserProperty, setUserInfo APIs
      */
     feature: 'set-user';
+    [k: string]: unknown;
+}
+export interface SetAccount {
+    /**
+     * setAccount, setAccountProperty APIs
+     */
+    feature: 'set-account';
     [k: string]: unknown;
 }
 export interface AddFeatureFlagEvaluation {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1246,6 +1246,20 @@ export interface CommonProperties {
         [k: string]: unknown;
     };
     /**
+     * Account properties
+     */
+    readonly account?: {
+        /**
+         * Identifier of the account
+         */
+        readonly id: string;
+        /**
+         * Name of the account
+         */
+        readonly name?: string;
+        [k: string]: unknown;
+    };
+    /**
      * Device connectivity properties
      */
     connectivity?: {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -407,7 +407,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | AddAction | AddError | SetGlobalContext | SetUser | AddFeatureFlagEvaluation;
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | AddAction | AddError | SetGlobalContext | SetUser | SetAccount | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
@@ -590,6 +590,13 @@ export interface SetUser {
      * setUser, setUserProperty, setUserInfo APIs
      */
     feature: 'set-user';
+    [k: string]: unknown;
+}
+export interface SetAccount {
+    /**
+     * setAccount, setAccountProperty APIs
+     */
+    feature: 'set-account';
     [k: string]: unknown;
 }
 export interface AddFeatureFlagEvaluation {

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -132,6 +132,25 @@
       },
       "readOnly": true
     },
+    "account": {
+      "type": "object",
+      "description": "Account properties",
+      "additionalProperties": true,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier of the account",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the account",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
     "connectivity": {
       "type": "object",
       "description": "Device connectivity properties",

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -89,6 +89,17 @@
     },
     {
       "required": ["feature"],
+      "title": "SetAccount",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setAccount, setAccountProperty APIs",
+          "const": "set-account"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
       "title": "AddFeatureFlagEvaluation",
       "properties": {
         "feature": {


### PR DESCRIPTION
This PR adds a new common field, `account`, and the telemetry for the associated APIs.