### PR TITLE
Set View event back to required

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -94,7 +94,7 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * Is the action starting in the foreground (focus in browser)
          */
@@ -159,7 +159,7 @@ export declare type RumTransitionEvent = CommonProperties & {
      * RUM event type
      */
     readonly type: 'transition';
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
@@ -441,7 +441,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * Is the error starting in the foreground (focus in browser)
          */
@@ -464,7 +464,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'long_task';
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
@@ -583,7 +583,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'resource';
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
@@ -1243,13 +1243,13 @@ export declare type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationSte
  * Schema for a duration vital event.
  */
 export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
      * Vital properties
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Type of the vital.
          */
@@ -1294,13 +1294,13 @@ export declare type RumVitalEventCommonProperties = CommonProperties & ViewConta
  * Schema for a vital operation step event.
  */
 export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
      * Vital properties
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Type of the vital.
          */
@@ -1328,7 +1328,7 @@ export declare type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Type of the vital.
          */
@@ -1434,7 +1434,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * UUID of the view
          */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -159,9 +159,6 @@ export declare type RumTransitionEvent = CommonProperties & {
      * RUM event type
      */
     readonly type: 'transition';
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Stream properties
      */
@@ -464,9 +461,6 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'long_task';
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Long Task properties
      */
@@ -583,9 +577,6 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'resource';
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Resource properties
      */
@@ -1243,9 +1234,6 @@ export declare type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationSte
  * Schema for a duration vital event.
  */
 export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Vital properties
      */
@@ -1294,9 +1282,6 @@ export declare type RumVitalEventCommonProperties = CommonProperties & ViewConta
  * Schema for a vital operation step event.
  */
 export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Vital properties
      */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -94,7 +94,7 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * Is the action starting in the foreground (focus in browser)
          */
@@ -159,7 +159,7 @@ export declare type RumTransitionEvent = CommonProperties & {
      * RUM event type
      */
     readonly type: 'transition';
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
@@ -441,7 +441,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * Is the error starting in the foreground (focus in browser)
          */
@@ -464,7 +464,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'long_task';
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
@@ -583,7 +583,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'resource';
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
@@ -1243,13 +1243,13 @@ export declare type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationSte
  * Schema for a duration vital event.
  */
 export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
      * Vital properties
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Type of the vital.
          */
@@ -1294,13 +1294,13 @@ export declare type RumVitalEventCommonProperties = CommonProperties & ViewConta
  * Schema for a vital operation step event.
  */
 export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
-    view: {
+    view?: {
         [k: string]: unknown;
     };
     /**
      * Vital properties
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Type of the vital.
          */
@@ -1328,7 +1328,7 @@ export declare type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Type of the vital.
          */
@@ -1434,7 +1434,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * UUID of the view
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -159,9 +159,6 @@ export declare type RumTransitionEvent = CommonProperties & {
      * RUM event type
      */
     readonly type: 'transition';
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Stream properties
      */
@@ -464,9 +461,6 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'long_task';
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Long Task properties
      */
@@ -583,9 +577,6 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
      * RUM event type
      */
     readonly type: 'resource';
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Resource properties
      */
@@ -1243,9 +1234,6 @@ export declare type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationSte
  * Schema for a duration vital event.
  */
 export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Vital properties
      */
@@ -1294,9 +1282,6 @@ export declare type RumVitalEventCommonProperties = CommonProperties & ViewConta
  * Schema for a vital operation step event.
  */
 export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
-    view?: {
-        [k: string]: unknown;
-    };
     /**
      * Vital properties
      */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -4,7 +4,7 @@
   "title": "CommonProperties",
   "type": "object",
   "description": "Schema of common properties of RUM events",
-  "required": ["date", "application", "session", "_dd"],
+  "required": ["date", "application", "session", "view", "_dd"],
   "properties": {
     "date": {
       "type": "integer",

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -12,7 +12,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "view", "action"],
+      "required": ["type", "action"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "view", "error"],
+      "required": ["type", "error"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -24,9 +24,6 @@
           "const": "long_task",
           "readOnly": true
         },
-        "view": {
-          "type": "object"
-        },
         "long_task": {
           "type": "object",
           "description": "Long Task properties",

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -16,7 +16,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "view", "long_task"],
+      "required": ["type", "long_task"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -23,9 +23,6 @@
           "const": "resource",
           "readOnly": true
         },
-        "view": {
-          "type": "object"
-        },
         "resource": {
           "type": "object",
           "description": "Resource properties",

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "view", "resource"],
+      "required": ["type", "resource"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/transition-schema.json
+++ b/schemas/rum/transition-schema.json
@@ -17,9 +17,6 @@
           "const": "transition",
           "readOnly": true
         },
-        "view": {
-          "type": "object"
-        },
         "stream": {
           "type": "object",
           "description": "Stream properties",

--- a/schemas/rum/transition-schema.json
+++ b/schemas/rum/transition-schema.json
@@ -9,7 +9,7 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": ["type", "transition", "view", "stream"],
+      "required": ["type", "transition", "stream"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/vital-app-launch-schema.json
+++ b/schemas/rum/vital-app-launch-schema.json
@@ -9,7 +9,6 @@
       "$ref": "_vital-common-schema.json"
     },
     {
-      "required": ["vital"],
       "properties": {
         "vital": {
           "type": "object",

--- a/schemas/rum/vital-duration-schema.json
+++ b/schemas/rum/vital-duration-schema.json
@@ -10,9 +10,6 @@
     },
     {
       "properties": {
-        "view": {
-          "type": "object"
-        },
         "vital": {
           "type": "object",
           "description": "Vital properties",

--- a/schemas/rum/vital-duration-schema.json
+++ b/schemas/rum/vital-duration-schema.json
@@ -9,7 +9,6 @@
       "$ref": "_vital-common-schema.json"
     },
     {
-      "required": ["view", "vital"],
       "properties": {
         "view": {
           "type": "object"

--- a/schemas/rum/vital-operation-step-schema.json
+++ b/schemas/rum/vital-operation-step-schema.json
@@ -10,9 +10,6 @@
     },
     {
       "properties": {
-        "view": {
-          "type": "object"
-        },
         "vital": {
           "type": "object",
           "description": "Vital properties",

--- a/schemas/rum/vital-operation-step-schema.json
+++ b/schemas/rum/vital-operation-step-schema.json
@@ -9,7 +9,6 @@
       "$ref": "_vital-common-schema.json"
     },
     {
-      "required": ["view", "vital"],
       "properties": {
         "view": {
           "type": "object"


### PR DESCRIPTION
## Motivation

[This PR](https://github.com/DataDog/rum-events-format/pull/306) had introduced an optionality on the view field in the app launch vital's schema. However, following [this RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/5629674495/Draft+RFC+Vital+architecture+for+TTID+TTFD), we have decided to stick with the view field being mandatory even on app launch vital event.

## Changes

- Add back the `"view"` field in the `required` list of the common schema, and remove it from all the `required` lists of the view children's schemas.
- Remove the `"required"` list for the three subtypes of vital events, since `"view"` is no longer required, and `"vital"` is already required in the common vital schema.