### PR TITLE
[RUM-10223] Add locale and timezone information to `@device`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -999,6 +999,18 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * Performance data. (Web Vitals, etc.)
          */
         performance?: ViewPerformanceData;
+        /**
+         * Locale of the user at the time of the view
+         */
+        readonly locale?: string;
+        /**
+         * Locale of the user at the time of the view
+         */
+        locales?: string[];
+        /**
+         * Timezone of the user at the time of the view
+         */
+        readonly timezone?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1404,7 +1404,7 @@ export interface CommonProperties {
         /**
          * Device type info
          */
-        readonly type: 'mobile' | 'desktop' | 'tablet' | 'tv' | 'gaming_console' | 'bot' | 'other';
+        readonly type?: 'mobile' | 'desktop' | 'tablet' | 'tv' | 'gaming_console' | 'bot' | 'other';
         /**
          * Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.
          */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1121,24 +1121,6 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
-    /**
-     * Device properties
-     */
-    readonly device?: {
-        /**
-         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
-         */
-        readonly current_locale?: string;
-        /**
-         * Ordered list of the user’s preferred system languages as IETF language tags.
-         */
-        readonly locales?: unknown[];
-        /**
-         * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
-         */
-        readonly time_zone?: string;
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
@@ -1439,6 +1421,18 @@ export interface CommonProperties {
          * The CPU architecture of the device that is reporting the error
          */
         readonly architecture?: string;
+        /**
+         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
+         */
+        readonly current_locale?: string;
+        /**
+         * Ordered list of the user’s preferred system languages as IETF language tags.
+         */
+        readonly locales?: unknown[];
+        /**
+         * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
+         */
+        readonly time_zone?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1422,9 +1422,9 @@ export interface CommonProperties {
          */
         readonly architecture?: string;
         /**
-         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
+         * The user’s locale as a language tag combining language and region, e.g. 'en-US'.
          */
-        readonly current_locale?: string;
+        readonly locale?: string;
         /**
          * Ordered list of the user’s preferred system languages as IETF language tags.
          */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -999,18 +999,6 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * Performance data. (Web Vitals, etc.)
          */
         performance?: ViewPerformanceData;
-        /**
-         * Locale of the user at the time of the view
-         */
-        readonly locale?: string;
-        /**
-         * Locale of the user at the time of the view
-         */
-        locales?: string[];
-        /**
-         * Timezone of the user at the time of the view
-         */
-        readonly timezone?: string;
         [k: string]: unknown;
     };
     /**
@@ -1131,6 +1119,24 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             readonly max_scroll_height_time: number;
             [k: string]: unknown;
         };
+        [k: string]: unknown;
+    };
+    /**
+     * Device properties
+     */
+    readonly device?: {
+        /**
+         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
+         */
+        readonly current_locale?: string;
+        /**
+         * Ordered list of the user’s preferred system languages as IETF language tags.
+         */
+        readonly locales?: unknown[];
+        /**
+         * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
+         */
+        readonly time_zone?: string;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -999,6 +999,18 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * Performance data. (Web Vitals, etc.)
          */
         performance?: ViewPerformanceData;
+        /**
+         * Locale of the user at the time of the view
+         */
+        readonly locale?: string;
+        /**
+         * Locale of the user at the time of the view
+         */
+        locales?: string[];
+        /**
+         * Timezone of the user at the time of the view
+         */
+        readonly timezone?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1404,7 +1404,7 @@ export interface CommonProperties {
         /**
          * Device type info
          */
-        readonly type: 'mobile' | 'desktop' | 'tablet' | 'tv' | 'gaming_console' | 'bot' | 'other';
+        readonly type?: 'mobile' | 'desktop' | 'tablet' | 'tv' | 'gaming_console' | 'bot' | 'other';
         /**
          * Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1121,24 +1121,6 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
-    /**
-     * Device properties
-     */
-    readonly device?: {
-        /**
-         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
-         */
-        readonly current_locale?: string;
-        /**
-         * Ordered list of the user’s preferred system languages as IETF language tags.
-         */
-        readonly locales?: unknown[];
-        /**
-         * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
-         */
-        readonly time_zone?: string;
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
@@ -1439,6 +1421,18 @@ export interface CommonProperties {
          * The CPU architecture of the device that is reporting the error
          */
         readonly architecture?: string;
+        /**
+         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
+         */
+        readonly current_locale?: string;
+        /**
+         * Ordered list of the user’s preferred system languages as IETF language tags.
+         */
+        readonly locales?: unknown[];
+        /**
+         * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
+         */
+        readonly time_zone?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1422,9 +1422,9 @@ export interface CommonProperties {
          */
         readonly architecture?: string;
         /**
-         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
+         * The user’s locale as a language tag combining language and region, e.g. 'en-US'.
          */
-        readonly current_locale?: string;
+        readonly locale?: string;
         /**
          * Ordered list of the user’s preferred system languages as IETF language tags.
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -999,18 +999,6 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
          * Performance data. (Web Vitals, etc.)
          */
         performance?: ViewPerformanceData;
-        /**
-         * Locale of the user at the time of the view
-         */
-        readonly locale?: string;
-        /**
-         * Locale of the user at the time of the view
-         */
-        locales?: string[];
-        /**
-         * Timezone of the user at the time of the view
-         */
-        readonly timezone?: string;
         [k: string]: unknown;
     };
     /**
@@ -1131,6 +1119,24 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             readonly max_scroll_height_time: number;
             [k: string]: unknown;
         };
+        [k: string]: unknown;
+    };
+    /**
+     * Device properties
+     */
+    readonly device?: {
+        /**
+         * The user’s current locale as a language tag combining language and region, e.g. 'en-US'.
+         */
+        readonly current_locale?: string;
+        /**
+         * Ordered list of the user’s preferred system languages as IETF language tags.
+         */
+        readonly locales?: unknown[];
+        /**
+         * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
+         */
+        readonly time_zone?: string;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -125,7 +125,7 @@
     "name": "iPad",
     "model": "iPad",
     "brand": "Apple",
-    "current_locale": "en-US",
+    "locale": "en-US",
     "locales": ["en-US", "fr-FR"],
     "time_zone": "Europe/Paris"
   },

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -126,10 +126,7 @@
     "model": "iPad",
     "brand": "Apple",
     "current_locale": "en-US",
-    "locales": [
-      "en-US",
-      "fr-FR"
-    ],
+    "locales": ["en-US", "fr-FR"],
     "time_zone": "Europe/Paris"
   },
   "os": {

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -93,10 +93,7 @@
         "target_selector": "#foo",
         "resource_url": "https://example.com/foo.jpg"
       }
-    },
-    "locale": "en-US",
-    "locales": ["en-US", "fr-FR"],
-    "timezone": "Europe/Paris"
+    }
   },
   "_dd": {
     "document_version": 9,
@@ -127,7 +124,13 @@
     "type": "tablet",
     "name": "iPad",
     "model": "iPad",
-    "brand": "Apple"
+    "brand": "Apple",
+    "current_locale": "en-US",
+    "locales": [
+      "en-US",
+      "fr-FR"
+    ],
+    "time_zone": "Europe/Paris"
   },
   "os": {
     "name": "iOS",

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -93,7 +93,10 @@
         "target_selector": "#foo",
         "resource_url": "https://example.com/foo.jpg"
       }
-    }
+    },
+    "locale": "en-US",
+    "locales": ["en-US", "fr-FR"],
+    "timezone": "Europe/Paris"
   },
   "_dd": {
     "document_version": 9,

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -313,9 +313,9 @@
           "description": "The CPU architecture of the device that is reporting the error",
           "readOnly": true
         },
