### PR TITLE
Add response error graphql properties

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -769,6 +769,42 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
              * String representation of the operation variables
              */
             variables?: string;
+            /**
+             * Number of GraphQL errors in the response
+             */
+            readonly errors_count?: number;
+            /**
+             * Array of GraphQL errors from the response
+             */
+            readonly errors?: {
+                /**
+                 * Error message
+                 */
+                readonly message: string;
+                /**
+                 * Error code from GraphQL extensions
+                 */
+                readonly code?: string;
+                /**
+                 * Array of error locations in the GraphQL query
+                 */
+                readonly locations?: {
+                    /**
+                     * Line number where the error occurred
+                     */
+                    readonly line: number;
+                    /**
+                     * Column number where the error occurred
+                     */
+                    readonly column: number;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Path to the field that caused the error
+                 */
+                readonly path?: (string | number)[];
+                [k: string]: unknown;
+            }[];
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -772,7 +772,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Number of GraphQL errors in the response
              */
-            readonly errors_count?: number;
+            readonly error_count?: number;
             /**
              * Array of GraphQL errors from the response
              */
@@ -782,7 +782,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
                  */
                 readonly message: string;
                 /**
-                 * Error code from GraphQL extensions
+                 * Error code (used by some providers)
                  */
                 readonly code?: string;
                 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -769,6 +769,42 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
              * String representation of the operation variables
              */
             variables?: string;
+            /**
+             * Number of GraphQL errors in the response
+             */
+            readonly errors_count?: number;
+            /**
+             * Array of GraphQL errors from the response
+             */
+            readonly errors?: {
+                /**
+                 * Error message
+                 */
+                readonly message: string;
+                /**
+                 * Error code from GraphQL extensions
+                 */
+                readonly code?: string;
+                /**
+                 * Array of error locations in the GraphQL query
+                 */
+                readonly locations?: {
+                    /**
+                     * Line number where the error occurred
+                     */
+                    readonly line: number;
+                    /**
+                     * Column number where the error occurred
+                     */
+                    readonly column: number;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Path to the field that caused the error
+                 */
+                readonly path?: (string | number)[];
+                [k: string]: unknown;
+            }[];
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -772,7 +772,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Number of GraphQL errors in the response
              */
-            readonly errors_count?: number;
+            readonly error_count?: number;
             /**
              * Array of GraphQL errors from the response
              */
@@ -782,7 +782,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
                  */
                 readonly message: string;
                 /**
-                 * Error code from GraphQL extensions
+                 * Error code (used by some providers)
                  */
                 readonly code?: string;
                 /**

--- a/samples/rum-events/resource-graphql.json
+++ b/samples/rum-events/resource-graphql.json
@@ -33,7 +33,7 @@
       "operationName": "GetUserProfile",
       "variables": "{\"userId\": \"123\"}",
       "payload": "query GetUserProfile($userId: ID!) { user(id: $userId) { name email } }",
-      "errors_count": 2,
+      "error_count": 2,
       "errors": [
         {
           "message": "User not found",

--- a/samples/rum-events/resource-graphql.json
+++ b/samples/rum-events/resource-graphql.json
@@ -44,7 +44,7 @@
               "column": 15
             }
           ],
-          "path": ["user", "name"]
+          "path": ["user", 1]
         },
         {
           "message": "Invalid email format",

--- a/samples/rum-events/resource-graphql.json
+++ b/samples/rum-events/resource-graphql.json
@@ -1,0 +1,72 @@
+{
+  "type": "resource",
+  "date": 1591284175328,
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599",
+    "type": "user"
+  },
+  "source": "browser",
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
+    "referrer": "",
+    "url": "https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view"
+  },
+  "resource": {
+    "id": "b83a5d82-cdd1-468d-9bc9-3aa9e54d957a",
+    "type": "fetch",
+    "method": "POST",
+    "url": "https://api.example.com/graphql",
+    "status_code": 200,
+    "duration": 246580000,
+    "size": 3599,
+    "encoded_body_size": 1599,
+    "decoded_body_size": 3599,
+    "transfer_size": 3699,
+    "render_blocking_status": "non-blocking",
+    "protocol": "HTTP/1.1",
+    "delivery_type": "cache",
+    "graphql": {
+      "operationType": "query",
+      "operationName": "GetUserProfile",
+      "variables": "{\"userId\": \"123\"}",
+      "payload": "query GetUserProfile($userId: ID!) { user(id: $userId) { name email } }",
+      "errors_count": 2,
+      "errors": [
+        {
+          "message": "User not found",
+          "code": "USER_NOT_FOUND",
+          "locations": [
+            {
+              "line": 1,
+              "column": 15
+            }
+          ],
+          "path": ["user", "name"]
+        },
+        {
+          "message": "Invalid email format",
+          "code": "INVALID_EMAIL",
+          "locations": [
+            {
+              "line": 1,
+              "column": 25
+            }
+          ],
+          "path": ["user", "email"]
+        }
+      ]
+    }
+  },
+  "action": {
+    "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+  },
+  "_dd": {
+    "format_version": 2,
+    "span_id": "12345",
+    "parent_span_id": "67890",
+    "trace_id": "7890"
+  }
+}

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -307,6 +307,75 @@
                   "type": "string",
                   "description": "String representation of the operation variables",
                   "readOnly": false
+                },
+                "errors_count": {
+                  "type": "integer",
+                  "description": "Number of GraphQL errors in the response",
+                  "minimum": 0,
+                  "readOnly": true
+                },
+                "errors": {
+                  "type": "array",
+                  "description": "Array of GraphQL errors from the response",
+                  "items": {
+                    "type": "object",
+                    "description": "GraphQL error details",
+                    "required": ["message"],
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Error message",
+                        "readOnly": true
+                      },
+                      "code": {
+                        "type": "string",
+                        "description": "Error code from GraphQL extensions",
+                        "readOnly": true
+                      },
+                      "locations": {
+                        "type": "array",
+                        "description": "Array of error locations in the GraphQL query",
+                        "items": {
+                          "type": "object",
+                          "description": "Error location",
+                          "required": ["line", "column"],
+                          "properties": {
+                            "line": {
+                              "type": "integer",
+                              "description": "Line number where the error occurred",
+                              "minimum": 1,
+                              "readOnly": true
+                            },
+                            "column": {
+                              "type": "integer",
+                              "description": "Column number where the error occurred",
+                              "minimum": 1,
+                              "readOnly": true
+                            }
+                          },
+                          "readOnly": true
+                        },
+                        "readOnly": true
+                      },
+                      "path": {
+                        "type": "array",
+                        "description": "Path to the field that caused the error",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        },
+                        "readOnly": true
+                      }
+                    },
+                    "readOnly": true
+                  },
+                  "readOnly": true
                 }
               },
               "readOnly": true

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -308,7 +308,7 @@
                   "description": "String representation of the operation variables",
                   "readOnly": false
                 },
-                "errors_count": {
+                "error_count": {
                   "type": "integer",
                   "description": "Number of GraphQL errors in the response",
                   "minimum": 0,
@@ -329,7 +329,7 @@
                       },
                       "code": {
                         "type": "string",
-                        "description": "Error code from GraphQL extensions",
+                        "description": "Error code (used by some providers)",
                         "readOnly": true
                       },
                       "locations": {


### PR DESCRIPTION
Add new properties for the following support for graphql response tracking. 

Note : The code property is not native but taken from the extension field and move at the top level. As we would like to query directly : `@resource.[…].errors.code:xxx`. It is present in the spec as a field in the extension part, so it could be manually added by the customers but also some libraries such as Apollo directly provide it in the response. ([see Documentation](https://www.apollographql.com/docs/apollo-server/data/errors))

See the spec for more informations about the graphql response format : [GraphQL Spec](https://github.com/graphql/graphql-spec/blob/main/spec/Section%207%20--%20Response.md)