### PR TITLE
Fix effective_type format

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1278,7 +1278,7 @@ export interface CommonProperties {
         /**
          * Cellular connection type reflecting the measured network performance
          */
-        readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g';
+        readonly effective_type?: 'slow-2g' | '2g' | '3g' | '4g';
         /**
          * Cellular connectivity properties
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1278,7 +1278,7 @@ export interface CommonProperties {
         /**
          * Cellular connection type reflecting the measured network performance
          */
-        readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g';
+        readonly effective_type?: 'slow-2g' | '2g' | '3g' | '4g';
         /**
          * Cellular connectivity properties
          */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -174,7 +174,7 @@
         "effective_type": {
           "type": "string",
           "description": "Cellular connection type reflecting the measured network performance",
-          "enum": ["slow_2g", "2g", "3g", "4g"],
+          "enum": ["slow-2g", "2g", "3g", "4g"],
           "readOnly": true
         },
         "cellular": {


### PR DESCRIPTION
Fix effective_type format: `slow_2g` => `slow-2g`