### PR TITLE
PANA-5615: Add mobile ui element identifier

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -541,6 +541,10 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -132,6 +132,10 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly selector?: string;
                 /**
+                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                 */
+                readonly permanent_id?: string;
+                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -1347,6 +1347,10 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -541,6 +541,10 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -132,6 +132,10 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly selector?: string;
                 /**
+                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                 */
+                readonly permanent_id?: string;
+                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -1347,6 +1347,10 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -180,6 +180,11 @@
                       "description": "CSS selector path of the target element",
                       "readOnly": true
                     },
+                    "permanent_id": {
+                      "type": "string",
+                      "description": "Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.",
+                      "readOnly": true
+                    },
                     "width": {
                       "type": "integer",
                       "description": "Width of the target element (in pixels)",

--- a/schemas/session-replay/mobile/_common-wireframe-schema.json
+++ b/schemas/session-replay/mobile/_common-wireframe-schema.json
@@ -33,6 +33,11 @@
     },
     "clip": {
       "$ref": "wireframe-clip-schema.json"
+    },
+    "permanentId": {
+      "type": "string",
+      "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+      "readOnly": true
     }
   }
 }


### PR DESCRIPTION
**Summary**
Adds optional `permanentId` field to mobile session replay common-wireframe-schema and rum-action schemas, for correlating wireframes with RUM action events.

**Changes**
Added `permanentId` to `_common-wireframe-schema.json`
Field: string, optional, readOnly
Description: MD5 hash of element's path (32 lowercase hex characters)

Added `permanentId` to `action-schema.json`
Field: string, optional, readOnly
Description: MD5 hash of element's path (32 lowercase hex characters)

**Affected Types**
All 5 wireframe types inherit this field:
`ShapeWireframe`
`TextWireframe`
`ImageWireframe`
`PlaceholderWireframe`
`WebviewWireframe`

Also, the rum action schema. 

**Compatibility**
Backwards compatible - existing data without `permanentId` remains valid.