### PR TITLE
[RUM-59] run browser-sdk e2e test

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -11,13 +11,13 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: 'DataDog/browser-sdk'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
         with:
-          node-version: 20
+          node-version: 23
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -11,11 +11,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: 'DataDog/browser-sdk'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
         with:
           node-version: 22
 

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'DataDog/browser-sdk'
-          ref: 'thomas.lebeau/rum-event-format-e2e'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -31,4 +31,4 @@ jobs:
         run: eval $command_${{matrix.test_type}}
         env:
           command_unit: 'yarn test:unit'
-          command_e2e: 'yarn test:e2e:ci --workers "50%"'
+          command_e2e: 'yarn test:e2e:ci --workers 10'

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -7,17 +7,18 @@ jobs:
   browser-sdk-test:
     strategy:
       matrix:
-        test_type: [unit] # e2e should be added back, see RUMF-1551
+        test_type: [unit, 'e2e:ci']
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'DataDog/browser-sdk'
+          ref: 'thomas.lebeau/rum-event-format-e2e'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -7,7 +7,7 @@ jobs:
   browser-sdk-test:
     strategy:
       matrix:
-        test_type: [unit, 'e2e:ci']
+        test_type: [unit, e2e]
 
     runs-on: ubuntu-latest
     steps:
@@ -28,4 +28,7 @@ jobs:
           git checkout ${{ github.sha }}
 
       - name: Run ${{matrix.test_type}} tests
-        run: yarn test:${{matrix.test_type}}
+        run: eval $command_${{matrix.test_type}}
+        env:
+          command_unit: 'yarn test:unit'
+          command_e2e: 'yarn test:e2e:ci --workers "50%"'


### PR DESCRIPTION
Now that Datadog/browser-sdk has migrated to playwright, test are less flaky and faster, so we can run the e2e test again for each PR on this repo.

Second attempt: see #258, #253 