### PR TITLE
RUM-12387: Add android sdk schema generator check

### DIFF
--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -1,0 +1,40 @@
+name: android-sdk
+
+on:
+  push:
+
+jobs:
+  android-sdk-test:
+    runs-on: ubuntu-latest
+    env:
+      NDK_VERSION: '28.0.13004108'
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          repository: 'DataDog/dd-sdk-android'
+
+      - name: Setup Java
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'gradle'
+
+      # Ubuntu latest image doesn't have the exact version of the NDK that we need.
+      # So we install it manually and cache.
+      # https://github.com/actions/runner-images/blob/84b177af1632c67d56338e7c706fbee966b6e24e/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L239
+      - name: Cache NDK
+        id: cache-ndk
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: /usr/local/lib/android/sdk/ndk/${{ env.NDK_VERSION }}
+          key: android-ndk-${{ env.NDK_VERSION }}
+
+      - name: Setup Android NDK
+        run: yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${{ env.NDK_VERSION }}"
+
+      - name: Clone RUM schema
+        run: ./gradlew cloneAllRumSchemas -Pdd.rum.schema.ref="${{ github.ref_name }}"
+
+      - name: Generate JSON models
+        run: ./gradlew generateAllJsonModels


### PR DESCRIPTION
Introducing a CI check for Android SDK similar to what already [exists](https://github.com/DataDog/rum-events-format/blob/master/.github/workflows/ios-sdk.yml) for iOS.

This check:
1. Clones [dd-sdk-android](https://github.com/DataDog/dd-sdk-android) repo.
2. Makes it use the RUM schema from the current branch of `rum-events-format` repo.
3. Generates all JSON serialization/deserialization code.

Implementation details:
1. A successful run of the check can be found [here](https://github.com/DataDog/rum-events-format/actions/runs/20658494546/job/59316122463). This run uses a branch of `dd-sdk-android` repo from [this](https://github.com/DataDog/dd-sdk-android/pull/3094) PR. It needs to be merged first before the current PR in `rum-events-format` repo is merged.
2. As the Android generator code is inside the main Gradle project it requires Java, Android SDK and Android NDK to run any Gradle command.
3. Android SDK is already present in ubuntu-latest images [link](https://github.com/actions/runner-images/blob/84b177af1632c67d56338e7c706fbee966b6e24e/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L228). Currently dd-sdk-android needs `platform-36, build-tools 36.0.0` which are already there. But we still ask Android SDK manager to install them in case ubuntu-latest image changes.
4. Java 17 is configured using the Github supported [action](https://github.com/actions/setup-java). This action is also needed to configure Gradle dependencies [cache](https://github.com/actions/setup-java?tab=readme-ov-file#caching-gradle-dependencies).
5. The version of NDK that `dd-sdk-android` needs is `28.0.13004108`. Is isn't preinstalled on the ubuntu-latest image. So we install it using Android SDK Manager and cache it using GitHub cache so that it isn't downloaded every time. You can see a successful cache hit [here](https://github.com/DataDog/rum-events-format/actions/runs/20658494546/job/59316122463#step:4:14).