### PR TITLE
🔧 add missing configuration values to telemetry schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -433,6 +433,18 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The id of the remote configuration
              */
             remote_configuration_id?: string;
+            /**
+             * Whether a proxy is used for remote configuration
+             */
+            use_remote_configuration_proxy?: boolean;
+            /**
+             * The percentage of sessions with Profiling enabled
+             */
+            profiling_sample_rate?: number;
+            /**
+             * Whether trace baggage is propagated to child spans
+             */
+            propagate_trace_baggage?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -433,6 +433,18 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * The id of the remote configuration
              */
             remote_configuration_id?: string;
+            /**
+             * Whether a proxy is used for remote configuration
+             */
+            use_remote_configuration_proxy?: boolean;
+            /**
+             * The percentage of sessions with Profiling enabled
+             */
+            profiling_sample_rate?: number;
+            /**
+             * Whether trace baggage is propagated to child spans
+             */
+            propagate_trace_baggage?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -480,6 +480,23 @@
                   "type": "string",
                   "description": "The id of the remote configuration",
                   "readOnly": false
+                },
+                "use_remote_configuration_proxy": {
+                  "type": "boolean",
+                  "description": "Whether a proxy is used for remote configuration",
+                  "readOnly": false
+                },
+                "profiling_sample_rate": {
+                  "type": "number",
+                  "description": "The percentage of sessions with Profiling enabled",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "readOnly": false
+                },
+                "propagate_trace_baggage": {
+                  "type": "boolean",
+                  "description": "Whether trace baggage is propagated to child spans",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
Some configuration values are not reported in telemetry. They have been excluded [here](https://github.com/DataDog/browser-sdk/blob/7abddf95860e10d771626e0ef3444aefa02f5b3e/packages/rum-core/src/domain/configuration/configuration.spec.ts#L556-L559) but I don't see why we shouldn't collect them.