### PR TITLE
✨ [RUM-6565] - Add previous and current rect attribution data for Cumulative Layout Shift

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1511,6 +1511,14 @@ export interface ViewPerformanceData {
          * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
          */
         readonly target_selector?: string;
+        /**
+         * Bounding client rect of the element before the layout shift
+         */
+        previous_rect?: RumRect;
+        /**
+         * Bounding client rect of the element after the layout shift
+         */
+        current_rect?: RumRect;
         [k: string]: unknown;
     };
     /**
@@ -1573,5 +1581,27 @@ export interface ViewPerformanceData {
         readonly target_selector?: string;
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/**
+ * Schema for DOMRect-like rectangles describing an element's bounding client rect
+ */
+export interface RumRect {
+    /**
+     * The x coordinate of the element's origin
+     */
+    readonly x: number;
+    /**
+     * The y coordinate of the element's origin
+     */
+    readonly y: number;
+    /**
+     * The element's width
+     */
+    readonly width: number;
+    /**
+     * The element's height
+     */
+    readonly height: number;
     [k: string]: unknown;
 }

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1511,6 +1511,14 @@ export interface ViewPerformanceData {
          * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
          */
         readonly target_selector?: string;
+        /**
+         * Bounding client rect of the element before the layout shift
+         */
+        previous_rect?: RumRect;
+        /**
+         * Bounding client rect of the element after the layout shift
+         */
+        current_rect?: RumRect;
         [k: string]: unknown;
     };
     /**
@@ -1573,5 +1581,27 @@ export interface ViewPerformanceData {
         readonly target_selector?: string;
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/**
+ * Schema for DOMRect-like rectangles describing an element's bounding client rect
+ */
+export interface RumRect {
+    /**
+     * The x coordinate of the element's origin
+     */
+    readonly x: number;
+    /**
+     * The y coordinate of the element's origin
+     */
+    readonly y: number;
+    /**
+     * The element's width
+     */
+    readonly width: number;
+    /**
+     * The element's height
+     */
+    readonly height: number;
     [k: string]: unknown;
 }

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -104,7 +104,19 @@
     "cls": {
       "score": 0.1,
       "timestamp": 2000,
-      "target_selector": "#foo"
+      "target_selector": "#foo",
+      "previous_rect": {
+        "x": 0,
+        "y": 0,
+        "width": 0,
+        "height": 0
+      },
+      "current_rect": {
+        "x": 0,
+        "y": 0,
+        "width": 0,
+        "height": 0
+      }
     },
     "fcp": {
       "timestamp": 420725000

--- a/schemas/rum/_rect-schema.json
+++ b/schemas/rum/_rect-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_rect-schema.json",
+  "title": "RumRect",
+  "type": "object",
+  "description": "Schema for DOMRect-like rectangles describing an element's bounding client rect",
+  "required": ["x", "y", "width", "height"],
+  "properties": {
+    "x": {
+      "type": "number",
+      "description": "The x coordinate of the element's origin",
+      "readOnly": true
+    },
+    "y": {
+      "type": "number",
+      "description": "The y coordinate of the element's origin",
+      "readOnly": true
+    },
+    "width": {
+      "type": "number",
+      "description": "The element's width",
+      "readOnly": true
+    },
+    "height": {
+      "type": "number",
+      "description": "The element's height",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/_view-performance-schema.json
+++ b/schemas/rum/_view-performance-schema.json
@@ -29,6 +29,14 @@
           "description": "CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS",
           "$comment": "Replaces the deprecated `view.cumulative_layout_shift_target_selector`",
           "readOnly": true
+        },
+        "previous_rect": {
+          "description": "Bounding client rect of the element before the layout shift",
+          "allOf": [{ "$ref": "_rect-schema.json" }]
+        },
+        "current_rect": {
+          "description": "Bounding client rect of the element after the layout shift",
+          "allOf": [{ "$ref": "_rect-schema.json" }]
         }
       },
       "readOnly": true


### PR DESCRIPTION
When trying to understand the causes and impact of a Cumulative Layout Shift score, it's often helpful to see how the affected element's position and size has changed. This PR updates our event format to add optional previous and current rects for CLS target elements. A future PR in the `browser-sdk` repo will add support for capturing this information when it's available.