### PR TITLE
RUM-9561 Update view schema to add accessibility attributes

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1007,6 +1007,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * Performance data. (Web Vitals, etc.)
          */
         performance?: ViewPerformanceData;
+        /**
+         * Accessibility properties of the view
+         */
+        accessibility?: ViewAccessibilityProperties;
         [k: string]: unknown;
     };
     /**
@@ -1738,5 +1742,95 @@ export interface RumRect {
      * The element's height
      */
     readonly height: number;
+    [k: string]: unknown;
+}
+/**
+ * Compact representation of accessibility features for a view
+ */
+export interface ViewAccessibilityProperties {
+    /**
+     * User’s preferred text scale relative to the default system size.
+     */
+    readonly text_size?: string;
+    /**
+     * Indicates whether a screen reader is currently active.
+     */
+    readonly screen_reader_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide bold text accessibility setting is enabled.
+     */
+    readonly bold_text_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide reduce transparency setting is enabled.
+     */
+    readonly reduce_transparency_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide reduce motion setting is enabled.
+     */
+    readonly reduce_motion_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide button shapes setting is enabled.
+     */
+    readonly button_shapes_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide color inversion setting is enabled.
+     */
+    readonly invert_colors_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide increase contrast setting is enabled.
+     */
+    readonly increase_contrast_enabled?: boolean;
+    /**
+     * Indicates whether an alternative input method like Switch Control or Switch Access is currently enabled.
+     */
+    readonly assistive_switch_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide AssistiveTouch feature is currently enabled.
+     */
+    readonly assistive_touch_enabled?: boolean;
+    /**
+     * Indicates whether the video autoplay setting is enabled in the system or application.
+     */
+    readonly video_autoplay_enabled?: boolean;
+    /**
+     * Indicates whether closed captioning is enabled for media playback.
+     */
+    readonly closed_captioning_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide mono audio setting is enabled.
+     */
+    readonly mono_audio_enabled?: boolean;
+    /**
+     * Indicates whether the Shake to Undo feature is enabled.
+     */
+    readonly shake_to_undo_enabled?: boolean;
+    /**
+     * Indicates whether the user prefers reduced animations or cross-fade transitions.
+     */
+    readonly reduced_animations_enabled?: boolean;
+    /**
+     * Indicates whether the system should differentiate interface elements without relying solely on color.
+     */
+    readonly should_differentiate_without_color?: boolean;
+    /**
+     * Indicates whether the device display is currently using grayscale mode.
+     */
+    readonly grayscale_enabled?: boolean;
+    /**
+     * Indicates whether the device is currently locked to a single app through Guided Access or Screen Pinning.
+     */
+    readonly single_app_mode_enabled?: boolean;
+    /**
+     * Indicates whether on/off switch labels are enabled in the system settings.
+     */
+    readonly on_off_switch_labels_enabled?: boolean;
+    /**
+     * Indicates whether the Speak Screen feature is enabled.
+     */
+    readonly speak_screen_enabled?: boolean;
+    /**
+     * Indicates whether the text-to-speech selection feature is enabled.
+     */
+    readonly speak_selection_enabled?: boolean;
     [k: string]: unknown;
 }

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1007,6 +1007,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * Performance data. (Web Vitals, etc.)
          */
         performance?: ViewPerformanceData;
+        /**
+         * Accessibility properties of the view
+         */
+        accessibility?: ViewAccessibilityProperties;
         [k: string]: unknown;
     };
     /**
@@ -1738,5 +1742,95 @@ export interface RumRect {
      * The element's height
      */
     readonly height: number;
+    [k: string]: unknown;
+}
+/**
+ * Compact representation of accessibility features for a view
+ */
+export interface ViewAccessibilityProperties {
+    /**
+     * User’s preferred text scale relative to the default system size.
+     */
+    readonly text_size?: string;
+    /**
+     * Indicates whether a screen reader is currently active.
+     */
+    readonly screen_reader_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide bold text accessibility setting is enabled.
+     */
+    readonly bold_text_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide reduce transparency setting is enabled.
+     */
+    readonly reduce_transparency_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide reduce motion setting is enabled.
+     */
+    readonly reduce_motion_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide button shapes setting is enabled.
+     */
+    readonly button_shapes_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide color inversion setting is enabled.
+     */
+    readonly invert_colors_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide increase contrast setting is enabled.
+     */
+    readonly increase_contrast_enabled?: boolean;
+    /**
+     * Indicates whether an alternative input method like Switch Control or Switch Access is currently enabled.
+     */
+    readonly assistive_switch_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide AssistiveTouch feature is currently enabled.
+     */
+    readonly assistive_touch_enabled?: boolean;
+    /**
+     * Indicates whether the video autoplay setting is enabled in the system or application.
+     */
+    readonly video_autoplay_enabled?: boolean;
+    /**
+     * Indicates whether closed captioning is enabled for media playback.
+     */
+    readonly closed_captioning_enabled?: boolean;
+    /**
+     * Indicates whether the system-wide mono audio setting is enabled.
+     */
+    readonly mono_audio_enabled?: boolean;
+    /**
+     * Indicates whether the Shake to Undo feature is enabled.
+     */
+    readonly shake_to_undo_enabled?: boolean;
+    /**
+     * Indicates whether the user prefers reduced animations or cross-fade transitions.
+     */
+    readonly reduced_animations_enabled?: boolean;
+    /**
+     * Indicates whether the system should differentiate interface elements without relying solely on color.
+     */
+    readonly should_differentiate_without_color?: boolean;
+    /**
+     * Indicates whether the device display is currently using grayscale mode.
+     */
+    readonly grayscale_enabled?: boolean;
+    /**
+     * Indicates whether the device is currently locked to a single app through Guided Access or Screen Pinning.
+     */
+    readonly single_app_mode_enabled?: boolean;
+    /**
+     * Indicates whether on/off switch labels are enabled in the system settings.
+     */
+    readonly on_off_switch_labels_enabled?: boolean;
+    /**
+     * Indicates whether the Speak Screen feature is enabled.
+     */
+    readonly speak_screen_enabled?: boolean;
+    /**
+     * Indicates whether the text-to-speech selection feature is enabled.
+     */
+    readonly speak_selection_enabled?: boolean;
     [k: string]: unknown;
 }

