### PR TITLE
RUM-8098: time based configuration telemetry support

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -382,6 +382,14 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             is_main_process?: boolean;
             /**
+             * Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used
+             */
+            inv_time_threshold_ms?: number;
+            /**
+             * The interval in milliseconds during which all network requests will be considered as initial, i.e. caused by the creation of this view. Only sent if a time based strategy has been used
+             */
+            tns_time_threshold_ms?: number;
+            /**
              * The list of events that include feature flags collection. The tracking is always enabled for views and errors.
              */
             track_feature_flags_for_events?: ('vital' | 'resource' | 'action' | 'long_task')[];

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -382,6 +382,14 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             is_main_process?: boolean;
             /**
+             * Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used
+             */
+            inv_time_threshold_ms?: number;
+            /**
+             * The interval in milliseconds during which all network requests will be considered as initial, i.e. caused by the creation of this view. Only sent if a time based strategy has been used
+             */
+            tns_time_threshold_ms?: number;
+            /**
              * The list of events that include feature flags collection. The tracking is always enabled for views and errors.
              */
             track_feature_flags_for_events?: ('vital' | 'resource' | 'action' | 'long_task')[];

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -414,6 +414,14 @@
                   "type": "boolean",
                   "description": "Whether the SDK is initialised on the application's main or a secondary process"
                 },
+                "inv_time_threshold_ms": {
+                  "type": "integer",
+                  "description": "Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used"
+                },
+                "tns_time_threshold_ms": {
+                  "type": "integer",
+                  "description": "The interval in milliseconds during which all network requests will be considered as initial, i.e. caused by the creation of this view. Only sent if a time based strategy has been used"
+                },
                 "track_feature_flags_for_events": {
                   "type": "array",
                   "items": {


### PR DESCRIPTION
[Spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4534173727/RUM+View+Ended+Telemetry+-+Spec)

If the user selects a time-based strategy for TNS and INV events - thresholds are sent with the telemetry configuration event.