### PR TITLE
RUM-9017: Add number of displays to configuration telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -252,6 +252,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             forward_errors_to_logs?: boolean;
             /**
+             * The number of displays available to the device
+             */
+            number_of_displays?: number;
+            /**
              * The console.* tracked
              */
             forward_console_logs?: string[] | 'all';

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -252,6 +252,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             forward_errors_to_logs?: boolean;
             /**
+             * The number of displays available to the device
+             */
+            number_of_displays?: number;
+            /**
              * The console.* tracked
              */
             forward_console_logs?: string[] | 'all';

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -232,6 +232,10 @@
                   "type": "boolean",
                   "description": "Whether console.error logs, uncaught exceptions and network errors are tracked"
                 },
+                "number_of_displays": {
+                  "type": "integer",
+                  "description": "The number of displays available to the device"
+                },
                 "forward_console_logs": {
                   "anyOf": [
                     {


### PR DESCRIPTION
Adds configuration telemetry for the number of displays available to a device. We will use this to determine the proportion of mobile devices having more than 1 display in order to prioritize supporting such a scenario.