### PR TITLE
🐛 rename `vital.details` to `vital.description`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1116,9 +1116,9 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly name?: string;
         /**
-         * Details of the vital. It can be used as a secondary identifier (URL, React component name...)
+         * Description of the vital. It can be used as a secondary identifier (URL, React component name...)
          */
-        readonly details?: string;
+        readonly description?: string;
         /**
          * Duration of the vital in nanoseconds
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1116,9 +1116,9 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly name?: string;
         /**
-         * Details of the vital. It can be used as a secondary identifier (URL, React component name...)
+         * Description of the vital. It can be used as a secondary identifier (URL, React component name...)
          */
-        readonly details?: string;
+        readonly description?: string;
         /**
          * Duration of the vital in nanoseconds
          */

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -42,9 +42,9 @@
               "description": "Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $",
               "readOnly": true
             },
-            "details": {
+            "description": {
               "type": "string",
-              "description": "Details of the vital. It can be used as a secondary identifier (URL, React component name...)",
+              "description": "Description of the vital. It can be used as a secondary identifier (URL, React component name...)",
               "readOnly": true
             },
             "duration": {


### PR DESCRIPTION
## Motivation

`vital.details` have been renamed to `vital.description` for GA. `vital.details` should not be used anymore as it was never publicly exposed (it was implemented behind a feature flag)