### PR TITLE
Revert "[GraphQL resource] Rename error_count to errors_count"

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -772,7 +772,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Number of GraphQL errors in the response
              */
-            readonly errors_count?: number;
+            readonly error_count?: number;
             /**
              * Array of GraphQL errors from the response
              */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -772,7 +772,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
             /**
              * Number of GraphQL errors in the response
              */
-            readonly errors_count?: number;
+            readonly error_count?: number;
             /**
              * Array of GraphQL errors from the response
              */

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -307,7 +307,7 @@
                   "description": "String representation of the operation variables",
                   "readOnly": false
                 },
-                "errors_count": {
+                "error_count": {
                   "type": "integer",
                   "description": "Number of GraphQL errors in the response",
                   "minimum": 0,


### PR DESCRIPTION
There were some discussions on whether we should keep `error_count` or `errors_count` (since the iOS SDK uses `error_count` and browser SDK uses `errors_count`. We eventually decided to keep `error_count` so this PR rolls back the change previously made from `error_count` to `errors_count`.