### PR TITLE
🔧 disable the rule 'boolean-prop-naming'

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,8 @@
+rulesets:
+  - typescript-best-practices:
+    rules:
+      # We have our own conventions about naming and following this rule advices would break
+      # consistency.
+      boolean-prop-naming:
+        ignore:
+          - '**'


### PR DESCRIPTION
## Motivation

[This](https://github.com/DataDog/rum-events-format/pull/268/files#r2086505522) kind of message is harmful. We have our own conventions about naming and following this rule advices would break consistency.

## Change

Disable this rule. We could also consider disabling static analysis altogether as we have our own linting in place.