--- a/schemas/rum/_view-accessibility-schema.json
+++ b/schemas/rum/_view-accessibility-schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_view-accessibility-schema.json",
+  "title": "ViewAccessibilityProperties",
+  "type": "object",
+  "description": "Compact representation of accessibility features for a view",
+  "readOnly": true,
+  "properties": {
+    "text_size": {
+      "type": "string",
+      "description": "User’s preferred text scale relative to the default system size.",
+      "readOnly": true
+    },
+    "screen_reader_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether a screen reader is currently active.",
+      "readOnly": true
+    },
+    "bold_text_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide bold text accessibility setting is enabled.",
+      "readOnly": true
+    },
+    "reduce_transparency_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide reduce transparency setting is enabled.",
+      "readOnly": true
+    },
+    "reduce_motion_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide reduce motion setting is enabled.",
+      "readOnly": true
+    },
+    "button_shapes_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide button shapes setting is enabled.",
+      "readOnly": true
+    },
+    "invert_colors_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide color inversion setting is enabled.",
+      "readOnly": true
+    },
+    "increase_contrast_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide increase contrast setting is enabled.",
+      "readOnly": true
+    },
+    "assistive_switch_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether an alternative input method like Switch Control or Switch Access is currently enabled.",
+      "readOnly": true
+    },
+    "assistive_touch_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide AssistiveTouch feature is currently enabled.",
+      "readOnly": true
+    },
+    "video_autoplay_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the video autoplay setting is enabled in the system or application.",
+      "readOnly": true
+    },
+    "closed_captioning_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether closed captioning is enabled for media playback.",
+      "readOnly": true
+    },
+    "mono_audio_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the system-wide mono audio setting is enabled.",
+      "readOnly": true
+    },
+    "shake_to_undo_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the Shake to Undo feature is enabled.",
+      "readOnly": true
+    },
+    "reduced_animations_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the user prefers reduced animations or cross-fade transitions.",
+      "readOnly": true
+    },
+    "should_differentiate_without_color": {
+      "type": "boolean",
+      "description": "Indicates whether the system should differentiate interface elements without relying solely on color.",
+      "readOnly": true
+    },
+    "grayscale_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the device display is currently using grayscale mode.",
+      "readOnly": true
+    },
+    "single_app_mode_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the device is currently locked to a single app through Guided Access or Screen Pinning.",
+      "readOnly": true
+    },
+    "on_off_switch_labels_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether on/off switch labels are enabled in the system settings.",
+      "readOnly": true
+    },
+    "speak_screen_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the Speak Screen feature is enabled.",
+      "readOnly": true
+    },
+    "speak_selection_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the text-to-speech selection feature is enabled.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -397,6 +397,10 @@
             "performance": {
               "description": "Performance data. (Web Vitals, etc.)",
               "allOf": [{ "$ref": "_view-performance-schema.json" }]
+            },
+            "accessibility": {
+              "description": "Accessibility properties of the view",
+              "allOf": [{ "$ref": "_view-accessibility-schema.json" }]
             }
           },
           "readOnly": true


### PR DESCRIPTION
Adds new accessibility parameters to the RUM View schema.

- `text_size` - User’s preferred text scale relative to the default system size.
- `screen_reader_enabled` - Indicates whether a screen reader is currently active.
- `bold_text_enabled` - Indicates whether the system-wide bold text accessibility setting is enabled.
- `reduce_transparency_enabled` - Indicates whether the system-wide reduce transparency setting is enabled.
- `reduce_motion_enabled` - Indicates whether the system-wide reduce motion setting is enabled.
- `button_shapes_enabled` - Indicates whether the system-wide button shapes setting is enabled.
- `invert_colors_enabled` - Indicates whether the system-wide color inversion setting is enabled.
- `increase_contrast_enabled` - Indicates whether the system-wide increase contrast setting is enabled.
- `assistive_switch_enabled` - Indicates whether an alternative input method like Switch Control or Switch Access is currently enabled.
- `assistive_touch_enabled` - Indicates whether the system-wide AssistiveTouch feature is currently enabled.
- `is_video_autoplay_enabled` - Indicates whether the video autoplay setting is enabled in the system or application.
- `closed_captioning_enabled` - Indicates whether closed captioning is enabled for media playback.
- `mono_audio_enabled` - Indicates whether the system-wide mono audio setting is enabled.
- `shake_to_undo_enabled` - Indicates whether the Shake to Undo feature is enabled.
- `reduced_animations_enabled` - Indicates whether the user prefers reduced animations or cross-fade transitions.
- `should_differentiate_without_color` - Indicates whether the system should differentiate interface elements without relying solely on color.
- `grayscale_enabled` - Indicates whether the device display is currently using grayscale mode.
- `single_app_mode_enabled` - Indicates whether the device is currently locked to a single app through Guided Access or Screen Pinning.
- `on_off_switch_labels_enabled` - Indicates whether on/off switch labels are enabled in the system settings.
- `speak_screen_enabled` - Indicates whether the Speak Screen feature is enabled.
- `speak_selection_enabled` - Indicates whether the text-to-speech selection feature is enabled.