### PR TITLE
🐛 Mark Web Vitals attribution fields as optional where appropriate

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1506,11 +1506,11 @@ export interface ViewPerformanceData {
         /**
          * Timestamp in ns of the largest layout shift contributing to CLS
          */
-        readonly timestamp: number;
+        readonly timestamp?: number;
         /**
          * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     /**
@@ -1538,7 +1538,7 @@ export interface ViewPerformanceData {
         /**
          * CSS selector path of the first input target element
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     /**
@@ -1552,11 +1552,11 @@ export interface ViewPerformanceData {
         /**
          * Timestamp in ns of the start of the INP interaction
          */
-        readonly timestamp: number;
+        readonly timestamp?: number;
         /**
          * CSS selector path of the interacted element for the INP interaction
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     /**
@@ -1570,7 +1570,7 @@ export interface ViewPerformanceData {
         /**
          * CSS selector path of the largest contentful paint element
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1506,11 +1506,11 @@ export interface ViewPerformanceData {
         /**
          * Timestamp in ns of the largest layout shift contributing to CLS
          */
-        readonly timestamp: number;
+        readonly timestamp?: number;
         /**
          * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     /**
@@ -1538,7 +1538,7 @@ export interface ViewPerformanceData {
         /**
          * CSS selector path of the first input target element
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     /**
@@ -1552,11 +1552,11 @@ export interface ViewPerformanceData {
         /**
          * Timestamp in ns of the start of the INP interaction
          */
-        readonly timestamp: number;
+        readonly timestamp?: number;
         /**
          * CSS selector path of the interacted element for the INP interaction
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     /**
@@ -1570,7 +1570,7 @@ export interface ViewPerformanceData {
         /**
          * CSS selector path of the largest contentful paint element
          */
-        readonly target_selector: string;
+        readonly target_selector?: string;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/schemas/rum/_view-performance-schema.json
+++ b/schemas/rum/_view-performance-schema.json
@@ -8,7 +8,7 @@
     "cls": {
       "type": "object",
       "description": "Cumulative Layout Shift",
-      "required": ["score", "timestamp", "target_selector"],
+      "required": ["score"],
       "properties": {
         "score": {
           "type": "number",
@@ -51,7 +51,7 @@
     "fid": {
       "type": "object",
       "description": "First Input Delay",
-      "required": ["duration", "timestamp", "target_selector"],
+      "required": ["duration", "timestamp"],
       "properties": {
         "duration": {
           "type": "integer",
@@ -79,7 +79,7 @@
     "inp": {
       "type": "object",
       "description": "Interaction to Next Paint",
-      "required": ["duration", "timestamp", "target_selector"],
+      "required": ["duration"],
       "properties": {
         "duration": {
           "type": "integer",
@@ -107,7 +107,7 @@
     "lcp": {
       "type": "object",
       "description": "Largest Contentful Paint",
-      "required": ["timestamp", "target_selector"],
+      "required": ["timestamp"],
       "properties": {
         "timestamp": {
           "type": "integer",


### PR DESCRIPTION
In some cases we may be able to generate a score for a Web Vital, but not be able to generate some of its attribution data. This PR makes all attribution fields that the browser SDK can fail to generate optional. This both better reflects reality and aligns the types in the schema with the types used internally by the browser SDK.