### PR TITLE
[RUM-11389] Add telemetry collection of operation step vital usage

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -463,7 +463,7 @@ export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSess
 /**
  * Schema of browser specific features usage
  */
-export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
+export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | AddOperationStepVital;
 /**
  * Schema of mobile specific features usage
  */
@@ -800,6 +800,13 @@ export interface AddDurationVital {
      * addDurationVital API
      */
     feature: 'add-duration-vital';
+    [k: string]: unknown;
+}
+export interface AddOperationStepVital {
+    /**
+     * addOperationStepVital API
+     */
+    feature: 'add-operation-step-vital';
     [k: string]: unknown;
 }
 export interface AddViewLoadingTime {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -463,7 +463,7 @@ export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSess
 /**
  * Schema of browser specific features usage
  */
-export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
+export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | AddOperationStepVital;
 /**
  * Schema of mobile specific features usage
  */
@@ -800,6 +800,13 @@ export interface AddDurationVital {
      * addDurationVital API
      */
     feature: 'add-duration-vital';
+    [k: string]: unknown;
+}
+export interface AddOperationStepVital {
+    /**
+     * addOperationStepVital API
+     */
+    feature: 'add-operation-step-vital';
     [k: string]: unknown;
 }
 export interface AddViewLoadingTime {

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -52,6 +52,17 @@
           "const": "add-duration-vital"
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "title": "AddOperationStepVital",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "addOperationStepVital API",
+          "const": "add-operation-step-vital"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
For early preview purpose, we want to collect the usage telemetry for operation step vitals.

Telemetry example:
To mark feature for `succeedOperationStep`, we can `addTelemetryUsage({ feature: 'add-operation-step-vital', step: 'succeed' })`