### PR TITLE
[PANA-4766] Add `truncationMode` property to `TextStyle` schema

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -119,6 +119,10 @@ export declare type TextStyle = {
      * The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
     readonly color: string;
+    /**
+     * Defines how text should be truncated when it exceeds the wireframe bounds. If omitted, text wraps naturally.
+     */
+    readonly truncationMode?: 'clip' | 'head' | 'tail' | 'middle';
 };
 /**
  * Schema of all properties of a TextPosition.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -429,6 +429,10 @@ export declare type TextStyle = {
      * The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
     readonly color: string;
+    /**
+     * Defines how text should be truncated when it exceeds the wireframe bounds. If omitted, text wraps naturally.
+     */
+    readonly truncationMode?: 'clip' | 'head' | 'tail' | 'middle';
 };
 /**
  * Schema of all properties of a TextPosition.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -119,6 +119,10 @@ export declare type TextStyle = {
      * The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
     readonly color: string;
+    /**
+     * Defines how text should be truncated when it exceeds the wireframe bounds. If omitted, text wraps naturally.
+     */
+    readonly truncationMode?: 'clip' | 'head' | 'tail' | 'middle';
 };
 /**
  * Schema of all properties of a TextPosition.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -429,6 +429,10 @@ export declare type TextStyle = {
      * The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
     readonly color: string;
+    /**
+     * Defines how text should be truncated when it exceeds the wireframe bounds. If omitted, text wraps naturally.
+     */
+    readonly truncationMode?: 'clip' | 'head' | 'tail' | 'middle';
 };
 /**
  * Schema of all properties of a TextPosition.

--- a/schemas/session-replay/mobile/text-style-schema.json
+++ b/schemas/session-replay/mobile/text-style-schema.json
@@ -23,6 +23,12 @@
           "pattern": "^#[A-Fa-f0-9]{6}([A-Fa-f0-9]{2})?$",
           "description": "The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.",
           "readOnly": true
+        },
+        "truncationMode": {
+          "type": "string",
+          "description": "Defines how text should be truncated when it exceeds the wireframe bounds. If omitted, text wraps naturally.",
+          "enum": ["clip", "head", "tail", "middle"],
+          "readOnly": true
         }
       },
       "readOnly": true


### PR DESCRIPTION
Adds a `truncationMode` property to the `TextStyle` schema to capture text truncation behavior in Session Replay.

The mobile Session Replay schemas capture text content, position, and basic styling (color, font, size) but don't capture how text should be truncated when it exceeds the wireframe bounds.

Here is the suggested mapping per platform:

| Platform        | API             | Value              | truncationMode | Notes                 |
|-----------------|-----------------|--------------------|----------------|-----------------------|
| iOS             | NSLineBreakMode | byTruncatingTail   | "tail"         | Most common           |
|                 |                 | byTruncatingHead   | "head"         | Ellipsis at start     |
|                 |                 | byTruncatingMiddle | "middle"       | Ellipsis in middle    |
|                 |                 | byClipping         | "clip"         | Hard cut              |
|                 |                 | byWordWrapping     | (omit)         | Normal wrapping       |
| Android Classic | TruncateAt      | END                | "tail"         | Most common           |
|                 |                 | START              | "head"         | Ellipsis at start     |
|                 |                 | MIDDLE             | "middle"       | Ellipsis in middle    |
|                 |                 | MARQUEE            | (omit)         | Scrolling animation   |
|                 |                 | null + maxLines    | "clip"         | No ellipsis, hard cut |
|                 |                 | null               | (omit)         | Normal wrapping       |
| Compose         | TextOverflow    | Ellipsis           | "tail"         | Only ellipsis option  |
|                 |                 | Clip               | "clip"         | Hard cut              |
|                 |                 | Visible            | (omit)         | No truncation         |
| Flutter         | TextOverflow    | ellipsis           | "tail"         | Only ellipsis option  |
|                 |                 | clip               | "clip"         | Hard cut              |
|                 |                 | fade               | "clip"         | Fades out             |
|                 |                 | visible            | (omit)         | No truncation         |