### PR TITLE
👷 Remove unused vital.custom field in favor of duration vital

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1176,12 +1176,6 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly duration?: number;
         /**
-         * User custom vital. (This field is deprecated in favor of `duration`)
-         */
-        readonly custom?: {
-            [k: string]: number;
-        };
-        /**
          * Type of the step that triggered the vital, if applicable
          */
         readonly step_type?: 'start' | 'update' | 'retry' | 'end';

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1176,7 +1176,7 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly duration?: number;
         /**
-         * User custom vital.
+         * User custom vital. (This field is deprecated in favor of `duration`)
          */
         readonly custom?: {
             [k: string]: number;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1176,12 +1176,6 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly duration?: number;
         /**
-         * User custom vital. (This field is deprecated in favor of `duration`)
-         */
-        readonly custom?: {
-            [k: string]: number;
-        };
-        /**
          * Type of the step that triggered the vital, if applicable
          */
         readonly step_type?: 'start' | 'update' | 'retry' | 'end';

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1176,7 +1176,7 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
          */
         readonly duration?: number;
         /**
-         * User custom vital.
+         * User custom vital. (This field is deprecated in favor of `duration`)
          */
         readonly custom?: {
             [k: string]: number;

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -58,17 +58,6 @@
               "description": "Duration of the vital in nanoseconds",
               "readOnly": true
             },
-            "custom": {
-              "type": "object",
-              "description": "User custom vital. (This field is deprecated in favor of `duration`)",
-              "deprecated": true,
-              "additionalProperties": {
-                "type": "number",
-                "minimum": 0,
-                "readOnly": true
-              },
-              "readOnly": true
-            },
             "step_type": {
               "type": "string",
               "description": "Type of the step that triggered the vital, if applicable",

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -60,7 +60,8 @@
             },
             "custom": {
               "type": "object",
-              "description": "User custom vital.",
+              "description": "User custom vital. (This field is deprecated in favor of `duration`)",
+              "deprecated": true,
               "additionalProperties": {
                 "type": "number",
                 "minimum": 0,


### PR DESCRIPTION
`vital.custom` field is no longer used in browser SDK and never used after GA. For future clarity, we should remove it.