### PR TITLE
[RUM Profiler] Add Profiling context to Long Task, View and Configuration

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1536,17 +1536,22 @@ export interface ProfilingInternalContextSchema {
      *
      * They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
      *
-     * - `not-available-in-slim-bundle`: The Profiler is not available in the slim bundle. Use the normal bundle to use the Profiler.
-     * - `initializing`: The Profiler is initializing (i.e., when the SDK just started). This is the initial status.
-     * - `missing-feature`: Missing `profiling` value in the `enableExperimentalFeatures` options.
-     * - `not-sampled`: The view was not sampled (i.e., when the sample rate is lower than 100%, there is a chance the view won't be profiled).
-     * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-     * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-     * - `failed-to-start`: The Profiler failed to start (most probable cause is when the web server did not return the `Document-Policy: js-profiling` HTTP response header).
+     * - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
      * - `running`: The Profiler is running.
      * - `stopped`: The Profiler is stopped.
+     * - `error`: The Profiler encountered an error. See `error_reason` for more details.
      */
-    readonly status?: 'not-available-in-slim-bundle' | 'initializing' | 'missing-feature' | 'not-sampled' | 'not-supported-by-browser' | 'failed-to-lazy-load' | 'failed-to-start' | 'running' | 'stopped';
+    readonly status?: 'starting' | 'running' | 'stopped' | 'error';
+    /**
+     * The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+     *
+     * Possible values:
+     * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+     * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+     * - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+     * - `unexpected-exception`: An exception occurred when starting the Profiler.
+     */
+    readonly error_reason?: 'not-supported-by-browser' | 'failed-to-lazy-load' | 'missing-document-policy-header' | 'unexpected-exception';
     [k: string]: unknown;
 }
 /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -507,6 +507,10 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
          * Whether the long task should be discarded or indexed
          */
         readonly discarded?: boolean;
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -1091,6 +1095,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             readonly start_session_replay_recording_manually?: boolean;
             [k: string]: unknown;
         };
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     /**
@@ -1457,6 +1465,10 @@ export interface CommonProperties {
              * The percentage of sessions with RUM & Session Replay pricing tracked
              */
             readonly session_replay_sample_rate?: number;
