### PR TITLE
RUM-10435 Add current locale

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1205,6 +1205,10 @@ export interface CommonProperties {
          * UUID of the application
          */
         readonly id: string;
+        /**
+         * The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+         */
+        readonly current_locale?: string;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1205,6 +1205,10 @@ export interface CommonProperties {
          * UUID of the application
          */
         readonly id: string;
+        /**
+         * The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+         */
+        readonly current_locale?: string;
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -22,6 +22,11 @@
           "description": "UUID of the application",
           "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
           "readOnly": true
+        },
+        "current_locale": {
+          "type": "string",
+          "description": "The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.",
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
Add the following attribute into `application` namespace:
- `current_locale`: The user’s current locale as a language tag (language + region), computed from their preferences and the app’s supported languages, e.g. 'es-FR'.