### PR TITLE
👷 add _dd.hidden_while_loading to view events

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1082,6 +1082,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             [k: string]: unknown;
         };
         /**
+         * Whether the view was hidden anytime during loading
+         */
+        readonly hidden_while_loading?: boolean;
+        /**
          * Subset of the SDK configuration options in use during its execution
          */
         readonly configuration?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1082,6 +1082,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             [k: string]: unknown;
         };
         /**
+         * Whether the view was hidden anytime during loading
+         */
+        readonly hidden_while_loading?: boolean;
+        /**
          * Subset of the SDK configuration options in use during its execution
          */
         readonly configuration?: {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -510,6 +510,11 @@
                 }
               }
             },
+            "hidden_while_loading": {
+              "type": "boolean",
+              "description": "Whether the view was hidden anytime during loading",
+              "readOnly": true
+            },
             "configuration": {
               "type": "object",
               "description": "Subset of the SDK configuration options in use during its execution",


### PR DESCRIPTION
The sdk discard loading time if the page was hidden at anytime during its loading. We would like to add this information to the event in order to differentiate it from other instances where loading time are missing for other reason.

Currently I'm suggesting `@view._dd.hidden_while_loading` but as this information could be valuable to the customers to understand why the loading time is missing for a particular view, we could consider make that property public (e.g. `@view.hidden_while_loading`)