### PR TITLE
✨ add `none` session persistence

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -178,7 +178,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Configure the storage strategy for persisting sessions
              */
-            session_persistence?: 'local-storage' | 'cookie';
+            session_persistence?: 'local-storage' | 'cookie' | 'none';
             /**
              * Whether contexts are stored in local storage
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -178,7 +178,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Configure the storage strategy for persisting sessions
              */
-            session_persistence?: 'local-storage' | 'cookie';
+            session_persistence?: 'local-storage' | 'cookie' | 'none';
             /**
              * Whether contexts are stored in local storage
              */

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -145,7 +145,7 @@
                 },
                 "session_persistence": {
                   "type": "string",
-                  "enum": ["local-storage", "cookie"],
+                  "enum": ["local-storage", "cookie", "none"],
                   "description": "Configure the storage strategy for persisting sessions"
                 },
                 "store_contexts_across_pages": {


### PR DESCRIPTION
I quickly created a new mock session in https://github.com/DataDog/browser-sdk/pull/3769 when we don't want to track a session for Logs.