+            /**
+             * The percentage of views profiled
+             */
+            readonly profiling_sample_rate?: number;
             [k: string]: unknown;
         };
         /**
@@ -1513,6 +1525,28 @@ export interface ActionChildProperties {
         readonly id: string | string[];
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/**
+ * RUM Profiler Internal Context schema
+ */
+export interface ProfilingInternalContextSchema {
+    /**
+     * Used to track the status of the RUM Profiler.
+     *
+     * They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+     *
+     * - `not-available-in-slim-bundle`: The Profiler is not available in the slim bundle. Use the normal bundle to use the Profiler.
+     * - `initializing`: The Profiler is initializing (i.e., when the SDK just started). This is the initial status.
+     * - `missing-feature`: Missing `profiling` value in the `enableExperimentalFeatures` options.
+     * - `not-sampled`: The view was not sampled (i.e., when the sample rate is lower than 100%, there is a chance the view won't be profiled).
+     * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+     * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+     * - `failed-to-start`: The Profiler failed to start (most probable cause is when the web server did not return the `Document-Policy: js-profiling` HTTP response header).
+     * - `running`: The Profiler is running.
+     * - `stopped`: The Profiler is stopped.
+     */
+    readonly status?: 'not-available-in-slim-bundle' | 'initializing' | 'missing-feature' | 'not-sampled' | 'not-supported-by-browser' | 'failed-to-lazy-load' | 'failed-to-start' | 'running' | 'stopped';
     [k: string]: unknown;
 }
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1536,17 +1536,22 @@ export interface ProfilingInternalContextSchema {
      *
      * They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
      *
-     * - `not-available-in-slim-bundle`: The Profiler is not available in the slim bundle. Use the normal bundle to use the Profiler.
-     * - `initializing`: The Profiler is initializing (i.e., when the SDK just started). This is the initial status.
-     * - `missing-feature`: Missing `profiling` value in the `enableExperimentalFeatures` options.
-     * - `not-sampled`: The view was not sampled (i.e., when the sample rate is lower than 100%, there is a chance the view won't be profiled).
-     * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-     * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-     * - `failed-to-start`: The Profiler failed to start (most probable cause is when the web server did not return the `Document-Policy: js-profiling` HTTP response header).
+     * - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
      * - `running`: The Profiler is running.
      * - `stopped`: The Profiler is stopped.
+     * - `error`: The Profiler encountered an error. See `error_reason` for more details.
      */
-    readonly status?: 'not-available-in-slim-bundle' | 'initializing' | 'missing-feature' | 'not-sampled' | 'not-supported-by-browser' | 'failed-to-lazy-load' | 'failed-to-start' | 'running' | 'stopped';
+    readonly status?: 'starting' | 'running' | 'stopped' | 'error';
+    /**
+     * The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+     *
+     * Possible values:
+     * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+     * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+     * - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+     * - `unexpected-exception`: An exception occurred when starting the Profiler.
+     */
+    readonly error_reason?: 'not-supported-by-browser' | 'failed-to-lazy-load' | 'missing-document-policy-header' | 'unexpected-exception';
     [k: string]: unknown;
 }
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -507,6 +507,10 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
          * Whether the long task should be discarded or indexed
          */
         readonly discarded?: boolean;
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -1091,6 +1095,10 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & {
             readonly start_session_replay_recording_manually?: boolean;
             [k: string]: unknown;
         };
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     /**
@@ -1457,6 +1465,10 @@ export interface CommonProperties {
              * The percentage of sessions with RUM & Session Replay pricing tracked
              */
             readonly session_replay_sample_rate?: number;
+            /**
+             * The percentage of views profiled
+             */
+            readonly profiling_sample_rate?: number;
             [k: string]: unknown;
         };
         /**
@@ -1513,6 +1525,28 @@ export interface ActionChildProperties {
         readonly id: string | string[];
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/**
+ * RUM Profiler Internal Context schema
+ */
+export interface ProfilingInternalContextSchema {
+    /**
+     * Used to track the status of the RUM Profiler.
+     *
+     * They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+     *
+     * - `not-available-in-slim-bundle`: The Profiler is not available in the slim bundle. Use the normal bundle to use the Profiler.
+     * - `initializing`: The Profiler is initializing (i.e., when the SDK just started). This is the initial status.
+     * - `missing-feature`: Missing `profiling` value in the `enableExperimentalFeatures` options.
+     * - `not-sampled`: The view was not sampled (i.e., when the sample rate is lower than 100%, there is a chance the view won't be profiled).
+     * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+     * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+     * - `failed-to-start`: The Profiler failed to start (most probable cause is when the web server did not return the `Document-Policy: js-profiling` HTTP response header).
+     * - `running`: The Profiler is running.
+     * - `stopped`: The Profiler is stopped.
+     */
+    readonly status?: 'not-available-in-slim-bundle' | 'initializing' | 'missing-feature' | 'not-sampled' | 'not-supported-by-browser' | 'failed-to-lazy-load' | 'failed-to-start' | 'running' | 'stopped';
     [k: string]: unknown;
 }
 /**

--- a/samples/rum-events/long_task.json
+++ b/samples/rum-events/long_task.json
@@ -21,10 +21,11 @@
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
-  "profiling": {
-    "status": "running"
-  },
+
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "profiling": {
+      "status": "running"
+    }
   }
 }

--- a/samples/rum-events/long_task.json
+++ b/samples/rum-events/long_task.json
@@ -21,6 +21,9 @@
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
+  "profiling": {
+    "status": "running"
+  },
   "_dd": {
     "format_version": 2
   }

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -111,6 +111,9 @@
       "session_sample_rate": 12.45,
       "session_replay_sample_rate": 100,
       "start_session_replay_recording_manually": true
+    },
+    "profiling": {
+      "status": "running"
     }
   },
   "synthetics": {

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -371,6 +371,13 @@
               "minimum": 0,
               "maximum": 100,
               "readOnly": true
+            },
+            "profiling_sample_rate": {
+              "type": "number",
+              "description": "The percentage of views profiled",
+              "minimum": 0,
+              "maximum": 100,
+              "readOnly": true
             }
           }
         },

--- a/schemas/rum/_profiling-internal-context-schema.json
+++ b/schemas/rum/_profiling-internal-context-schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "rum/_profiling-schema.json",
-  "title": "ProfilingSchema",
+  "$id": "rum/_profiling-internal-context-schema.json",
+  "title": "ProfilingInternalContextSchema",
   "type": "object",
-  "description": "Profiling schema for the RUM Profiler",
+  "description": "RUM Profiler Internal Context schema",
   "properties": {
     "status": {
       "type": "string",

--- a/schemas/rum/_profiling-internal-context-schema.json
+++ b/schemas/rum/_profiling-internal-context-schema.json
@@ -7,17 +7,18 @@
   "properties": {
     "status": {
       "type": "string",
-      "description": "Used to track the status of the RUM Profiler.\n\nThey are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.\n\n- `not-available-in-slim-bundle`: The Profiler is not available in the slim bundle. Use the normal bundle to use the Profiler.\n- `initializing`: The Profiler is initializing (i.e., when the SDK just started). This is the initial status.\n- `missing-feature`: Missing `profiling` value in the `enableExperimentalFeatures` options.\n- `not-sampled`: The view was not sampled (i.e., when the sample rate is lower than 100%, there is a chance the view won't be profiled).\n- `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).\n- `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).\n- `failed-to-start`: The Profiler failed to start (most probable cause is when the web server did not return the `Document-Policy: js-profiling` HTTP response header).\n- `running`: The Profiler is running.\n- `stopped`: The Profiler is stopped.",
+      "description": "Used to track the status of the RUM Profiler.\n\nThey are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.\n\n- `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.\n- `running`: The Profiler is running.\n- `stopped`: The Profiler is stopped.\n- `error`: The Profiler encountered an error. See `error_reason` for more details.",
+      "enum": ["starting", "running", "stopped", "error"],
+      "readOnly": true
+    },
+    "error_reason": {
+      "type": "string",
+      "description": "The reason the Profiler encountered an error. This attribute is only present if the status is `error`.\n\nPossible values:\n- `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).\n- `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).\n- `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.\n- `unexpected-exception`: An exception occurred when starting the Profiler.",
       "enum": [
-        "not-available-in-slim-bundle",
-        "initializing",
-        "missing-feature",
-        "not-sampled",
         "not-supported-by-browser",
         "failed-to-lazy-load",
-        "failed-to-start",
-        "running",
-        "stopped"
+        "missing-document-policy-header",
+        "unexpected-exception"
       ],
       "readOnly": true
     }

--- a/schemas/rum/_profiling-schema.json
+++ b/schemas/rum/_profiling-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_profiling-schema.json",
+  "title": "ProfilingSchema",
+  "type": "object",
+  "description": "Profiling schema for the RUM Profiler",
+  "properties": {
+    "status": {
+      "type": "string",
+      "description": "Used to track the status of the RUM Profiler.\n\nThey are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.\n\n- `not-available-in-slim-bundle`: The Profiler is not available in the slim bundle. Use the normal bundle to use the Profiler.\n- `initializing`: The Profiler is initializing (i.e., when the SDK just started). This is the initial status.\n- `missing-feature`: Missing `profiling` value in the `enableExperimentalFeatures` options.\n- `not-sampled`: The view was not sampled (i.e., when the sample rate is lower than 100%, there is a chance the view won't be profiled).\n- `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).\n- `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).\n- `failed-to-start`: The Profiler failed to start (most probable cause is when the web server did not return the `Document-Policy: js-profiling` HTTP response header).\n- `running`: The Profiler is running.\n- `stopped`: The Profiler is stopped.",
+      "enum": [
+        "not-available-in-slim-bundle",
+        "initializing",
+        "missing-feature",
+        "not-sampled",
+        "not-supported-by-browser",
+        "failed-to-lazy-load",
+        "failed-to-start",
+        "running",
+        "stopped"
+      ],
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -16,9 +16,6 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "$ref": "_profiling-schema.json"
-    },
-    {
       "required": ["type", "long_task"],
       "properties": {
         "type": {
@@ -172,6 +169,11 @@
               "type": "boolean",
               "description": "Whether the long task should be discarded or indexed",
               "readOnly": true
+            },
+            "profiling": {
+              "type": "object",
+              "description": "Profiling context",
+              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
             }
           },
           "readOnly": true

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -16,6 +16,9 @@
       "$ref": "_view-container-schema.json"
     },
     {
+      "$ref": "_profiling-schema.json"
+    },
+    {
       "required": ["type", "long_task"],
       "properties": {
         "type": {

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -12,9 +12,6 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "$ref": "_profiling-schema.json"
-    },
-    {
       "required": ["type", "view", "_dd"],
       "properties": {
         "type": {
@@ -524,6 +521,11 @@
                   "readOnly": true
                 }
               }
+            },
+            "profiling": {
+              "type": "object",
+              "description": "Profiling context",
+              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
             }
           },
           "readOnly": true

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -12,6 +12,9 @@
       "$ref": "_view-container-schema.json"
     },
     {
+      "$ref": "_profiling-schema.json"
+    },
+    {
       "required": ["type", "view", "_dd"],
       "properties": {
         "type": {


### PR DESCRIPTION
- new `profiling_sample_rate` in the `configuration` field. 
- new `_dd.profiling` field to hold all the RUM Profiler internal context we need (following the accepted [RFC](https://docs.google.com/document/d/1MW9Wkje5HJb_2T8HtG5z9plY77Wm_bHAijhooktJiMw/edit?pli=1&tab=t.0))

They will be set in https://github.com/DataDog/browser-sdk/pull/3583 (more context there).

In a nutshell, these fields will help us show users why there is no Profiling data for certain Long Tasks. 