### PR TITLE
remove readonly on some loaf scripts properties

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -474,7 +474,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
             /**
              * The script resource name where available (or empty if not found)
              */
-            readonly source_url?: string;
+            source_url?: string;
             /**
              * The script function name where available (or empty if not found)
              */
@@ -486,7 +486,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
             /**
              * Information about the invoker of the script
              */
-            readonly invoker?: string;
+            invoker?: string;
             /**
              * Type of the invoker of the script
              */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -474,7 +474,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
             /**
              * The script resource name where available (or empty if not found)
              */
-            readonly source_url?: string;
+            source_url?: string;
             /**
              * The script function name where available (or empty if not found)
              */
@@ -486,7 +486,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
             /**
              * Information about the invoker of the script
              */
-            readonly invoker?: string;
+            invoker?: string;
             /**
              * Type of the invoker of the script
              */

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -120,8 +120,7 @@
                   },
                   "source_url": {
                     "type": "string",
-                    "description": "The script resource name where available (or empty if not found)",
-                    "readOnly": true
+                    "description": "The script resource name where available (or empty if not found)"
                   },
                   "source_function_name": {
                     "type": "string",
@@ -135,8 +134,7 @@
                   },
                   "invoker": {
                     "type": "string",
-                    "description": "Information about the invoker of the script",
-                    "readOnly": true
+                    "description": "Information about the invoker of the script"
                   },
                   "invoker_type": {
                     "type": "string",


### PR DESCRIPTION
We want to be able to modify source_url and invoker properties of Loaf script attributions from the beforeSend function. This allow customer to scrub urls for potential PII.

see: https://github.com/DataDog/browser-sdk/pull/3325