### PR TITLE
[RUM] Add new `_dd.sdk_name` attribute

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1463,6 +1463,10 @@ export interface CommonProperties {
          * Browser SDK version
          */
         readonly browser_sdk_version?: string;
+        /**
+         * SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
+         */
+        readonly sdk_name?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1463,6 +1463,10 @@ export interface CommonProperties {
          * Browser SDK version
          */
         readonly browser_sdk_version?: string;
+        /**
+         * SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
+         */
+        readonly sdk_name?: string;
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -378,6 +378,11 @@
           "type": "string",
           "description": "Browser SDK version",
           "readOnly": true
+        },
+        "sdk_name": {
+          "type": "string",
+          "description": "SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)",
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
### Goal

- Being able to identify what kind of SDK is responsible for the event. 

### How it's useful

- For the RUM Profiler, it's useful to know if we are on the _slim_ version of the SDK, to let users know why there  is no profile, and how they can activate the RUM Profiler by switching to the full _rum_ SDK.
- For Session Replay, it can used to the same extent as well.

### How

New `_dd.sdk_name` with potential values `rum-slim`, `rum` or `logs`. 
