### PR TITLE
Make graphQL operationType optional in schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -756,7 +756,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Type of the GraphQL operation
              */
-            readonly operationType: 'query' | 'mutation' | 'subscription';
+            readonly operationType?: 'query' | 'mutation' | 'subscription';
             /**
              * Name of the GraphQL operation
              */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -756,7 +756,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Type of the GraphQL operation
              */
-            readonly operationType: 'query' | 'mutation' | 'subscription';
+            readonly operationType?: 'query' | 'mutation' | 'subscription';
             /**
              * Name of the GraphQL operation
              */

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -285,7 +285,6 @@
             "graphql": {
               "type": "object",
               "description": "GraphQL requests parameters",
-              "required": ["operationType"],
               "properties": {
                 "operationType": {
                   "type": "string",


### PR DESCRIPTION
Following this [PR](https://github.com/DataDog/browser-sdk/pull/3992), operationType is not required anymore. 