### PR TITLE
RUM-11840: Add optionality to view on Vital event

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1216,6 +1216,10 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
             readonly computed_value?: boolean;
             [k: string]: unknown;
         };
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -94,7 +94,7 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the action starting in the foreground (focus in browser)
          */
@@ -438,7 +438,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the error starting in the foreground (focus in browser)
          */
@@ -1375,7 +1375,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * UUID of the view
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1216,6 +1216,10 @@ export declare type RumVitalEvent = CommonProperties & ViewContainerSchema & {
             readonly computed_value?: boolean;
             [k: string]: unknown;
         };
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -94,7 +94,7 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the action starting in the foreground (focus in browser)
          */
@@ -438,7 +438,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the error starting in the foreground (focus in browser)
          */
@@ -1375,7 +1375,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * UUID of the view
          */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -4,7 +4,7 @@
   "title": "CommonProperties",
   "type": "object",
   "description": "Schema of common properties of RUM events",
-  "required": ["date", "application", "session", "view", "_dd"],
+  "required": ["date", "application", "session", "_dd"],
   "properties": {
     "date": {
       "type": "integer",

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -12,7 +12,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "action"],
+      "required": ["type", "view", "action"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "error"],
+      "required": ["type", "view", "error"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -16,7 +16,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "long_task"],
+      "required": ["type", "view", "long_task"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "resource"],
+      "required": ["type", "view", "resource"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/transition-schema.json
+++ b/schemas/rum/transition-schema.json
@@ -9,7 +9,7 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": ["type", "transition", "stream"],
+      "required": ["type", "transition", "view", "stream"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/vital-schema.json
+++ b/schemas/rum/vital-schema.json
@@ -49,6 +49,11 @@
                 }
               },
               "readOnly": true
+            },
+            "profiling": {
+              "type": "object",
+              "description": "Profiling context",
+              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
             }
           },
           "readOnly": true


### PR DESCRIPTION
This PR extends the [Vital schema](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/vital-schema.json) to include "[app_launch](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/vital-app-launch-schema.json)" vital requirements: 
- The "app_launch" vitals don't necessarily link to a View. This PR makes that linkage optional.
- The "app_launch" vitals will be associated with profiling data. This PR attaches the [profiling schema](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/_profiling-internal-context-schema.json) to the Vital event.