### PR TITLE
RUM-12199: Device Capabilities Attributes Refactoring

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1625,9 +1625,9 @@ export interface CommonProperties {
          */
         readonly brightness_level?: number;
         /**
-         * Number of device processors
+         * Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
          */
-        readonly processor_count?: number;
+        readonly logical_cpu_count?: number;
         /**
          * Total RAM in megabytes
          */
@@ -1635,7 +1635,7 @@ export interface CommonProperties {
         /**
          * Whether the device is considered a low RAM device (Android)
          */
-        readonly is_low_ram_device?: boolean;
+        readonly is_low_ram?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -600,9 +600,9 @@ export interface CommonTelemetryProperties {
              */
             model?: string;
             /**
-             * Number of device processors
+             * Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
              */
-            readonly processor_count?: number;
+            readonly logical_cpu_count?: number;
             /**
              * Total RAM in megabytes
              */
@@ -610,7 +610,7 @@ export interface CommonTelemetryProperties {
             /**
              * Whether the device is considered a low RAM device (Android)
              */
-            readonly is_low_ram_device?: boolean;
+            readonly is_low_ram?: boolean;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1625,9 +1625,9 @@ export interface CommonProperties {
          */
         readonly brightness_level?: number;
         /**
-         * Number of device processors
+         * Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
          */
-        readonly processor_count?: number;
+        readonly logical_cpu_count?: number;
         /**
          * Total RAM in megabytes
          */
@@ -1635,7 +1635,7 @@ export interface CommonProperties {
         /**
          * Whether the device is considered a low RAM device (Android)
          */
-        readonly is_low_ram_device?: boolean;
+        readonly is_low_ram?: boolean;
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -600,9 +600,9 @@ export interface CommonTelemetryProperties {
              */
             model?: string;
             /**
-             * Number of device processors
+             * Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
              */
-            readonly processor_count?: number;
+            readonly logical_cpu_count?: number;
             /**
              * Total RAM in megabytes
              */
@@ -610,7 +610,7 @@ export interface CommonTelemetryProperties {
             /**
              * Whether the device is considered a low RAM device (Android)
              */
-            readonly is_low_ram_device?: boolean;
+            readonly is_low_ram?: boolean;
             [k: string]: unknown;
         };
         /**

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -366,7 +366,7 @@
           "description": "Total RAM in megabytes",
           "readOnly": true
         },
-        "is_low_ram_device": {
+        "is_low_ram": {
           "type": "boolean",
           "description": "Whether the device is considered a low RAM device (Android)",
           "readOnly": true

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -356,9 +356,9 @@
           "description": "Current screen brightness level (0.0 to 1.0).",
           "readOnly": true
         },
-        "processor_count": {
+        "logical_cpu_count": {
           "type": "number",
-          "description": "Number of device processors",
+          "description": "Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.",
           "readOnly": true
         },
         "total_ram": {

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -137,7 +137,7 @@
               "description": "Total RAM in megabytes",
               "readOnly": true
             },
-            "is_low_ram_device": {
+            "is_low_ram": {
               "type": "boolean",
               "description": "Whether the device is considered a low RAM device (Android)",
               "readOnly": true

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -127,9 +127,9 @@
               "type": "string",
               "description": "Model of the device"
             },
-            "processor_count": {
+            "logical_cpu_count": {
               "type": "number",
-              "description": "Number of device processors",
+              "description": "Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.",
               "readOnly": true
             },
             "total_ram": {


### PR DESCRIPTION
### What does this PR do?

This PR refines device capability attribute names to improve clarity and reduce ambiguity.

#### `processor_count` → `logical_cpu_count`

The attribute was renamed to explicitly reflect what is actually reported by mobile platform APIs.

* On **Android**, `Runtime.availableProcessors()` returns the number of **logical CPU cores** available to the runtime.
* On **iOS**, `ProcessInfo.processInfo.processorCount` likewise reports the number of **logical** (not physical) cores.

Because both platforms expose logical core counts, the new name and updated description make this behavior explicit and avoid confusion with physical CPU cores.

#### `is_low_ram_device` → `is_low_ram`

The `_device` suffix was removed because the attribute already lives under the `device` parent, making the original name redundant.
