### PR TITLE
Revert "[RUM-59] run browser-sdk e2e test"

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -7,17 +7,17 @@ jobs:
   browser-sdk-test:
     strategy:
       matrix:
-        test_type: [unit, 'e2e:ci']
+        test_type: [unit] # e2e should be added back, see RUMF-1551
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v3
         with:
           repository: 'DataDog/browser-sdk'
 
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+      - uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 20
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Reverts DataDog/rum-events-format#253 as it's seems e2e aren't passing anymore.