### PR TITLE
fix: Update `resource._dd.trace_id` regex pattern

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -724,7 +724,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly span_id?: string;
         /**
-         * trace identifier in decimal format
+         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
          */
         readonly trace_id?: string;
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -724,7 +724,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly span_id?: string;
         /**
-         * trace identifier in decimal format
+         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
          */
         readonly trace_id?: string;
         /**

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -326,8 +326,8 @@
             },
             "trace_id": {
               "type": "string",
-              "description": "trace identifier in decimal format",
-              "pattern": "^[0-9]+$",
+              "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
+              "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
               "readOnly": true
             },
             "rule_psr": {


### PR DESCRIPTION
## What?

📦 This PR updates the regex pattern for `resource._dd.trace_id` to accept both decimal and hexadecimal formats.

## Why?

Originally, `trace_id` was restricted to decimal values. However, since `RUM-1827` introduced 128-bit trace IDs, we’ve adopted hexadecimal formatting across SDKs and the backend. This update ensures the schema reflects that change.