### PR TITLE
view-schema: update to include `cls:{device_pixel_ratio}` inside `_dd`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1050,6 +1050,16 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             [k: string]: unknown;
         };
         /**
+         * Additional information of the reported Cumulative Layout Shift
+         */
+        readonly cls?: {
+            /**
+             * Pixel ratio of the device where the layout shift was reported
+             */
+            readonly device_pixel_ratio?: number;
+            [k: string]: unknown;
+        };
+        /**
          * Subset of the SDK configuration options in use during its execution
          */
         readonly configuration?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1050,6 +1050,16 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             [k: string]: unknown;
         };
         /**
+         * Additional information of the reported Cumulative Layout Shift
+         */
+        readonly cls?: {
+            /**
+             * Pixel ratio of the device where the layout shift was reported
+             */
+            readonly device_pixel_ratio?: number;
+            [k: string]: unknown;
+        };
+        /**
          * Subset of the SDK configuration options in use during its execution
          */
         readonly configuration?: {

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -104,6 +104,9 @@
         "start": 1345678
       }
     ],
+    "cls": {
+      "device_pixel_ratio": 2
+    },
     "configuration": {
       "session_sample_rate": 12.45,
       "session_replay_sample_rate": 100,

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -463,6 +463,18 @@
                 }
               }
             },
+            "cls": {
+              "type": "object",
+              "description": "Additional information of the reported Cumulative Layout Shift",
+              "readOnly": true,
+              "properties": {
+                "device_pixel_ratio": {
+                  "type": "number",
+                  "description": "Pixel ratio of the device where the layout shift was reported",
+                  "readOnly": true
+                }
+              }
+            },
             "configuration": {
               "type": "object",
               "description": "Subset of the SDK configuration options in use during its execution",


### PR DESCRIPTION
We'd like to include devicePixelRatio information in `_dd`, inside a object `cls`. This way:
```
_dd :{
   ...
   ...
   cls? : {
      device_pixel_ratio: number
   }
}
```

In order to be able to move on with [this PR](https://github.com/DataDog/browser-sdk/pull/3389)
