### PR TITLE
RUM-10377 Add battery attributes

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1441,6 +1441,18 @@ export interface CommonProperties {
          * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
          */
         readonly time_zone?: string;
+        /**
+         * Current battery level of the device (0.0 to 1.0).
+         */
+        readonly battery_level?: number;
+        /**
+         * Whether the device is in power saving mode.
+         */
+        readonly power_saving_mode?: boolean;
+        /**
+         * Current screen brightness level (0.0 to 1.0).
+         */
+        readonly brightness_level?: number;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1441,6 +1441,18 @@ export interface CommonProperties {
          * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
          */
         readonly time_zone?: string;
+        /**
+         * Current battery level of the device (0.0 to 1.0).
+         */
+        readonly battery_level?: number;
+        /**
+         * Whether the device is in power saving mode.
+         */
+        readonly power_saving_mode?: boolean;
+        /**
+         * Current screen brightness level (0.0 to 1.0).
+         */
+        readonly brightness_level?: number;
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -330,6 +330,21 @@
           "type": "string",
           "description": "The device’s current time zone identifier, e.g. 'Europe/Berlin'.",
           "readOnly": true
+        },
+        "battery_level": {
+          "type": "number",
+          "description": "Current battery level of the device (0.0 to 1.0).",
+          "readOnly": true
+        },
+        "power_saving_mode": {
+          "type": "boolean",
+          "description": "Whether the device is in power saving mode.",
+          "readOnly": true
+        },
+        "brightness_level": {
+          "type": "number",
+          "description": "Current screen brightness level (0.0 to 1.0).",
+          "readOnly": true
         }
       }
     },


### PR DESCRIPTION
Add battery related attributes:
- `battery_level`: Current battery level of the device (0.0 to 1.0)
- `power_saving_mode`: Whether the device is in power saving mode
- `brightness_level`: Current screen brightness level (0.0 to 1.0)