### PR TITLE
[Long tasks] Improve attributes descriptions

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -486,15 +486,15 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
          */
         readonly blocking_duration?: number;
         /**
-         * Start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks
+         * Time difference (in ns) between the timeOrigin and the start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks
          */
         readonly render_start?: number;
         /**
-         * Start time of the time period spent in style and layout calculations
+         * Time difference (in ns) between the timeOrigin and the start time of the time period spent in style and layout calculations
          */
         readonly style_and_layout_start?: number;
         /**
-         * Start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame
+         * Time difference (in ns) between the timeOrigin and the start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame
          */
         readonly first_ui_event_timestamp?: number;
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -486,15 +486,15 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
          */
         readonly blocking_duration?: number;
         /**
-         * Start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks
+         * Time difference (in ns) between the timeOrigin and the start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks
          */
         readonly render_start?: number;
         /**
-         * Start time of the time period spent in style and layout calculations
+         * Time difference (in ns) between the timeOrigin and the start time of the time period spent in style and layout calculations
          */
         readonly style_and_layout_start?: number;
         /**
-         * Start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame
+         * Time difference (in ns) between the timeOrigin and the start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame
          */
         readonly first_ui_event_timestamp?: number;
         /**

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -61,19 +61,19 @@
             },
             "render_start": {
               "type": "number",
-              "description": "Start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks",
+              "description": "Time difference (in ns) between the timeOrigin and the start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks",
               "minimum": 0,
               "readOnly": true
             },
             "style_and_layout_start": {
               "type": "number",
-              "description": "Start time of the time period spent in style and layout calculations",
+              "description": "Time difference (in ns) between the timeOrigin and the start time of the time period spent in style and layout calculations",
               "minimum": 0,
               "readOnly": true
             },
             "first_ui_event_timestamp": {
               "type": "number",
-              "description": "Start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame",
+              "description": "Time difference (in ns) between the timeOrigin and the start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame",
               "minimum": 0,
               "readOnly": true
             },


### PR DESCRIPTION
Improve the description of `render_start`, `style_and_layout_start` and `first_ui_event_timestamp` in the long tasks schema, to explain in which unit they are and how they are computed (which helps explaining why these durations can be higher than the duration of the parent session). 