### PR TITLE
Telemetry GraphQl Response Tracking

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -212,6 +212,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_track_graph_ql_payload?: boolean;
             /**
+             * Whether GraphQL response errors tracking is used for at least one GraphQL endpoint
+             */
+            use_track_graph_ql_response_errors?: boolean;
+            /**
              * A list of selected tracing propagators
              */
             selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[];

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -212,6 +212,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_track_graph_ql_payload?: boolean;
             /**
+             * Whether GraphQL response errors tracking is used for at least one GraphQL endpoint
+             */
+            use_track_graph_ql_response_errors?: boolean;
+            /**
              * A list of selected tracing propagators
              */
             selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[];

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -47,6 +47,7 @@
       "use_allowed_tracing_origins": false,
       "use_allowed_graph_ql_urls": false,
       "use_track_graph_ql_payload": false,
+      "use_track_graph_ql_response_errors": true,
       "default_privacy_level": "mask",
       "text_and_input_privacy_level": "mask_all",
       "image_privacy_level": "mask_all",

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -181,6 +181,10 @@
                   "type": "boolean",
                   "description": "Whether GraphQL payload tracking is used for at least one GraphQL endpoint"
                 },
+                "use_track_graph_ql_response_errors": {
+                  "type": "boolean",
+                  "description": "Whether GraphQL response errors tracking is used for at least one GraphQL endpoint"
+                },
                 "selected_tracing_propagators": {
                   "type": "array",
                   "items": {


### PR DESCRIPTION
Add telemetry to have data about the usage of the new parameter to track graphql response.
See : https://github.com/DataDog/browser-sdk/pull/3921