### PR TITLE
Add --stacktrace to gradle invocation on CI

### DIFF
--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -34,7 +34,7 @@ jobs:
         run: yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${{ env.NDK_VERSION }}"
 
       - name: Clone RUM schema
-        run: ./gradlew cloneAllRumSchemas -Pdd.rum.schema.ref="${{ github.ref_name }}"
+        run: ./gradlew cloneAllRumSchemas -Pdd.rum.schema.ref="${{ github.ref_name }}" --stacktrace
 
       - name: Generate JSON models
-        run: ./gradlew generateAllJsonModels
+        run: ./gradlew generateAllJsonModels --stacktrace


### PR DESCRIPTION
Adding `--stacktrace` argument to gradle invocation, so that we can have more info on build failures.