### PR TITLE
[RUM-10044] ✨ add new configuration parameters to telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -417,6 +417,18 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether a list of allowed origins is used to control SDK execution in browser extension contexts. When enabled, the SDK will check if the current origin matches the allowed origins list before running.
              */
             use_allowed_tracking_origins?: boolean;
+            /**
+             * The version of the SDK that is running.
+             */
+            sdk_version?: string;
+            /**
+             * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+             */
+            source?: string;
+            /**
+             * The variant of the SDK build (e.g., standard, lite, etc.).
+             */
+            variant?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -417,6 +417,18 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether a list of allowed origins is used to control SDK execution in browser extension contexts. When enabled, the SDK will check if the current origin matches the allowed origins list before running.
              */
             use_allowed_tracking_origins?: boolean;
+            /**
+             * The version of the SDK that is running.
+             */
+            sdk_version?: string;
+            /**
+             * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+             */
+            source?: string;
+            /**
+             * The variant of the SDK build (e.g., standard, lite, etc.).
+             */
+            variant?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -460,6 +460,21 @@
                   "description": "Whether a list of allowed origins is used to control SDK execution in browser extension contexts. When enabled, the SDK will check if the current origin matches the allowed origins list before running.",
                   "readOnly": false,
                   "default": false
+                },
+                "sdk_version": {
+                  "type": "string",
+                  "description": "The version of the SDK that is running.",
+                  "readOnly": false
+                },
+                "source": {
+                  "type": "string",
+                  "description": "The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.",
+                  "readOnly": false
+                },
+                "variant": {
+                  "type": "string",
+                  "description": "The variant of the SDK build (e.g., standard, lite, etc.).",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
We implemented overridable fields for cross platform extensions in the Browser SDK. We want to report those fields as part of the telemetry events.