### PR TITLE
Add parent span id to RUM Resource

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -728,6 +728,10 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly span_id?: string;
         /**
+         * parent span identifier in decimal format
+         */
+        readonly parent_span_id?: string;
+        /**
          * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
          */
         readonly trace_id?: string;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -728,6 +728,10 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
          */
         readonly span_id?: string;
         /**
+         * parent span identifier in decimal format
+         */
+        readonly parent_span_id?: string;
+        /**
          * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
          */
         readonly trace_id?: string;

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -47,6 +47,7 @@
   "_dd": {
     "format_version": 2,
     "span_id": "12345",
+    "parent_span_id": "67890",
     "trace_id": "7890"
   }
 }

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -324,6 +324,12 @@
               "pattern": "^[0-9]+$",
               "readOnly": true
             },
+            "parent_span_id": {
+              "type": "string",
+              "description": "parent span identifier in decimal format",
+              "pattern": "^[0-9]+$",
+              "readOnly": true
+            },
             "trace_id": {
               "type": "string",
               "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",


### PR DESCRIPTION
Adds parent span id parameter that will enable SDKs to provide API for setting the parent span for a RUM resource.

Requires changes on the backend to work.

Additional context:
- Related "bug" https://datadoghq.atlassian.net/browse/RUM-8084
- It's part of the KR `Connect Native Mobile traces to RUM generated resource spans`