### PR TITLE
RUM-9540: Introduce `Network` in `@error.category`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -216,7 +216,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * The specific category of the error. It provides a high-level grouping for different types of errors.
          */
-        readonly category?: 'ANR' | 'App Hang' | 'Exception' | 'Watchdog Termination' | 'Memory Warning';
+        readonly category?: 'ANR' | 'App Hang' | 'Exception' | 'Watchdog Termination' | 'Memory Warning' | 'Network';
         /**
          * Whether the error has been handled manually in the source code or not
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -216,7 +216,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
         /**
          * The specific category of the error. It provides a high-level grouping for different types of errors.
          */
-        readonly category?: 'ANR' | 'App Hang' | 'Exception' | 'Watchdog Termination' | 'Memory Warning';
+        readonly category?: 'ANR' | 'App Hang' | 'Exception' | 'Watchdog Termination' | 'Memory Warning' | 'Network';
         /**
          * Whether the error has been handled manually in the source code or not
          */

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -101,7 +101,7 @@
             "category": {
               "type": "string",
               "description": "The specific category of the error. It provides a high-level grouping for different types of errors.",
-              "enum": ["ANR", "App Hang", "Exception", "Watchdog Termination", "Memory Warning"],
+              "enum": ["ANR", "App Hang", "Exception", "Watchdog Termination", "Memory Warning", "Network"],
               "readOnly": true
             },
             "handling": {


### PR DESCRIPTION
This PR adds a new category, `Network`, to the [@error.category](https://github.com/DataDog/rum-events-format/blob/81c3d7401cba2a2faf48b5f4c0e8aca05c759662/schemas/rum/error-schema.json#L104).

This is an addition to the error category to filter out all network errors (no connection, connection cancelled, etc).