### PR TITLE
Add use_beta_encode_cookie_options to TelemetryConfigurationEvent

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -461,6 +461,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether trace baggage is propagated to child spans
              */
             propagate_trace_baggage?: boolean;
+            /**
+             * Whether the beta encode cookie options is enabled
+             */
+            use_beta_encode_cookie_options?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -464,7 +464,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Whether the beta encode cookie options is enabled
              */
-            use_beta_encode_cookie_options?: boolean;
+            beta_encode_cookie_options?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -461,6 +461,10 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether trace baggage is propagated to child spans
              */
             propagate_trace_baggage?: boolean;
+            /**
+             * Whether the beta encode cookie options is enabled
+             */
+            use_beta_encode_cookie_options?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -464,7 +464,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * Whether the beta encode cookie options is enabled
              */
-            use_beta_encode_cookie_options?: boolean;
+            beta_encode_cookie_options?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -514,6 +514,11 @@
                   "type": "boolean",
                   "description": "Whether trace baggage is propagated to child spans",
                   "readOnly": false
+                },
+                "use_beta_encode_cookie_options": {
+                  "type": "boolean",
+                  "description": "Whether the beta encode cookie options is enabled",
+                  "readOnly": false
                 }
               }
             }

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -515,7 +515,7 @@
                   "description": "Whether trace baggage is propagated to child spans",
                   "readOnly": false
                 },
-                "use_beta_encode_cookie_options": {
+                "beta_encode_cookie_options": {
                   "type": "boolean",
                   "description": "Whether the beta encode cookie options is enabled",
                   "readOnly": false


### PR DESCRIPTION
We want to release the [encode cookie option](https://github.com/DataDog/browser-sdk/pull/3905) behind a new beta init parameter

see https://github.com/DataDog/browser-sdk/pull/3951