-        "current_locale": {
+        "locale": {
           "type": "string",
-          "description": "The user’s current locale as a language tag combining language and region, e.g. 'en-US'.",
+          "description": "The user’s locale as a language tag combining language and region, e.g. 'en-US'.",
           "readOnly": true
         },
         "locales": {

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -313,6 +313,21 @@
           "type": "string",
           "description": "The CPU architecture of the device that is reporting the error",
           "readOnly": true
+        },
+        "current_locale": {
+          "type": "string",
+          "description": "The user’s current locale as a language tag combining language and region, e.g. 'en-US'.",
+          "readOnly": true
+        },
+        "locales": {
+          "type": "array",
+          "description": "Ordered list of the user’s preferred system languages as IETF language tags.",
+          "readOnly": true
+        },
+        "time_zone": {
+          "type": "string",
+          "description": "The device’s current time zone identifier, e.g. 'Europe/Berlin'.",
+          "readOnly": true
         }
       }
     },

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -286,7 +286,6 @@
     "device": {
       "type": "object",
       "description": "Device properties",
-      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -559,28 +559,6 @@
               "readOnly": true
             }
           }
-        },
-        "device": {
-          "type": "object",
-          "description": "Device properties",
-          "readOnly": true,
-          "properties": {
-            "current_locale": {
-              "type": "string",
-              "description": "The user’s current locale as a language tag combining language and region, e.g. 'en-US'.",
-              "readOnly": true
-            },
-            "locales": {
-              "type": "array",
-              "description": "Ordered list of the user’s preferred system languages as IETF language tags.",
-              "readOnly": true
-            },
-            "time_zone": {
-              "type": "string",
-              "description": "The device’s current time zone identifier, e.g. 'Europe/Berlin'.",
-              "readOnly": true
-            }
-          }
         }
       }
     }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -397,23 +397,6 @@
             "performance": {
               "description": "Performance data. (Web Vitals, etc.)",
               "allOf": [{ "$ref": "_view-performance-schema.json" }]
-            },
-            "locale": {
-              "type": "string",
-              "description": "Locale of the user at the time of the view",
-              "readOnly": true
-            },
-            "locales": {
-              "type": "array",
-              "description": "Locale of the user at the time of the view",
-              "items": {
-                "type": "string"
-              }
-            },
-            "timezone": {
-              "type": "string",
-              "description": "Timezone of the user at the time of the view",
-              "readOnly": true
             }
           },
           "readOnly": true
