### PR TITLE
add `trackEarlyRequests` in config telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -152,6 +152,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_resources?: boolean;
             /**
+             * Whether early requests are tracked
+             */
+            track_early_requests?: boolean;
+            /**
              * Whether long tasks are tracked
              */
             track_long_task?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -152,6 +152,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_resources?: boolean;
             /**
+             * Whether early requests are tracked
+             */
+            track_early_requests?: boolean;
+            /**
              * Whether long tasks are tracked
              */
             track_long_task?: boolean;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -117,6 +117,11 @@
                   "description": "Whether resources are tracked",
                   "readOnly": false
                 },
+                "track_early_requests": {
+                  "type": "boolean",
+                  "description": "Whether early requests are tracked",
+                  "readOnly": false
+                },
                 "track_long_task": {
                   "type": "boolean",
                   "description": "Whether long tasks are tracked",


### PR DESCRIPTION
I want to GA [Early Request Collection](https://github.com/DataDog/browser-sdk/pull/3740), but since it has been evaluated as a small breaking change I want to introduce a `trackEarlyRequests` configuration parameter to opt-in this new behavior.

This PR adds telemetry support for this parameter.

This parameter should be removed in the next major, where we'll enable this new behavior as the default.