### PR TITLE
Add more granular context APIs telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -423,7 +423,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | SetGlobalContext | SetUser | SetAccount | AddFeatureFlagEvaluation;
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
@@ -624,16 +624,58 @@ export interface AddError {
 }
 export interface SetGlobalContext {
     /**
-     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+     * setGlobalContext, addAttribute APIs
      */
     feature: 'set-global-context';
     [k: string]: unknown;
 }
+export interface SetGlobalContextProperty {
+    /**
+     * setGlobalContextProperty API
+     */
+    feature: 'set-global-context-property';
+    [k: string]: unknown;
+}
+export interface RemoveGlobalContextProperty {
+    /**
+     * removeGlobalContextProperty API
+     */
+    feature: 'remove-global-context-property';
+    [k: string]: unknown;
+}
+export interface ClearGlobalContext {
+    /**
+     * clearGlobalContext API
+     */
+    feature: 'clear-global-context';
+    [k: string]: unknown;
+}
 export interface SetUser {
     /**
-     * setUser, setUserProperty, setUserInfo APIs
+     * setUser, setUserInfo APIs
      */
     feature: 'set-user';
+    [k: string]: unknown;
+}
+export interface SetUserProperty {
+    /**
+     * setUserProperty API
+     */
+    feature: 'set-user-property';
+    [k: string]: unknown;
+}
+export interface RemoveUserProperty {
+    /**
+     * removeUserProperty API
+     */
+    feature: 'remove-user-property';
+    [k: string]: unknown;
+}
+export interface ClearUser {
+    /**
+     * clearUser API
+     */
+    feature: 'clear-user';
     [k: string]: unknown;
 }
 export interface SetAccount {
@@ -641,6 +683,27 @@ export interface SetAccount {
      * setAccount, setAccountProperty APIs
      */
     feature: 'set-account';
+    [k: string]: unknown;
+}
+export interface SetAccountProperty {
+    /**
+     * setAccountProperty API
+     */
+    feature: 'set-account-property';
+    [k: string]: unknown;
+}
+export interface RemoveAccountProperty {
+    /**
+     * removeAccountProperty API
+     */
+    feature: 'remove-account-property';
+    [k: string]: unknown;
+}
+export interface ClearAccount {
+    /**
+     * clearAccount API
+     */
+    feature: 'clear-account';
     [k: string]: unknown;
 }
 export interface AddFeatureFlagEvaluation {

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -423,7 +423,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation;
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
@@ -622,6 +622,13 @@ export interface AddError {
     feature: 'add-error';
     [k: string]: unknown;
 }
+export interface GetGlobalContext {
+    /**
+     * getGlobalContext API
+     */
+    feature: 'get-global-context';
+    [k: string]: unknown;
+}
 export interface SetGlobalContext {
     /**
      * setGlobalContext, addAttribute APIs
@@ -650,6 +657,13 @@ export interface ClearGlobalContext {
     feature: 'clear-global-context';
     [k: string]: unknown;
 }
+export interface GetUser {
+    /**
+     * getUser API
+     */
+    feature: 'get-user';
+    [k: string]: unknown;
+}
 export interface SetUser {
     /**
      * setUser, setUserInfo APIs
@@ -676,6 +690,13 @@ export interface ClearUser {
      * clearUser API
      */
     feature: 'clear-user';
+    [k: string]: unknown;
+}
+export interface GetAccount {
+    /**
+     * getAccount API
+     */
+    feature: 'get-account';
     [k: string]: unknown;
 }
 export interface SetAccount {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -423,7 +423,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | SetGlobalContext | SetUser | SetAccount | AddFeatureFlagEvaluation;
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
@@ -624,16 +624,58 @@ export interface AddError {
 }
 export interface SetGlobalContext {
     /**
-     * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+     * setGlobalContext, addAttribute APIs
      */
     feature: 'set-global-context';
     [k: string]: unknown;
 }
+export interface SetGlobalContextProperty {
+    /**
+     * setGlobalContextProperty API
+     */
+    feature: 'set-global-context-property';
+    [k: string]: unknown;
+}
+export interface RemoveGlobalContextProperty {
+    /**
+     * removeGlobalContextProperty API
+     */
+    feature: 'remove-global-context-property';
+    [k: string]: unknown;
+}
+export interface ClearGlobalContext {
+    /**
+     * clearGlobalContext API
+     */
+    feature: 'clear-global-context';
+    [k: string]: unknown;
+}
 export interface SetUser {
     /**
-     * setUser, setUserProperty, setUserInfo APIs
+     * setUser, setUserInfo APIs
      */
     feature: 'set-user';
+    [k: string]: unknown;
+}
+export interface SetUserProperty {
+    /**
+     * setUserProperty API
+     */
+    feature: 'set-user-property';
+    [k: string]: unknown;
+}
+export interface RemoveUserProperty {
+    /**
+     * removeUserProperty API
+     */
+    feature: 'remove-user-property';
+    [k: string]: unknown;
+}
+export interface ClearUser {
+    /**
+     * clearUser API
+     */
+    feature: 'clear-user';
     [k: string]: unknown;
 }
 export interface SetAccount {
@@ -641,6 +683,27 @@ export interface SetAccount {
      * setAccount, setAccountProperty APIs
      */
     feature: 'set-account';
+    [k: string]: unknown;
+}
+export interface SetAccountProperty {
+    /**
+     * setAccountProperty API
+     */
+    feature: 'set-account-property';
+    [k: string]: unknown;
+}
+export interface RemoveAccountProperty {
+    /**
+     * removeAccountProperty API
+     */
+    feature: 'remove-account-property';
+    [k: string]: unknown;
+}
+export interface ClearAccount {
+    /**
+     * clearAccount API
+     */
+    feature: 'clear-account';
     [k: string]: unknown;
 }
 export interface AddFeatureFlagEvaluation {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -423,7 +423,7 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation;
+export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation;
 /**
  * Schema of browser specific features usage
  */
@@ -622,6 +622,13 @@ export interface AddError {
     feature: 'add-error';
     [k: string]: unknown;
 }
+export interface GetGlobalContext {
+    /**
+     * getGlobalContext API
+     */
+    feature: 'get-global-context';
+    [k: string]: unknown;
+}
 export interface SetGlobalContext {
     /**
      * setGlobalContext, addAttribute APIs
@@ -650,6 +657,13 @@ export interface ClearGlobalContext {
     feature: 'clear-global-context';
     [k: string]: unknown;
 }
+export interface GetUser {
+    /**
+     * getUser API
+     */
+    feature: 'get-user';
+    [k: string]: unknown;
+}
 export interface SetUser {
     /**
      * setUser, setUserInfo APIs
@@ -676,6 +690,13 @@ export interface ClearUser {
      * clearUser API
      */
     feature: 'clear-user';
+    [k: string]: unknown;
+}
+export interface GetAccount {
+    /**
+     * getAccount API
+     */
+    feature: 'get-account';
     [k: string]: unknown;
 }
 export interface SetAccount {

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -115,8 +115,41 @@
       "properties": {
         "feature": {
           "type": "string",
-          "description": "setGlobalContext, setGlobalContextProperty, addAttribute APIs",
+          "description": "setGlobalContext, addAttribute APIs",
           "const": "set-global-context"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "SetGlobalContextProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setGlobalContextProperty API",
+          "const": "set-global-context-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "RemoveGlobalContextProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "removeGlobalContextProperty API",
+          "const": "remove-global-context-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "ClearGlobalContext",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "clearGlobalContext API",
+          "const": "clear-global-context"
         }
       }
     },
@@ -126,8 +159,41 @@
       "properties": {
         "feature": {
           "type": "string",
-          "description": "setUser, setUserProperty, setUserInfo APIs",
+          "description": "setUser, setUserInfo APIs",
           "const": "set-user"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "SetUserProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setUserProperty API",
+          "const": "set-user-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "RemoveUserProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "removeUserProperty API",
+          "const": "remove-user-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "ClearUser",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "clearUser API",
+          "const": "clear-user"
         }
       }
     },
@@ -139,6 +205,39 @@
           "type": "string",
           "description": "setAccount, setAccountProperty APIs",
           "const": "set-account"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "SetAccountProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setAccountProperty API",
+          "const": "set-account-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "RemoveAccountProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "removeAccountProperty API",
+          "const": "remove-account-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "ClearAccount",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "clearAccount API",
+          "const": "clear-account"
         }
       }
     },

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -111,6 +111,17 @@
     },
     {
       "required": ["feature"],
+      "title": "GetGlobalContext",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "getGlobalContext API",
+          "const": "get-global-context"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
       "title": "SetGlobalContext",
       "properties": {
         "feature": {
@@ -155,6 +166,17 @@
     },
     {
       "required": ["feature"],
+      "title": "GetUser",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "getUser API",
+          "const": "get-user"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
       "title": "SetUser",
       "properties": {
         "feature": {
@@ -194,6 +216,17 @@
           "type": "string",
           "description": "clearUser API",
           "const": "clear-user"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "GetAccount",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "getAccount API",
+          "const": "get-account"
         }
       }
     },


### PR DESCRIPTION
Better track the usage of context APIs: GetXXX, SetXXXProperty, RemoveXXXProperty, and ClearXXX.