@@ -573,6 +556,28 @@
                   "readOnly": true
                 }
               },
+              "readOnly": true
+            }
+          }
+        },
+        "device": {
+          "type": "object",
+          "description": "Device properties",
+          "readOnly": true,
+          "properties": {
+            "current_locale": {
+              "type": "string",
+              "description": "The user’s current locale as a language tag combining language and region, e.g. 'en-US'.",
+              "readOnly": true
+            },
+            "locales": {
+              "type": "array",
+              "description": "Ordered list of the user’s preferred system languages as IETF language tags.",
+              "readOnly": true
+            },
+            "time_zone": {
+              "type": "string",
+              "description": "The device’s current time zone identifier, e.g. 'Europe/Berlin'.",
               "readOnly": true
             }
           }

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -397,6 +397,23 @@
             "performance": {
               "description": "Performance data. (Web Vitals, etc.)",
               "allOf": [{ "$ref": "_view-performance-schema.json" }]
+            },
+            "locale": {
+              "type": "string",
+              "description": "Locale of the user at the time of the view",
+              "readOnly": true
+            },
+            "locales": {
+              "type": "array",
+              "description": "Locale of the user at the time of the view",
+              "items": {
+                "type": "string"
+              }
+            },
+            "timezone": {
+              "type": "string",
+              "description": "Timezone of the user at the time of the view",
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
# What

This PR adds `locale`, `locales` and `time_zone` to the `device` common field.

# Why

Most of our competitors collect locale and timezone information out-of-the-box. We want to give the same support.

> [!NOTE]
> I needed to remove the requirement from `type` because the browser is not currently sending any device data. Everything was computed in the backend. Now, we want to share only the locale and timezone details. 