### PR TITLE
Fix validate script + fix new validation errors

### DIFF
--- a/schemas/rum/_stream-schema.json
+++ b/schemas/rum/_stream-schema.json
@@ -8,7 +8,6 @@
     "stream": {
       "type": "object",
       "description": "Stream properties",
-      "required": ["id"],
       "properties": {
         "bitrate": {
           "type": "number",

--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -26,7 +26,7 @@
         "view": {
           "type": "object",
           "description": "View properties",
-          "required": ["id", "url", "time_spent", "action", "error", "resource"],
+          "required": ["time_spent", "action", "error", "resource"],
           "properties": {
             "loading_time": {
               "type": "integer",

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -21,6 +21,7 @@ function validateSchemasObjectsPropertiesCase() {
       `${SCHEMAS_DIRECTORY}/session-replay/common/_common-segment-metadata-schema.json`,
       ['records_count', 'index_in_view', 'has_full_snapshot'],
     ],
+    [`${SCHEMAS_DIRECTORY}/session-replay/browser/segment-metadata-schema.json`, ['creation_reason']],
     [`${SCHEMAS_DIRECTORY}/session-replay/common/focus-record-schema.json`, ['has_focus']],
     [`${SCHEMAS_DIRECTORY}/rum/resource-schema.json`, ['operationType', 'operationName']],
   ])
@@ -148,15 +149,15 @@ function forEachObject(schema, callback) {
   if (Array.isArray(schema)) {
     // traverse arrays
     for (const value of schema) {
-      forEachObjectProperty(value, callback)
+      forEachObject(value, callback)
     }
   } else if (typeof schema === 'object' && schema !== null) {
     // traverse objects
     for (const value of Object.values(schema)) {
-      forEachObjectProperty(value, callback)
+      forEachObject(value, callback)
     }
 
-    if (schema.type === 'object') {
+    if (schema.type === 'object' || schema.properties) {
       callback(schema)
     }
   }


### PR DESCRIPTION
The validate script did not iterate correctly on all objects. Also, it looks like `type: object` is not needed for JSON format to consider a type as an object, so we missed some properties validation.

