### PR TITLE
[RUM-13793] make resource.url optional

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -596,7 +596,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
         /**
          * URL of the resource
          */
-        url: string;
+        url?: string;
         /**
          * HTTP status code of the resource
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -596,7 +596,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
         /**
          * URL of the resource
          */
-        url: string;
+        url?: string;
         /**
          * HTTP status code of the resource
          */

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -26,7 +26,7 @@
         "resource": {
           "type": "object",
           "description": "Resource properties",
-          "required": ["type", "url"],
+          "required": ["type"],
           "properties": {
             "id": {
               "type": "string",


### PR DESCRIPTION
On some conditions, the Browser SDK sends resource events without URL:

```js
      DD_RUM.init({
        clientToken: 'xxx',
        applicationId: 'xxx',
        beforeSend() {},
      })
      fetch('/' + 'a'.repeat(300_000))
```

We'll work on a fix, but unfortunately old versions will still be around.