### PR TITLE
🐛 [RUM-6567] Move performance namespace inside view

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -973,6 +973,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * The JavaScript refresh rate for React Native
          */
         js_refresh_rate?: RumPerfMetric;
+        /**
+         * Performance data. (Web Vitals, etc.)
+         */
+        performance?: ViewPerformanceData;
         [k: string]: unknown;
     };
     /**
@@ -1085,10 +1089,6 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
-    /**
-     * Performance data. (Web Vitals, etc.)
-     */
-    performance?: ViewPerformanceData;
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -973,6 +973,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * The JavaScript refresh rate for React Native
          */
         js_refresh_rate?: RumPerfMetric;
+        /**
+         * Performance data. (Web Vitals, etc.)
+         */
+        performance?: ViewPerformanceData;
         [k: string]: unknown;
     };
     /**
@@ -1085,10 +1089,6 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
-    /**
-     * Performance data. (Web Vitals, etc.)
-     */
-    performance?: ViewPerformanceData;
     [k: string]: unknown;
 };
 /**

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -56,7 +56,43 @@
     "in_foreground_periods": [
       { "start": 1345678, "duration": 67 },
       { "start": 1645678, "duration": 67 }
-    ]
+    ],
+    "performance": {
+      "cls": {
+        "score": 0.1,
+        "timestamp": 2000,
+        "target_selector": "#foo",
+        "previous_rect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0
+        },
+        "current_rect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0
+        }
+      },
+      "fcp": {
+        "timestamp": 420725000
+      },
+      "fid": {
+        "duration": 20000000,
+        "timestamp": 20000000,
+        "target_selector": "#foo"
+      },
+      "inp": {
+        "duration": 20000000,
+        "timestamp": 20000000,
+        "target_selector": "#foo"
+      },
+      "lcp": {
+        "timestamp": 20000000,
+        "target_selector": "#foo"
+      }
+    }
   },
   "_dd": {
     "document_version": 9,
@@ -99,41 +135,5 @@
   },
   "privacy": {
     "replay_level": "mask"
-  },
-  "performance": {
-    "cls": {
-      "score": 0.1,
-      "timestamp": 2000,
-      "target_selector": "#foo",
-      "previous_rect": {
-        "x": 0,
-        "y": 0,
-        "width": 0,
-        "height": 0
-      },
-      "current_rect": {
-        "x": 0,
-        "y": 0,
-        "width": 0,
-        "height": 0
-      }
-    },
-    "fcp": {
-      "timestamp": 420725000
-    },
-    "fid": {
-      "duration": 20000000,
-      "timestamp": 20000000,
-      "target_selector": "#foo"
-    },
-    "inp": {
-      "duration": 20000000,
-      "timestamp": 20000000,
-      "target_selector": "#foo"
-    },
-    "lcp": {
-      "timestamp": 20000000,
-      "target_selector": "#foo"
-    }
   }
 }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -358,6 +358,10 @@
             "js_refresh_rate": {
               "description": "The JavaScript refresh rate for React Native",
               "allOf": [{ "$ref": "_perf-metric-schema.json" }]
+            },
+            "performance": {
+              "description": "Performance data. (Web Vitals, etc.)",
+              "allOf": [{ "$ref": "_view-performance-schema.json" }]
             }
           },
           "readOnly": true
@@ -508,10 +512,6 @@
               "readOnly": true
             }
           }
-        },
-        "performance": {
-          "description": "Performance data. (Web Vitals, etc.)",
-          "allOf": [{ "$ref": "_view-performance-schema.json" }]
         }
       }
     }


### PR DESCRIPTION
This PR moves the `performance` namespace added in #240 inside `@view`, to align better with the pattern we've followed in the past for fields that are only used in the context of a single event.

Since we haven't yet landed the PRs that use the `performance` namespace in the `browser-sdk` repo, it's still possible to make this change safely.