### PR TITLE
chore: Remove view optionality from Vital events

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1411,7 +1411,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * UUID of the view
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1411,7 +1411,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * UUID of the view
          */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -4,7 +4,7 @@
   "title": "CommonProperties",
   "type": "object",
   "description": "Schema of common properties of RUM events",
-  "required": ["date", "application", "session", "_dd"],
+  "required": ["date", "application", "session", "view", "_dd"],
   "properties": {
     "date": {
       "type": "integer",


### PR DESCRIPTION
### What and why
This PR reverts #306, which made the view optional for vital events.

The topic will be revisited later to find a better solution that accommodates the requirements of all SDKs.