### PR TITLE
[GraphQL resource] Rename error_count to errors_count

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -772,7 +772,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Number of GraphQL errors in the response
              */
-            readonly error_count?: number;
+            readonly errors_count?: number;
             /**
              * Array of GraphQL errors from the response
              */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -772,7 +772,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Number of GraphQL errors in the response
              */
-            readonly error_count?: number;
+            readonly errors_count?: number;
             /**
              * Array of GraphQL errors from the response
              */

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -307,7 +307,7 @@
                   "description": "String representation of the operation variables",
                   "readOnly": false
                 },
-                "error_count": {
+                "errors_count": {
                   "type": "integer",
                   "description": "Number of GraphQL errors in the response",
                   "minimum": 0,


### PR DESCRIPTION
On the resource schema, the field `error_count` of the GraphQL object has the wrong name, it should be called `errors_count` (see on Org2, there are [no resources](https://app.datadoghq.com/rum/sessions?query=%40type%3Aresource%20%40resource.graphql.error_count%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=has_replay%2Cstatus%2Ctimestamp%2C%40view.name%2C%40resource.url%2C%40resource.duration%2C%40resource.size%2C%40resource.status_code%2C%40resource.type&fromUser=false&sort_by=timestamp&sort_order=desc&viz=stream&from_ts=1765811409856&to_ts=1765897809856&live=true) for `error_count` but [there are some](https://app.datadoghq.com/rum/sessions?query=%40type%3Aresource%20%40resource.graphql.errors_count%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=has_replay%2Cstatus%2Ctimestamp%2C%40view.name%2C%40resource.url%2C%40resource.duration%2C%40resource.size%2C%40resource.status_code%2C%40resource.type&fromUser=false&sort_by=timestamp&sort_order=desc&viz=stream&from_ts=1765811409856&to_ts=1765897809856&live=true) for `errors_count`)