### PR TITLE
Add bfCache tracking parameter in telemetry configuration

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -156,6 +156,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_long_task?: boolean;
             /**
+             * Whether views loaded from the bfcache are tracked
+             */
+            track_bfcache_views?: boolean;
+            /**
              * Whether a secure cross-site session cookie is used (deprecated)
              */
             use_cross_site_session_cookie?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -156,6 +156,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_long_task?: boolean;
             /**
+             * Whether views loaded from the bfcache are tracked
+             */
+            track_bfcache_views?: boolean;
+            /**
              * Whether a secure cross-site session cookie is used (deprecated)
              */
             use_cross_site_session_cookie?: boolean;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -39,6 +39,7 @@
       "track_session_across_subdomains": true,
       "track_resources": true,
       "track_long_task": true,
+      "track_bfcache_views": true,
       "use_cross_site_session_cookie": false,
       "use_secure_session_cookie": true,
       "session_persistence": "cookie",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -122,6 +122,11 @@
                   "description": "Whether long tasks are tracked",
                   "readOnly": false
                 },
+                "track_bfcache_views": {
+                  "type": "boolean",
+                  "description": "Whether views loaded from the bfcache are tracked",
+                  "readOnly": false
+                },
                 "use_cross_site_session_cookie": {
                   "type": "boolean",
                   "description": "Whether a secure cross-site session cookie is used (deprecated)"


### PR DESCRIPTION
Add the new tracking parameter for bfCache in rum event format telemetry

See [PR](https://github.com/DataDog/browser-sdk/pull/3527)