### PR TITLE
RUM-11595: Extend Vital event to App Launch metrics

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1147,44 +1147,7 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
      * RUM event type
      */
     readonly type: 'vital';
-    /**
-     * Vital properties
-     */
-    readonly vital: {
-        /**
-         * Type of the vital
-         */
-        readonly type: 'duration' | 'operation_step';
-        /**
-         * UUID of the vital
-         */
-        readonly id: string;
-        /**
-         * Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')
-         */
-        readonly operation_key?: string;
-        /**
-         * Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $
-         */
-        readonly name?: string;
-        /**
-         * Description of the vital. It can be used as a secondary identifier (URL, React component name...)
-         */
-        readonly description?: string;
-        /**
-         * Duration of the vital in nanoseconds
-         */
-        readonly duration?: number;
-        /**
-         * Type of the step that triggered the vital, if applicable
-         */
-        readonly step_type?: 'start' | 'update' | 'retry' | 'end';
-        /**
-         * Reason for the failure of the step, if applicable
-         */
-        readonly failure_reason?: 'error' | 'abandoned' | 'other';
-        [k: string]: unknown;
-    };
+    readonly vital: DurationProperties | AppLaunchProperties | FeatureOperationProperties;
     /**
      * Internal properties
      */
@@ -1201,6 +1164,90 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+};
+/**
+ * Duration properties of a Vital event
+ */
+export declare type DurationProperties = VitalCommonProperties & {
+    /**
+     * Type of the vital.
+     */
+    readonly type: 'duration';
+    /**
+     * Duration of the vital in nanoseconds.
+     */
+    readonly duration: number;
+    [k: string]: unknown;
+};
+/**
+ * Schema of common properties for a Vital event
+ */
+export declare type VitalCommonProperties = {
+    /**
+     * UUID of the vital
+     */
+    readonly id: string;
+    /**
+     * Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $
+     */
+    readonly name?: string;
+    /**
+     * Description of the vital. It can be used as a secondary identifier (URL, React component name...)
+     */
+    readonly description?: string;
+    [k: string]: unknown;
+};
+/**
+ * Schema for app launch metrics.
+ */
+export declare type AppLaunchProperties = VitalCommonProperties & {
+    /**
+     * Type of the vital.
+     */
+    readonly type: 'app_launch';
+    /**
+     * The metric of the app launch.
+     */
+    readonly app_launch_metric: 'ttid' | 'ttfd';
+    /**
+     * Duration of the vital in nanoseconds.
+     */
+    readonly duration: number;
+    /**
+     * The type of the app launch.
+     */
+    readonly startup_type?: 'cold_start' | 'warm_start';
+    /**
+     * Whether the app launch was prewarmed.
+     */
+    readonly is_prewarmed?: boolean;
+    /**
+     * If the app launch had a saved instance state bundle.
+     */
+    readonly has_saved_instance_state_bundle?: boolean;
+    [k: string]: unknown;
+};
+/**
+ * Schema for a feature operation.
+ */
+export declare type FeatureOperationProperties = VitalCommonProperties & {
+    /**
+     * Type of the vital.
+     */
+    readonly type: 'operation_step';
+    /**
+     * Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')
+     */
+    readonly operation_key?: string;
+    /**
+     * Type of the step that triggered the vital, if applicable
+     */
+    readonly step_type?: 'start' | 'update' | 'retry' | 'end';
+    /**
+     * Reason for the failure of the step, if applicable
+     */
+    readonly failure_reason?: 'error' | 'abandoned' | 'other';
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1147,44 +1147,7 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
      * RUM event type
      */
     readonly type: 'vital';
-    /**
-     * Vital properties
-     */
-    readonly vital: {
-        /**
-         * Type of the vital
-         */
-        readonly type: 'duration' | 'operation_step';
-        /**
-         * UUID of the vital
-         */
-        readonly id: string;
-        /**
-         * Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')
-         */
-        readonly operation_key?: string;
-        /**
-         * Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $
-         */
-        readonly name?: string;
-        /**
-         * Description of the vital. It can be used as a secondary identifier (URL, React component name...)
-         */
-        readonly description?: string;
-        /**
-         * Duration of the vital in nanoseconds
-         */
-        readonly duration?: number;
-        /**
-         * Type of the step that triggered the vital, if applicable
-         */
-        readonly step_type?: 'start' | 'update' | 'retry' | 'end';
-        /**
-         * Reason for the failure of the step, if applicable
-         */
-        readonly failure_reason?: 'error' | 'abandoned' | 'other';
-        [k: string]: unknown;
-    };
+    readonly vital: DurationProperties | AppLaunchProperties | FeatureOperationProperties;
     /**
      * Internal properties
      */
@@ -1201,6 +1164,90 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
         };
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+};
+/**
+ * Duration properties of a Vital event
+ */
+export declare type DurationProperties = VitalCommonProperties & {
+    /**
+     * Type of the vital.
+     */
+    readonly type: 'duration';
+    /**
+     * Duration of the vital in nanoseconds.
+     */
+    readonly duration: number;
+    [k: string]: unknown;
+};
+/**
+ * Schema of common properties for a Vital event
+ */
+export declare type VitalCommonProperties = {
+    /**
+     * UUID of the vital
+     */
+    readonly id: string;
+    /**
+     * Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $
+     */
+    readonly name?: string;
+    /**
+     * Description of the vital. It can be used as a secondary identifier (URL, React component name...)
+     */
+    readonly description?: string;
+    [k: string]: unknown;
+};
+/**
+ * Schema for app launch metrics.
+ */
+export declare type AppLaunchProperties = VitalCommonProperties & {
+    /**
+     * Type of the vital.
+     */
+    readonly type: 'app_launch';
+    /**
+     * The metric of the app launch.
+     */
+    readonly app_launch_metric: 'ttid' | 'ttfd';
+    /**
+     * Duration of the vital in nanoseconds.
+     */
+    readonly duration: number;
+    /**
+     * The type of the app launch.
+     */
+    readonly startup_type?: 'cold_start' | 'warm_start';
+    /**
+     * Whether the app launch was prewarmed.
+     */
+    readonly is_prewarmed?: boolean;
+    /**
+     * If the app launch had a saved instance state bundle.
+     */
+    readonly has_saved_instance_state_bundle?: boolean;
+    [k: string]: unknown;
+};
+/**
+ * Schema for a feature operation.
+ */
+export declare type FeatureOperationProperties = VitalCommonProperties & {
+    /**
+     * Type of the vital.
+     */
+    readonly type: 'operation_step';
+    /**
+     * Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')
+     */
+    readonly operation_key?: string;
+    /**
+     * Type of the step that triggered the vital, if applicable
+     */
+    readonly step_type?: 'start' | 'update' | 'retry' | 'end';
+    /**
+     * Reason for the failure of the step, if applicable
+     */
+    readonly failure_reason?: 'error' | 'abandoned' | 'other';
     [k: string]: unknown;
 };
 /**

--- a/schemas/rum/_vital-common-schema.json
+++ b/schemas/rum/_vital-common-schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_vital-common-schema.json",
+  "title": "VitalCommonProperties",
+  "type": "object",
+  "description": "Schema of common properties for a Vital event",
+  "allOf": [
+    {
+      "description": "Vital properties",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the vital",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the vital. It can be used as a secondary identifier (URL, React component name...)",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/schemas/rum/vital-app-launch-schema.json
+++ b/schemas/rum/vital-app-launch-schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-app-launch-schema.json",
+  "title": "AppLaunchProperties",
+  "type": "object",
+  "description": "Schema for app launch metrics.",
+  "allOf": [
+    {
+      "$ref": "_vital-common-schema.json"
+    },
+    {
+      "required": ["type", "app_launch_metric", "duration"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the vital.",
+          "const": "app_launch",
+          "readOnly": true
+        },
+        "app_launch_metric": {
+          "type": "string",
+          "description": "The metric of the app launch.",
+          "enum": ["ttid", "ttfd"],
+          "readOnly": true
+        },
+        "duration": {
+          "type": "number",
+          "description": "Duration of the vital in nanoseconds.",
+          "readOnly": true
+        },
+        "startup_type": {
+          "type": "string",
+          "description": "The type of the app launch.",
+          "enum": ["cold_start", "warm_start"],
+          "readOnly": true
+        },
+        "is_prewarmed": {
+          "type": "boolean",
+          "description": "Whether the app launch was prewarmed.",
+          "readOnly": true
+        },
+        "has_saved_instance_state_bundle": {
+          "type": "boolean",
+          "description": "If the app launch had a saved instance state bundle.",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/schemas/rum/vital-duration-schema.json
+++ b/schemas/rum/vital-duration-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-duration-schema.json",
+  "title": "DurationProperties",
+  "type": "object",
+  "description": "Duration properties of a Vital event",
+  "allOf": [
+    {
+      "$ref": "_vital-common-schema.json"
+    },
+    {
+      "required": ["type", "duration"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the vital.",
+          "const": "duration",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "number",
+          "description": "Duration of the vital in nanoseconds.",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/schemas/rum/vital-feature-operation-schema.json
+++ b/schemas/rum/vital-feature-operation-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-feature-operation-schema.json",
+  "title": "FeatureOperationProperties",
+  "type": "object",
+  "description": "Schema for a feature operation.",
+  "allOf": [
+    {
+      "$ref": "_vital-common-schema.json"
+    },
+    {
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the vital.",
+          "const": "operation_step",
+          "readOnly": true
+        },
+        "operation_key": {
+          "type": "string",
+          "description": "Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')",
+          "readOnly": true
+        },
+        "step_type": {
+          "type": "string",
+          "description": "Type of the step that triggered the vital, if applicable",
+          "enum": ["start", "update", "retry", "end"],
+          "readOnly": true
+        },
+        "failure_reason": {
+          "type": "string",
+          "description": "Reason for the failure of the step, if applicable",
+          "enum": ["error", "abandoned", "other"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -21,55 +21,17 @@
           "readOnly": true
         },
         "vital": {
-          "type": "object",
-          "description": "Vital properties",
-          "required": ["id", "type"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "description": "Type of the vital",
-              "enum": ["duration", "operation_step"],
-              "readOnly": true
+          "oneOf": [
+            {
+              "$ref": "vital-duration-schema.json"
             },
-            "id": {
-              "type": "string",
-              "description": "UUID of the vital",
-              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-              "readOnly": true
+            {
+              "$ref": "vital-app-launch-schema.json"
             },
-            "operation_key": {
-              "type": "string",
-              "description": "Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')",
-              "readOnly": true
-            },
-            "name": {
-              "type": "string",
-              "description": "Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $",
-              "readOnly": true
-            },
-            "description": {
-              "type": "string",
-              "description": "Description of the vital. It can be used as a secondary identifier (URL, React component name...)",
-              "readOnly": true
-            },
-            "duration": {
-              "type": "number",
-              "description": "Duration of the vital in nanoseconds",
-              "readOnly": true
-            },
-            "step_type": {
-              "type": "string",
-              "description": "Type of the step that triggered the vital, if applicable",
-              "enum": ["start", "update", "retry", "end"],
-              "readOnly": true
-            },
-            "failure_reason": {
-              "type": "string",
-              "description": "Reason for the failure of the step, if applicable",
-              "enum": ["error", "abandoned", "other"],
-              "readOnly": true
+            {
+              "$ref": "vital-feature-operation-schema.json"
             }
-          },
+          ],
           "readOnly": true
         },
         "_dd": {


### PR DESCRIPTION
This PR proposes extending the [Vital schema](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/vital-schema.json) to other features. 

Currently, the [Vital schema](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/vital-schema.json) includes some "Feature Operations" parameters. Since the "App Launch" initiative is leveraging vitals, it makes sense to design the schema with scalability in mind.

It introduces new sub schemas of the common `vital-common-schema.json`:
- `vital-duration-schema.json` - Focused on duration properties. It is isolated because Feature Operations doesn't have duration.
- `vital-app-launch-schema.json` - Focused on App launch metrics.
- `vital-feature-operations-schema.json` - Focused on Feature Operations.