### PR TITLE
[FEAT] Added new attributes to RUM Device Info

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1639,6 +1639,18 @@ export interface CommonProperties {
          * Current screen brightness level (0.0 to 1.0).
          */
         readonly brightness_level?: number;
+        /**
+         * Number of device processors
+         */
+        readonly processor_count?: number;
+        /**
+         * Total RAM in megabytes
+         */
+        readonly total_ram?: number;
+        /**
+         * Whether the device is considered a low RAM device (Android)
+         */
+        readonly is_low_ram_device?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -599,6 +599,18 @@ export interface CommonTelemetryProperties {
              * Model of the device
              */
             model?: string;
+            /**
+             * Number of device processors
+             */
+            readonly processor_count?: number;
+            /**
+             * Total RAM in megabytes
+             */
+            readonly total_ram?: number;
+            /**
+             * Whether the device is considered a low RAM device (Android)
+             */
+            readonly is_low_ram_device?: boolean;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1639,6 +1639,18 @@ export interface CommonProperties {
          * Current screen brightness level (0.0 to 1.0).
          */
         readonly brightness_level?: number;
+        /**
+         * Number of device processors
+         */
+        readonly processor_count?: number;
+        /**
+         * Total RAM in megabytes
+         */
+        readonly total_ram?: number;
+        /**
+         * Whether the device is considered a low RAM device (Android)
+         */
+        readonly is_low_ram_device?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -599,6 +599,18 @@ export interface CommonTelemetryProperties {
              * Model of the device
              */
             model?: string;
+            /**
+             * Number of device processors
+             */
+            readonly processor_count?: number;
+            /**
+             * Total RAM in megabytes
+             */
+            readonly total_ram?: number;
+            /**
+             * Whether the device is considered a low RAM device (Android)
+             */
+            readonly is_low_ram_device?: boolean;
             [k: string]: unknown;
         };
         /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -355,6 +355,21 @@
           "type": "number",
           "description": "Current screen brightness level (0.0 to 1.0).",
           "readOnly": true
+        },
+        "processor_count": {
+          "type": "number",
+          "description": "Number of device processors",
+          "readOnly": true
+        },
+        "total_ram": {
+          "type": "number",
+          "description": "Total RAM in megabytes",
+          "readOnly": true
+        },
+        "is_low_ram_device": {
+          "type": "boolean",
+          "description": "Whether the device is considered a low RAM device (Android)",
+          "readOnly": true
         }
       }
     },

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -126,6 +126,21 @@
             "model": {
               "type": "string",
               "description": "Model of the device"
+            },
+            "processor_count": {
+              "type": "number",
+              "description": "Number of device processors",
+              "readOnly": true
+            },
+            "total_ram": {
+              "type": "number",
+              "description": "Total RAM in megabytes",
+              "readOnly": true
+            },
+            "is_low_ram_device": {
+              "type": "boolean",
+              "description": "Whether the device is considered a low RAM device (Android)",
+              "readOnly": true
             }
           }
         },


### PR DESCRIPTION
### What does this PR do?

Adds new attributes to the RUM Device Info:

- **totalRam**: The total RAM in megabytes
- **processorCount**: Number of device processors
- **isLowRamDevice**: Whether the device is considered a low RAM device; currently this is an Android only property coming from `ActivityManager.isLowRamDevice`, and it depends on the [device configuration](https://developer.android.com/reference/android/app/ActivityManager#isLowRamDevice()).

### Motivation

These attributes allow us to classify devices as low-, mid-, or high-tier, which improves our ability to diagnose performance issues.

The corresponding Mobile SDK PRs can be found here:

- **Android**: https://github.com/DataDog/dd-sdk-android/pull/3024
- **iOS**: https://github.com/DataDog/dd-sdk-ios/pull/2591