### PR TITLE
update JS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ After editing any schema, you must re-generate the JS + TS definitions ([see bel
 This repository accommodates various usages, specifically:
 
 - The [Browser SDK](https://github.com/DataDog/browser-sdk/):
-
   - Generates TypeScript types from `schemas/rum-events-browser-schema.json`,
     `schemas/telemetry-events-schema.json` and `schemas/session-replay-browser-schema.json`.
 

--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of Browser SDK Profiling types.
  */
-export declare type BrowserProfiling = BrowserProfileEvent | BrowserProfilerTrace;
+export type BrowserProfiling = BrowserProfileEvent | BrowserProfilerTrace;
 /**
  * Schema of the Browser SDK Profile Event payload.
  */
-export declare type BrowserProfileEvent = ProfileCommonProperties & {
+export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Profile data format.
      */

--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -4,7 +4,7 @@
 /**
  * Browser-specific. Schema of a Session Replay data Segment.
  */
-export declare type BrowserSegment = BrowserSegmentMetadata & {
+export type BrowserSegment = BrowserSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -13,7 +13,7 @@ export declare type BrowserSegment = BrowserSegmentMetadata & {
 /**
  * Browser-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -23,15 +23,15 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
+export type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */
-export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
+export type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -41,7 +41,7 @@ export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema 
 /**
  * Schema of common properties for a Record event type that is supported by slots.
  */
-export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -50,17 +50,17 @@ export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNodeWithId = {
+export type SerializedNodeWithId = {
     id: number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -71,11 +71,11 @@ export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecord
 /**
  * Browser-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
+export type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
 /**
  * Browser-specific. Schema of a MutationData.
  */
-export declare type BrowserMutationData = {
+export type BrowserMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -84,7 +84,7 @@ export declare type BrowserMutationData = {
 /**
  * Browser-specific. Schema of a MutationPayload.
  */
-export declare type BrowserMutationPayload = {
+export type BrowserMutationPayload = {
     /**
      * Contains the newly added nodes.
      */
@@ -105,7 +105,7 @@ export declare type BrowserMutationPayload = {
 /**
  * Browser-specific. Schema of a MouseInteractionData.
  */
-export declare type MouseInteractionData = {
+export type MouseInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -114,7 +114,7 @@ export declare type MouseInteractionData = {
 /**
  * Browser-specific. Schema of a MouseInteraction.
  */
-export declare type MouseInteraction = {
+export type MouseInteraction = {
     /**
      * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
@@ -144,7 +144,7 @@ export declare type MouseInteraction = {
 /**
  * Browser-specific. Schema of a ScrollData.
  */
-export declare type ScrollData = {
+export type ScrollData = {
     /**
      * The source of this type of incremental data.
      */
@@ -153,7 +153,7 @@ export declare type ScrollData = {
 /**
  * Browser-specific. Schema of an InputData.
  */
-export declare type InputData = {
+export type InputData = {
     /**
      * The source of this type of incremental data.
      */
@@ -166,7 +166,7 @@ export declare type InputData = {
 /**
  * Browser-specific. Schema of an InputState.
  */
-export declare type InputState = {
+export type InputState = {
     /**
      * Text value for this InputState.
      */
@@ -180,7 +180,7 @@ export declare type InputState = {
 /**
  * Browser-specific. Schema of a MediaInteractionData.
  */
-export declare type MediaInteractionData = {
+export type MediaInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -189,7 +189,7 @@ export declare type MediaInteractionData = {
 /**
  * Browser-specific. Schema of a StyleSheetRuleData.
  */
-export declare type StyleSheetRuleData = {
+export type StyleSheetRuleData = {
     /**
      * The source of this type of incremental data.
      */
@@ -198,7 +198,7 @@ export declare type StyleSheetRuleData = {
 /**
  * Schema of a ViewportResizeData.
  */
-export declare type ViewportResizeData = {
+export type ViewportResizeData = {
     /**
      * The source of this type of incremental data.
      */
@@ -207,7 +207,7 @@ export declare type ViewportResizeData = {
 /**
  * Schema of a PointerInteractionData.
  */
-export declare type PointerInteractionData = {
+export type PointerInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -216,7 +216,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
+export type MetaRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -242,7 +242,7 @@ export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
+export type FocusRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -257,7 +257,7 @@ export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
+export type ViewEndRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -266,7 +266,7 @@ export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
+export type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -284,7 +284,7 @@ export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
+export type FrustrationRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -306,7 +306,7 @@ export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema of a record type which represents changes using a compact encoding. (Experimental; subject to change.)
  */
-export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -317,51 +317,51 @@ export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export declare type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
 /**
  * Browser-specific. Schema representing the addition of a string to the string table.
  */
-export declare type AddStringChange = string;
+export type AddStringChange = string;
 /**
  * Browser-specific. Schema representing the addition of a new node to the document.
  */
-export declare type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
+export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
 /**
  * Schema representing the addition of a new #cdata-section node.
  *
  * @minItems 2
  */
-export declare type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
-export declare type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
+export type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
 /**
  * A positive integer insertion point. Inserting a node at positive integer N indicates that the new node's parent is the node with an id N lower than the new node, and that we should insert the new node at the end of its parent's child list, as if the DOM method appendChild() was being used.
  */
-export declare type AppendChildInsertionPoint = number;
+export type AppendChildInsertionPoint = number;
 /**
  * A zero insertion point. Inserting a node at zero indicates that the new node should be inserted after the node with an id one lower than the new node, as if the DOM method after() is being used. Using a zero insertion point repeatedly is thus a quick way to insert a sequence of sibling elements.
  */
-export declare type InsertAfterPreviousInsertionPoint = 0;
+export type InsertAfterPreviousInsertionPoint = 0;
 /**
  * A negative integer insertion point. Inserting a node at negative integer -N indicates that the new node's next sibling is the node with an id N lower than the new node, and that we should insert the new node before its next sibling, as if the DOM method insertBefore() was being used.
  */
-export declare type InsertBeforeInsertionPoint = number;
+export type InsertBeforeInsertionPoint = number;
 /**
  * A null insertion point, indicating that the node should be inserted at the root of the document.
  */
-export declare type RootInsertionPoint = null;
+export type RootInsertionPoint = null;
 /**
  * Browser-specific. Schema representing a string, expressed as an index into the string table.
  */
-export declare type StringReference = number;
+export type StringReference = number;
 /**
  * Schema representing the addition of a new #doctype node, using the format [#doctype, name, public ID, system ID].
  *
  * @minItems 5
  */
-export declare type AddDocTypeNodeChange = [
+export type AddDocTypeNodeChange = [
     InsertionPoint,
     '#doctype' | StringReference,
     StringOrStringReference,
@@ -371,133 +371,133 @@ export declare type AddDocTypeNodeChange = [
 /**
  * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
  */
-export declare type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = string | StringReference;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export declare type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export declare type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export declare type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
  * @minItems 2
  */
-export declare type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
+export type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
 /**
  * Schema representing the addition of a new #shadow-root node.
  *
  * @minItems 2
  */
-export declare type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export declare type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
-export declare type RemoveNodeChange = number;
+export type RemoveNodeChange = number;
 /**
  * Browser-specific. Schema representing a change to an node's attributes.
  *
  * @minItems 1
  */
-export declare type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
+export type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
 /**
  * Browser-specific. Schema representing the ID of a DOM node.
  */
-export declare type NodeId = number;
+export type NodeId = number;
 /**
  * Schema representing a change to an attribute, either by assignment of a new value or by deletion of the attribute.
  */
-export declare type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
+export type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
 /**
  * Schema representing the deletion of an attribute.
  *
  * @minItems 1
  */
-export declare type AttributeDeletion = [StringOrStringReference];
+export type AttributeDeletion = [StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change to the text content of a #text node.
  *
  * @minItems 2
  */
-export declare type TextChange = [NodeId, StringOrStringReference];
+export type TextChange = [NodeId, StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change in an element's size.
  *
  * @minItems 3
  */
-export declare type SizeChange = [NodeId, number, number];
+export type SizeChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing a scroll position change.
  *
  * @minItems 3
  */
-export declare type ScrollPositionChange = [NodeId, number, number];
+export type ScrollPositionChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing the addition of a new stylesheet to the document.
  */
-export declare type AddStyleSheetChange = StyleSheetSnapshot;
+export type AddStyleSheetChange = StyleSheetSnapshot;
 /**
  * Schema representing a snapshot of a CSS stylesheet.
  *
  * @minItems 1
  */
-export declare type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */
-export declare type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
+export type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
 /**
  * If non-empty, the list of medias for which this stylesheet is active. Defaults to the empty list if not present.
  */
-export declare type StyleSheetMediaList = StringOrStringReference[];
+export type StyleSheetMediaList = StringOrStringReference[];
 /**
  * Browser-specific. Schema representing a change to the stylesheets attached to a DOM node. For <link> or <style> elements, which use classic CSSOM APIs, at most one stylesheet can be attached. For #document, #document-fragment, or #shadow-root nodes, which use the `adoptedStyleSheets` API, any number of stylesheets can be attached.
  *
  * @minItems 1
  */
-export declare type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
+export type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
 /**
  * Browser-specific. Schema representing the ID of a stylesheet.
  */
-export declare type StyleSheetId = number;
+export type StyleSheetId = number;
 /**
  * Browser-specific. Schema representing a change to the playback state of the media associated with an <audio> or <video> element.
  *
  * @minItems 2
  */
-export declare type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
+export type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
 /**
  * A playback state indicating that the associated media is playing.
  */
-export declare type PlaybackStatePlaying = 0;
+export type PlaybackStatePlaying = 0;
 /**
  * A playback state indicating that the associated media is paused.
  */
-export declare type PlaybackStatePaused = 1;
+export type PlaybackStatePaused = 1;
 /**
  * Browser-specific. Schema representing a change to the visual viewport, defined in terms of the web platform VisualViewport API.
  *
  * @minItems 7
  */
-export declare type VisualViewportChange = [
+export type VisualViewportChange = [
     VisualViewportOffsetLeft,
     VisualViewportOffsetTop,
     VisualViewportPageLeft,
@@ -509,31 +509,31 @@ export declare type VisualViewportChange = [
 /**
  * The offset of the left edge of the visual viewport from the left edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetLeft = number;
+export type VisualViewportOffsetLeft = number;
 /**
  * The offset of the top edge of the visual viewport from the top edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetTop = number;
+export type VisualViewportOffsetTop = number;
 /**
  * The x coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageLeft = number;
+export type VisualViewportPageLeft = number;
 /**
  * The y coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageTop = number;
+export type VisualViewportPageTop = number;
 /**
  * The width of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportWidth = number;
+export type VisualViewportWidth = number;
 /**
  * The height of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportHeight = number;
+export type VisualViewportHeight = number;
 /**
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
-export declare type VisualViewportScale = number;
+export type VisualViewportScale = number;
 /**
  * Schema of a Session Replay Segment context.
  */

--- a/lib/cjs/generated/mobileProfiling.d.ts
+++ b/lib/cjs/generated/mobileProfiling.d.ts
@@ -4,7 +4,7 @@
 /**
  * Schema of the Mobile SDK Profile Event metadata.
  */
-export declare type MobileProfileEvent = ProfileCommonProperties & {
+export type MobileProfileEvent = ProfileCommonProperties & {
     /**
      * The RUM Vital this profile event is associated with.
      */

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -4,7 +4,7 @@
 /**
  * Mobile-specific. Schema of a Session Replay data Segment.
  */
-export declare type MobileSegment = MobileSegmentMetadata & {
+export type MobileSegment = MobileSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -13,7 +13,7 @@ export declare type MobileSegment = MobileSegmentMetadata & {
 /**
  * Mobile-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -22,11 +22,11 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
 /**
  * Mobile-specific. Schema of a Session Replay Record.
  */
-export declare type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
+export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -41,11 +41,11 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
+export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
-export declare type ShapeWireframe = CommonShapeWireframe & {
+export type ShapeWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -54,14 +54,14 @@ export declare type ShapeWireframe = CommonShapeWireframe & {
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
  */
-export declare type CommonShapeWireframe = CommonWireframe & {
+export type CommonShapeWireframe = CommonWireframe & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * The style of this wireframe.
  */
-export declare type ShapeStyle = {
+export type ShapeStyle = {
     /**
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
@@ -78,7 +78,7 @@ export declare type ShapeStyle = {
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
-export declare type ShapeBorder = {
+export type ShapeBorder = {
     /**
      * The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
@@ -91,7 +91,7 @@ export declare type ShapeBorder = {
 /**
  * Schema of all properties of a TextWireframe.
  */
-export declare type TextWireframe = CommonShapeWireframe & {
+export type TextWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -106,7 +106,7 @@ export declare type TextWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a TextStyle.
  */
-export declare type TextStyle = {
+export type TextStyle = {
     /**
      * The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif
      */
@@ -127,7 +127,7 @@ export declare type TextStyle = {
 /**
  * Schema of all properties of a TextPosition.
  */
-export declare type TextPosition = {
+export type TextPosition = {
     readonly padding?: {
         /**
          * The top padding in pixels. The default value is 0.
@@ -160,7 +160,7 @@ export declare type TextPosition = {
 /**
  * Schema of all properties of a ImageWireframe.
  */
-export declare type ImageWireframe = CommonShapeWireframe & {
+export type ImageWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -185,7 +185,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframe = CommonWireframe & {
+export type PlaceholderWireframe = CommonWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -198,7 +198,7 @@ export declare type PlaceholderWireframe = CommonWireframe & {
 /**
  * Schema of all properties of a WebviewWireframe.
  */
-export declare type WebviewWireframe = CommonShapeWireframe & {
+export type WebviewWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -215,7 +215,7 @@ export declare type WebviewWireframe = CommonShapeWireframe & {
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -225,11 +225,11 @@ export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
-export declare type MobileMutationData = {
+export type MobileMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -238,11 +238,11 @@ export declare type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
-export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
+export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -257,14 +257,14 @@ export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
  */
-export declare type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
  */
-export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -273,7 +273,7 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a ImageWireframeUpdate.
  */
-export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -298,7 +298,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
+export type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -311,7 +311,7 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
 /**
  * Schema of all properties of a WebviewWireframeUpdate.
  */
-export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -328,7 +328,7 @@ export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of a TouchData.
  */
-export declare type TouchData = {
+export type TouchData = {
     /**
      * The source of this type of incremental data.
      */
@@ -358,7 +358,7 @@ export declare type TouchData = {
 /**
  * Schema of a ViewportResizeData.
  */
-export declare type ViewportResizeData = {
+export type ViewportResizeData = {
     /**
      * The source of this type of incremental data.
      */
@@ -367,7 +367,7 @@ export declare type ViewportResizeData = {
 /**
  * Schema of a PointerInteractionData.
  */
-export declare type PointerInteractionData = {
+export type PointerInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -376,7 +376,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
+export type MetaRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -402,7 +402,7 @@ export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of common properties for a Record event type that is supported by slots.
  */
-export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -411,7 +411,7 @@ export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
+export type FocusRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -426,7 +426,7 @@ export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
+export type ViewEndRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -435,7 +435,7 @@ export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
+export type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;

--- a/lib/cjs/generated/profiling.d.ts
+++ b/lib/cjs/generated/profiling.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of RUM Profiling.
  */
-export declare type Profiling = BrowserProfileEvent | MobileProfileEvent;
+export type Profiling = BrowserProfileEvent | MobileProfileEvent;
 /**
  * Browser SDK profiling payload.
  */
-export declare type BrowserProfileEvent = ProfileCommonProperties & {
+export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Profile data format.
      */
@@ -28,7 +28,7 @@ export declare type BrowserProfileEvent = ProfileCommonProperties & {
 /**
  * Mobile SDK profiling event.
  */
-export declare type MobileProfileEvent = ProfileCommonProperties & {
+export type MobileProfileEvent = ProfileCommonProperties & {
     /**
      * The RUM Vital this profile event is associated with.
      */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -870,50 +870,62 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & Stre
          */
         readonly time_spent: number;
         /**
+         * @deprecated
          * Duration in ns to the first rendering (deprecated in favor of `view.performance.fcp.timestamp`)
          */
         readonly first_contentful_paint?: number;
         /**
+         * @deprecated
          * Duration in ns to the largest contentful paint (deprecated in favor of `view.performance.lcp.timestamp`)
          */
         readonly largest_contentful_paint?: number;
         /**
+         * @deprecated
          * CSS selector path of the largest contentful paint element (deprecated in favor of `view.performance.lcp.target_selector`)
          */
         readonly largest_contentful_paint_target_selector?: string;
         /**
+         * @deprecated
          * Duration in ns of the first input event delay (deprecated in favor of `view.performance.fid.duration`)
          */
         readonly first_input_delay?: number;
         /**
+         * @deprecated
          * Duration in ns to the first input (deprecated in favor of `view.performance.fid.timestamp`)
          */
         readonly first_input_time?: number;
         /**
+         * @deprecated
          * CSS selector path of the first input target element (deprecated in favor of `view.performance.fid.target_selector`)
          */
         readonly first_input_target_selector?: string;
         /**
+         * @deprecated
          * Longest duration in ns between an interaction and the next paint (deprecated in favor of `view.performance.inp.duration`)
          */
         readonly interaction_to_next_paint?: number;
         /**
+         * @deprecated
          * Duration in ns between start of the view and start of the INP (deprecated in favor of `view.performance.inp.timestamp`)
          */
         readonly interaction_to_next_paint_time?: number;
         /**
+         * @deprecated
          * CSS selector path of the interacted element corresponding to INP (deprecated in favor of `view.performance.inp.target_selector`)
          */
         readonly interaction_to_next_paint_target_selector?: string;
         /**
+         * @deprecated
          * Total layout shift score that occurred on the view (deprecated in favor of `view.performance.cls.score`)
          */
         readonly cumulative_layout_shift?: number;
         /**
+         * @deprecated
          * Duration in ns between start of the view and start of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.timestamp`)
          */
         readonly cumulative_layout_shift_time?: number;
         /**
+         * @deprecated
          * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.target_selector`)
          */
         readonly cumulative_layout_shift_target_selector?: string;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of all properties of a RUM event
  */
-export declare type RumEvent = RumActionEvent | RumTransitionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent | RumVitalEvent;
+export type RumEvent = RumActionEvent | RumTransitionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent | RumVitalEvent;
 /**
  * Schema of all properties of an Action event
  */
-export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
+export type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -154,7 +154,7 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
 /**
  * Schema of all properties of an Transition event
  */
-export declare type RumTransitionEvent = CommonProperties & {
+export type RumTransitionEvent = CommonProperties & {
     /**
      * RUM event type
      */
@@ -208,7 +208,7 @@ export declare type RumTransitionEvent = CommonProperties & {
 /**
  * Schema of all properties of an Error event
  */
-export declare type RumErrorEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
+export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -456,7 +456,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
 /**
  * Schema of all properties of a Long Task event
  */
-export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
+export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -572,7 +572,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a Resource event
  */
-export declare type RumResourceEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
+export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -840,7 +840,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a View event
  */
-export declare type RumViewEvent = CommonProperties & ViewContainerSchema & StreamSchema & {
+export type RumViewEvent = CommonProperties & ViewContainerSchema & StreamSchema & {
     /**
      * RUM event type
      */
@@ -1241,11 +1241,11 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & Stre
     };
     [k: string]: unknown;
 };
-export declare type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent | RumVitalAppLaunchEvent;
+export type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent | RumVitalAppLaunchEvent;
 /**
  * Schema for a duration vital event.
  */
-export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
+export type RumVitalDurationEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */
@@ -1265,7 +1265,7 @@ export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
 /**
  * Schema of common properties for a Vital event
  */
-export declare type RumVitalEventCommonProperties = CommonProperties & ViewContainerSchema & {
+export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -1293,7 +1293,7 @@ export declare type RumVitalEventCommonProperties = CommonProperties & ViewConta
 /**
  * Schema for a vital operation step event.
  */
-export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
+export type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */
@@ -1321,7 +1321,7 @@ export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties &
 /**
  * Schema for app launch metrics.
  */
-export declare type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
+export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -4,15 +4,15 @@
 /**
  * Schema of all properties of Session Replay
  */
-export declare type SessionReplay = Segment & SegmentMetadata & Record & FullSnapshotRecord & IncrementalSnapshotRecord & IncrementalData & MutationData & MutationPayload;
+export type SessionReplay = Segment & SegmentMetadata & Record & FullSnapshotRecord & IncrementalSnapshotRecord & IncrementalData & MutationData & MutationPayload;
 /**
  * Schema of a Session Replay data Segment.
  */
-export declare type Segment = BrowserSegment | MobileSegment;
+export type Segment = BrowserSegment | MobileSegment;
 /**
  * Browser-specific. Schema of a Session Replay data Segment.
  */
-export declare type BrowserSegment = BrowserSegmentMetadata & {
+export type BrowserSegment = BrowserSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -21,7 +21,7 @@ export declare type BrowserSegment = BrowserSegmentMetadata & {
 /**
  * Browser-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -31,15 +31,15 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
+export type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */
-export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
+export type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -49,7 +49,7 @@ export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema 
 /**
  * Schema of common properties for a Record event type that is supported by slots.
  */
-export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -58,17 +58,17 @@ export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNodeWithId = {
+export type SerializedNodeWithId = {
     id: number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -79,11 +79,11 @@ export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecord
 /**
  * Browser-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
+export type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
 /**
  * Browser-specific. Schema of a MutationData.
  */
-export declare type BrowserMutationData = {
+export type BrowserMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -92,7 +92,7 @@ export declare type BrowserMutationData = {
 /**
  * Browser-specific. Schema of a MutationPayload.
  */
-export declare type BrowserMutationPayload = {
+export type BrowserMutationPayload = {
     /**
      * Contains the newly added nodes.
      */
@@ -113,7 +113,7 @@ export declare type BrowserMutationPayload = {
 /**
  * Browser-specific. Schema of a MouseInteractionData.
  */
-export declare type MouseInteractionData = {
+export type MouseInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -122,7 +122,7 @@ export declare type MouseInteractionData = {
 /**
  * Browser-specific. Schema of a MouseInteraction.
  */
-export declare type MouseInteraction = {
+export type MouseInteraction = {
     /**
      * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
@@ -152,7 +152,7 @@ export declare type MouseInteraction = {
 /**
  * Browser-specific. Schema of a ScrollData.
  */
-export declare type ScrollData = {
+export type ScrollData = {
     /**
      * The source of this type of incremental data.
      */
@@ -161,7 +161,7 @@ export declare type ScrollData = {
 /**
  * Browser-specific. Schema of an InputData.
  */
-export declare type InputData = {
+export type InputData = {
     /**
      * The source of this type of incremental data.
      */
@@ -174,7 +174,7 @@ export declare type InputData = {
 /**
  * Browser-specific. Schema of an InputState.
  */
-export declare type InputState = {
+export type InputState = {
     /**
      * Text value for this InputState.
      */
@@ -188,7 +188,7 @@ export declare type InputState = {
 /**
  * Browser-specific. Schema of a MediaInteractionData.
  */
-export declare type MediaInteractionData = {
+export type MediaInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -197,7 +197,7 @@ export declare type MediaInteractionData = {
 /**
  * Browser-specific. Schema of a StyleSheetRuleData.
  */
-export declare type StyleSheetRuleData = {
+export type StyleSheetRuleData = {
     /**
      * The source of this type of incremental data.
      */
@@ -206,7 +206,7 @@ export declare type StyleSheetRuleData = {
 /**
  * Schema of a ViewportResizeData.
  */
-export declare type ViewportResizeData = {
+export type ViewportResizeData = {
     /**
      * The source of this type of incremental data.
      */
@@ -215,7 +215,7 @@ export declare type ViewportResizeData = {
 /**
  * Schema of a PointerInteractionData.
  */
-export declare type PointerInteractionData = {
+export type PointerInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -224,7 +224,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
+export type MetaRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -250,7 +250,7 @@ export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
+export type FocusRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -265,7 +265,7 @@ export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
+export type ViewEndRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -274,7 +274,7 @@ export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
+export type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -292,7 +292,7 @@ export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
+export type FrustrationRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -314,7 +314,7 @@ export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema of a record type which represents changes using a compact encoding. (Experimental; subject to change.)
  */
-export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -325,51 +325,51 @@ export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export declare type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
 /**
  * Browser-specific. Schema representing the addition of a string to the string table.
  */
-export declare type AddStringChange = string;
+export type AddStringChange = string;
 /**
  * Browser-specific. Schema representing the addition of a new node to the document.
  */
-export declare type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
+export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
 /**
  * Schema representing the addition of a new #cdata-section node.
  *
  * @minItems 2
  */
-export declare type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
-export declare type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
+export type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
 /**
  * A positive integer insertion point. Inserting a node at positive integer N indicates that the new node's parent is the node with an id N lower than the new node, and that we should insert the new node at the end of its parent's child list, as if the DOM method appendChild() was being used.
  */
-export declare type AppendChildInsertionPoint = number;
+export type AppendChildInsertionPoint = number;
 /**
  * A zero insertion point. Inserting a node at zero indicates that the new node should be inserted after the node with an id one lower than the new node, as if the DOM method after() is being used. Using a zero insertion point repeatedly is thus a quick way to insert a sequence of sibling elements.
  */
-export declare type InsertAfterPreviousInsertionPoint = 0;
+export type InsertAfterPreviousInsertionPoint = 0;
 /**
  * A negative integer insertion point. Inserting a node at negative integer -N indicates that the new node's next sibling is the node with an id N lower than the new node, and that we should insert the new node before its next sibling, as if the DOM method insertBefore() was being used.
  */
-export declare type InsertBeforeInsertionPoint = number;
+export type InsertBeforeInsertionPoint = number;
 /**
  * A null insertion point, indicating that the node should be inserted at the root of the document.
  */
-export declare type RootInsertionPoint = null;
+export type RootInsertionPoint = null;
 /**
  * Browser-specific. Schema representing a string, expressed as an index into the string table.
  */
-export declare type StringReference = number;
+export type StringReference = number;
 /**
  * Schema representing the addition of a new #doctype node, using the format [#doctype, name, public ID, system ID].
  *
  * @minItems 5
  */
-export declare type AddDocTypeNodeChange = [
+export type AddDocTypeNodeChange = [
     InsertionPoint,
     '#doctype' | StringReference,
     StringOrStringReference,
@@ -379,133 +379,133 @@ export declare type AddDocTypeNodeChange = [
 /**
  * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
  */
-export declare type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = string | StringReference;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export declare type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export declare type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export declare type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
  * @minItems 2
  */
-export declare type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
+export type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
 /**
  * Schema representing the addition of a new #shadow-root node.
  *
  * @minItems 2
  */
-export declare type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export declare type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
-export declare type RemoveNodeChange = number;
+export type RemoveNodeChange = number;
 /**
  * Browser-specific. Schema representing a change to an node's attributes.
  *
  * @minItems 1
  */
-export declare type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
+export type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
 /**
  * Browser-specific. Schema representing the ID of a DOM node.
  */
-export declare type NodeId = number;
+export type NodeId = number;
 /**
  * Schema representing a change to an attribute, either by assignment of a new value or by deletion of the attribute.
  */
-export declare type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
+export type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
 /**
  * Schema representing the deletion of an attribute.
  *
  * @minItems 1
  */
-export declare type AttributeDeletion = [StringOrStringReference];
+export type AttributeDeletion = [StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change to the text content of a #text node.
  *
  * @minItems 2
  */
-export declare type TextChange = [NodeId, StringOrStringReference];
+export type TextChange = [NodeId, StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change in an element's size.
  *
  * @minItems 3
  */
-export declare type SizeChange = [NodeId, number, number];
+export type SizeChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing a scroll position change.
  *
  * @minItems 3
  */
-export declare type ScrollPositionChange = [NodeId, number, number];
+export type ScrollPositionChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing the addition of a new stylesheet to the document.
  */
-export declare type AddStyleSheetChange = StyleSheetSnapshot;
+export type AddStyleSheetChange = StyleSheetSnapshot;
 /**
  * Schema representing a snapshot of a CSS stylesheet.
  *
  * @minItems 1
  */
-export declare type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */
-export declare type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
+export type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
 /**
  * If non-empty, the list of medias for which this stylesheet is active. Defaults to the empty list if not present.
  */
-export declare type StyleSheetMediaList = StringOrStringReference[];
+export type StyleSheetMediaList = StringOrStringReference[];
 /**
  * Browser-specific. Schema representing a change to the stylesheets attached to a DOM node. For <link> or <style> elements, which use classic CSSOM APIs, at most one stylesheet can be attached. For #document, #document-fragment, or #shadow-root nodes, which use the `adoptedStyleSheets` API, any number of stylesheets can be attached.
  *
  * @minItems 1
  */
-export declare type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
+export type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
 /**
  * Browser-specific. Schema representing the ID of a stylesheet.
  */
-export declare type StyleSheetId = number;
+export type StyleSheetId = number;
 /**
  * Browser-specific. Schema representing a change to the playback state of the media associated with an <audio> or <video> element.
  *
  * @minItems 2
  */
-export declare type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
+export type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
 /**
  * A playback state indicating that the associated media is playing.
  */
-export declare type PlaybackStatePlaying = 0;
+export type PlaybackStatePlaying = 0;
 /**
  * A playback state indicating that the associated media is paused.
  */
-export declare type PlaybackStatePaused = 1;
+export type PlaybackStatePaused = 1;
 /**
  * Browser-specific. Schema representing a change to the visual viewport, defined in terms of the web platform VisualViewport API.
  *
  * @minItems 7
  */
-export declare type VisualViewportChange = [
+export type VisualViewportChange = [
     VisualViewportOffsetLeft,
     VisualViewportOffsetTop,
     VisualViewportPageLeft,
@@ -517,35 +517,35 @@ export declare type VisualViewportChange = [
 /**
  * The offset of the left edge of the visual viewport from the left edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetLeft = number;
+export type VisualViewportOffsetLeft = number;
 /**
  * The offset of the top edge of the visual viewport from the top edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetTop = number;
+export type VisualViewportOffsetTop = number;
 /**
  * The x coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageLeft = number;
+export type VisualViewportPageLeft = number;
 /**
  * The y coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageTop = number;
+export type VisualViewportPageTop = number;
 /**
  * The width of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportWidth = number;
+export type VisualViewportWidth = number;
 /**
  * The height of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportHeight = number;
+export type VisualViewportHeight = number;
 /**
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
-export declare type VisualViewportScale = number;
+export type VisualViewportScale = number;
 /**
  * Mobile-specific. Schema of a Session Replay data Segment.
  */
-export declare type MobileSegment = MobileSegmentMetadata & {
+export type MobileSegment = MobileSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -554,7 +554,7 @@ export declare type MobileSegment = MobileSegmentMetadata & {
 /**
  * Mobile-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -563,11 +563,11 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
 /**
  * Mobile-specific. Schema of a Session Replay Record.
  */
-export declare type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
+export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -582,11 +582,11 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
+export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
-export declare type ShapeWireframe = CommonShapeWireframe & {
+export type ShapeWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -595,14 +595,14 @@ export declare type ShapeWireframe = CommonShapeWireframe & {
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
  */
-export declare type CommonShapeWireframe = CommonWireframe & {
+export type CommonShapeWireframe = CommonWireframe & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * The style of this wireframe.
  */
-export declare type ShapeStyle = {
+export type ShapeStyle = {
     /**
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
@@ -619,7 +619,7 @@ export declare type ShapeStyle = {
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
-export declare type ShapeBorder = {
+export type ShapeBorder = {
     /**
      * The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
@@ -632,7 +632,7 @@ export declare type ShapeBorder = {
 /**
  * Schema of all properties of a TextWireframe.
  */
-export declare type TextWireframe = CommonShapeWireframe & {
+export type TextWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -647,7 +647,7 @@ export declare type TextWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a TextStyle.
  */
-export declare type TextStyle = {
+export type TextStyle = {
     /**
      * The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif
      */
@@ -668,7 +668,7 @@ export declare type TextStyle = {
 /**
  * Schema of all properties of a TextPosition.
  */
-export declare type TextPosition = {
+export type TextPosition = {
     readonly padding?: {
         /**
          * The top padding in pixels. The default value is 0.
@@ -701,7 +701,7 @@ export declare type TextPosition = {
 /**
  * Schema of all properties of a ImageWireframe.
  */
-export declare type ImageWireframe = CommonShapeWireframe & {
+export type ImageWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -726,7 +726,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframe = CommonWireframe & {
+export type PlaceholderWireframe = CommonWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -739,7 +739,7 @@ export declare type PlaceholderWireframe = CommonWireframe & {
 /**
  * Schema of all properties of a WebviewWireframe.
  */
-export declare type WebviewWireframe = CommonShapeWireframe & {
+export type WebviewWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -756,7 +756,7 @@ export declare type WebviewWireframe = CommonShapeWireframe & {
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -766,11 +766,11 @@ export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
-export declare type MobileMutationData = {
+export type MobileMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -779,11 +779,11 @@ export declare type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
-export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
+export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -798,14 +798,14 @@ export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
  */
-export declare type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
  */
-export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -814,7 +814,7 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a ImageWireframeUpdate.
  */
-export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -839,7 +839,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
+export type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -852,7 +852,7 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
 /**
  * Schema of all properties of a WebviewWireframeUpdate.
  */
-export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -869,7 +869,7 @@ export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of a TouchData.
  */
-export declare type TouchData = {
+export type TouchData = {
     /**
      * The source of this type of incremental data.
      */
@@ -899,31 +899,31 @@ export declare type TouchData = {
 /**
  * Schema of a Session Replay SegmentMetadata.
  */
-export declare type SegmentMetadata = BrowserSegmentMetadata | MobileSegmentMetadata;
+export type SegmentMetadata = BrowserSegmentMetadata | MobileSegmentMetadata;
 /**
  * Schema of a Session Replay Record.
  */
-export declare type Record = BrowserRecord | MobileRecord;
+export type Record = BrowserRecord | MobileRecord;
 /**
  * Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type FullSnapshotRecord = BrowserFullSnapshotRecord | MobileFullSnapshotRecord;
+export type FullSnapshotRecord = BrowserFullSnapshotRecord | MobileFullSnapshotRecord;
 /**
  * Schema of a Record type which contains mutations of a screen.
  */
-export declare type IncrementalSnapshotRecord = BrowserIncrementalSnapshotRecord | MobileIncrementalSnapshotRecord;
+export type IncrementalSnapshotRecord = BrowserIncrementalSnapshotRecord | MobileIncrementalSnapshotRecord;
 /**
  * Schema of a Session Replay IncrementalData type.
  */
-export declare type IncrementalData = BrowserIncrementalData | MobileIncrementalData;
+export type IncrementalData = BrowserIncrementalData | MobileIncrementalData;
 /**
  * Schema of a MutationData.
  */
-export declare type MutationData = BrowserMutationData | MobileMutationData;
+export type MutationData = BrowserMutationData | MobileMutationData;
 /**
  * Schema of a MutationPayload.
  */
-export declare type MutationPayload = BrowserMutationPayload | MobileMutationPayload;
+export type MutationPayload = BrowserMutationPayload | MobileMutationPayload;
 /**
  * Schema of a Session Replay Segment context.
  */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of all properties of a telemetry event
  */
-export declare type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent | TelemetryUsageEvent;
+export type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent | TelemetryUsageEvent;
 /**
  * Schema of all properties of a telemetry error event
  */
-export declare type TelemetryErrorEvent = CommonTelemetryProperties & {
+export type TelemetryErrorEvent = CommonTelemetryProperties & {
     /**
      * The telemetry log information
      */
@@ -46,7 +46,7 @@ export declare type TelemetryErrorEvent = CommonTelemetryProperties & {
 /**
  * Schema of all properties of a telemetry debug event
  */
-export declare type TelemetryDebugEvent = CommonTelemetryProperties & {
+export type TelemetryDebugEvent = CommonTelemetryProperties & {
     /**
      * The telemetry log information
      */
@@ -70,7 +70,7 @@ export declare type TelemetryDebugEvent = CommonTelemetryProperties & {
 /**
  * Schema of all properties of a telemetry configuration event
  */
-export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
+export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
     /**
      * The telemetry configuration information
      */
@@ -474,7 +474,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
 /**
  * Schema of all properties of a telemetry usage event
  */
-export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
+export type TelemetryUsageEvent = CommonTelemetryProperties & {
     /**
      * The telemetry usage information
      */
@@ -491,15 +491,15 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital;
+export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital;
 /**
  * Schema of browser specific features usage
  */
-export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
 /**
  * Schema of mobile specific features usage
  */
-export declare type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView;
+export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView;
 /**
  * Schema of common properties of Telemetry events
  */

--- a/lib/cjs/src/profiling.js
+++ b/lib/cjs/src/profiling.js
@@ -15,13 +15,23 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };

--- a/lib/cjs/src/session-replay-browser.d.ts
+++ b/lib/cjs/src/session-replay-browser.d.ts
@@ -6,7 +6,7 @@ export * from '../generated/browserSessionReplay';
 export declare const BrowserSource: {
     readonly Browser: "browser";
 };
-export declare type BrowserSource = typeof BrowserSource[keyof typeof BrowserSource];
+export type BrowserSource = (typeof BrowserSource)[keyof typeof BrowserSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.BrowserFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.BrowserIncrementalSnapshotRecord['type'];
@@ -17,7 +17,7 @@ export declare const RecordType: {
     FrustrationRecord: SessionReplay.FrustrationRecord['type'];
     Change: SessionReplay.BrowserChangeRecord['type'];
 };
-export declare type RecordType = typeof RecordType[keyof typeof RecordType];
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
 export declare const NodeType: {
     Document: SessionReplay.DocumentNode['type'];
     DocumentType: SessionReplay.DocumentTypeNode['type'];
@@ -26,7 +26,7 @@ export declare const NodeType: {
     CDATA: SessionReplay.CDataNode['type'];
     DocumentFragment: SessionReplay.DocumentFragmentNode['type'];
 };
-export declare type NodeType = typeof NodeType[keyof typeof NodeType];
+export type NodeType = (typeof NodeType)[keyof typeof NodeType];
 export declare const IncrementalSource: {
     Mutation: SessionReplay.BrowserMutationData['source'];
     MouseMove: Exclude<SessionReplay.MousemoveData['source'], 6>;
@@ -39,7 +39,7 @@ export declare const IncrementalSource: {
     StyleSheetRule: SessionReplay.StyleSheetRuleData['source'];
     PointerInteraction: SessionReplay.PointerInteractionData['source'];
 };
-export declare type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource];
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];
 export declare const MouseInteractionType: {
     readonly MouseUp: 0;
     readonly MouseDown: 1;
@@ -51,13 +51,13 @@ export declare const MouseInteractionType: {
     readonly TouchStart: 7;
     readonly TouchEnd: 9;
 };
-export declare type MouseInteractionType = typeof MouseInteractionType[keyof typeof MouseInteractionType];
+export type MouseInteractionType = (typeof MouseInteractionType)[keyof typeof MouseInteractionType];
 export declare const MediaInteractionType: {
     readonly Play: 0;
     readonly Pause: 1;
 };
-export declare type MediaInteractionType = typeof MediaInteractionType[keyof typeof MediaInteractionType];
-declare type ChangeTypeId<Id, Data> = [Id, ...Data[]] extends SessionReplay.Change ? Id : never;
+export type MediaInteractionType = (typeof MediaInteractionType)[keyof typeof MediaInteractionType];
+type ChangeTypeId<Id, Data> = [Id, ...Data[]] extends SessionReplay.Change ? Id : never;
 export declare const ChangeType: {
     AddString: ChangeTypeId<0, SessionReplay.AddStringChange>;
     AddNode: ChangeTypeId<1, SessionReplay.AddNodeChange>;
@@ -71,9 +71,9 @@ export declare const ChangeType: {
     MediaPlaybackState: ChangeTypeId<9, SessionReplay.MediaPlaybackStateChange>;
     VisualViewport: ChangeTypeId<10, SessionReplay.VisualViewportChange>;
 };
-export declare type ChangeType = typeof ChangeType[keyof typeof ChangeType];
+export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType];
 export declare const PlaybackState: {
     Playing: SessionReplay.PlaybackStatePlaying;
     Paused: SessionReplay.PlaybackStatePaused;
 };
-export declare type PlaybackState = typeof PlaybackState[keyof typeof PlaybackState];
+export type PlaybackState = (typeof PlaybackState)[keyof typeof PlaybackState];

--- a/lib/cjs/src/session-replay-mobile.d.ts
+++ b/lib/cjs/src/session-replay-mobile.d.ts
@@ -7,7 +7,7 @@ export declare const MobileSource: {
     readonly ReactNative: "react-native";
     readonly KotlinMultiplatform: "kotlin-multiplatform";
 };
-export declare type MobileSource = typeof MobileSource[keyof typeof MobileSource];
+export type MobileSource = (typeof MobileSource)[keyof typeof MobileSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.MobileFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.MobileIncrementalSnapshotRecord['type'];
@@ -16,16 +16,16 @@ export declare const RecordType: {
     ViewEnd: SessionReplay.ViewEndRecord['type'];
     VisualViewport: SessionReplay.VisualViewportRecord['type'];
 };
-export declare type RecordType = typeof RecordType[keyof typeof RecordType];
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
 export declare const WireframeType: {
     Shape: SessionReplay.ShapeWireframe['type'];
     Text: SessionReplay.TextWireframe['type'];
 };
-export declare type WireframeType = typeof WireframeType[keyof typeof WireframeType];
+export type WireframeType = (typeof WireframeType)[keyof typeof WireframeType];
 export declare const IncrementalSource: {
     Mutation: SessionReplay.MobileMutationData['source'];
     Touch: SessionReplay.TouchData['source'];
     ViewportResize: SessionReplay.ViewportResizeData['source'];
     PointerInteraction: SessionReplay.PointerInteractionData['source'];
 };
-export declare type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource];
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];

--- a/lib/cjs/src/session-replay.d.ts
+++ b/lib/cjs/src/session-replay.d.ts
@@ -15,26 +15,26 @@ export declare const RecordType: {
     MobileIncrementalSnapshot: typeof MobileRecordType.IncrementalSnapshot;
     BrowserChange: typeof BrowserRecordType.Change;
 };
-export declare type RecordType = typeof RecordType[keyof typeof RecordType];
-export declare type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource;
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
+export type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource;
 export declare const PointerEventType: {
     readonly PointerDown: "down";
     readonly PointerUp: "up";
     readonly PointerMove: "move";
 };
-export declare type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType];
+export type PointerEventType = (typeof PointerEventType)[keyof typeof PointerEventType];
 export declare const PointerType: {
     readonly Mouse: "mouse";
     readonly Touch: "touch";
     readonly Pen: "pen";
 };
-export declare type PointerType = typeof PointerType[keyof typeof PointerType];
-export declare type NodeId = number & {
+export type PointerType = (typeof PointerType)[keyof typeof PointerType];
+export type NodeId = number & {
     __brand: 'NodeId';
 };
-export declare type StringId = number & {
+export type StringId = number & {
     __brand: 'StringId';
 };
-export declare type StyleSheetId = number & {
+export type StyleSheetId = number & {
     __brand: 'StyleSheetId';
 };

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of Browser SDK Profiling types.
  */
-export declare type BrowserProfiling = BrowserProfileEvent | BrowserProfilerTrace;
+export type BrowserProfiling = BrowserProfileEvent | BrowserProfilerTrace;
 /**
  * Schema of the Browser SDK Profile Event payload.
  */
-export declare type BrowserProfileEvent = ProfileCommonProperties & {
+export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Profile data format.
      */

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -4,7 +4,7 @@
 /**
  * Browser-specific. Schema of a Session Replay data Segment.
  */
-export declare type BrowserSegment = BrowserSegmentMetadata & {
+export type BrowserSegment = BrowserSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -13,7 +13,7 @@ export declare type BrowserSegment = BrowserSegmentMetadata & {
 /**
  * Browser-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -23,15 +23,15 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
+export type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */
-export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
+export type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -41,7 +41,7 @@ export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema 
 /**
  * Schema of common properties for a Record event type that is supported by slots.
  */
-export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -50,17 +50,17 @@ export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNodeWithId = {
+export type SerializedNodeWithId = {
     id: number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -71,11 +71,11 @@ export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecord
 /**
  * Browser-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
+export type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
 /**
  * Browser-specific. Schema of a MutationData.
  */
-export declare type BrowserMutationData = {
+export type BrowserMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -84,7 +84,7 @@ export declare type BrowserMutationData = {
 /**
  * Browser-specific. Schema of a MutationPayload.
  */
-export declare type BrowserMutationPayload = {
+export type BrowserMutationPayload = {
     /**
      * Contains the newly added nodes.
      */
@@ -105,7 +105,7 @@ export declare type BrowserMutationPayload = {
 /**
  * Browser-specific. Schema of a MouseInteractionData.
  */
-export declare type MouseInteractionData = {
+export type MouseInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -114,7 +114,7 @@ export declare type MouseInteractionData = {
 /**
  * Browser-specific. Schema of a MouseInteraction.
  */
-export declare type MouseInteraction = {
+export type MouseInteraction = {
     /**
      * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
@@ -144,7 +144,7 @@ export declare type MouseInteraction = {
 /**
  * Browser-specific. Schema of a ScrollData.
  */
-export declare type ScrollData = {
+export type ScrollData = {
     /**
      * The source of this type of incremental data.
      */
@@ -153,7 +153,7 @@ export declare type ScrollData = {
 /**
  * Browser-specific. Schema of an InputData.
  */
-export declare type InputData = {
+export type InputData = {
     /**
      * The source of this type of incremental data.
      */
@@ -166,7 +166,7 @@ export declare type InputData = {
 /**
  * Browser-specific. Schema of an InputState.
  */
-export declare type InputState = {
+export type InputState = {
     /**
      * Text value for this InputState.
      */
@@ -180,7 +180,7 @@ export declare type InputState = {
 /**
  * Browser-specific. Schema of a MediaInteractionData.
  */
-export declare type MediaInteractionData = {
+export type MediaInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -189,7 +189,7 @@ export declare type MediaInteractionData = {
 /**
  * Browser-specific. Schema of a StyleSheetRuleData.
  */
-export declare type StyleSheetRuleData = {
+export type StyleSheetRuleData = {
     /**
      * The source of this type of incremental data.
      */
@@ -198,7 +198,7 @@ export declare type StyleSheetRuleData = {
 /**
  * Schema of a ViewportResizeData.
  */
-export declare type ViewportResizeData = {
+export type ViewportResizeData = {
     /**
      * The source of this type of incremental data.
      */
@@ -207,7 +207,7 @@ export declare type ViewportResizeData = {
 /**
  * Schema of a PointerInteractionData.
  */
-export declare type PointerInteractionData = {
+export type PointerInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -216,7 +216,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
+export type MetaRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -242,7 +242,7 @@ export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
+export type FocusRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -257,7 +257,7 @@ export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
+export type ViewEndRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -266,7 +266,7 @@ export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
+export type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -284,7 +284,7 @@ export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
+export type FrustrationRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -306,7 +306,7 @@ export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema of a record type which represents changes using a compact encoding. (Experimental; subject to change.)
  */
-export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -317,51 +317,51 @@ export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export declare type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
 /**
  * Browser-specific. Schema representing the addition of a string to the string table.
  */
-export declare type AddStringChange = string;
+export type AddStringChange = string;
 /**
  * Browser-specific. Schema representing the addition of a new node to the document.
  */
-export declare type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
+export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
 /**
  * Schema representing the addition of a new #cdata-section node.
  *
  * @minItems 2
  */
-export declare type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
-export declare type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
+export type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
 /**
  * A positive integer insertion point. Inserting a node at positive integer N indicates that the new node's parent is the node with an id N lower than the new node, and that we should insert the new node at the end of its parent's child list, as if the DOM method appendChild() was being used.
  */
-export declare type AppendChildInsertionPoint = number;
+export type AppendChildInsertionPoint = number;
 /**
  * A zero insertion point. Inserting a node at zero indicates that the new node should be inserted after the node with an id one lower than the new node, as if the DOM method after() is being used. Using a zero insertion point repeatedly is thus a quick way to insert a sequence of sibling elements.
  */
-export declare type InsertAfterPreviousInsertionPoint = 0;
+export type InsertAfterPreviousInsertionPoint = 0;
 /**
  * A negative integer insertion point. Inserting a node at negative integer -N indicates that the new node's next sibling is the node with an id N lower than the new node, and that we should insert the new node before its next sibling, as if the DOM method insertBefore() was being used.
  */
-export declare type InsertBeforeInsertionPoint = number;
+export type InsertBeforeInsertionPoint = number;
 /**
  * A null insertion point, indicating that the node should be inserted at the root of the document.
  */
-export declare type RootInsertionPoint = null;
+export type RootInsertionPoint = null;
 /**
  * Browser-specific. Schema representing a string, expressed as an index into the string table.
  */
-export declare type StringReference = number;
+export type StringReference = number;
 /**
  * Schema representing the addition of a new #doctype node, using the format [#doctype, name, public ID, system ID].
  *
  * @minItems 5
  */
-export declare type AddDocTypeNodeChange = [
+export type AddDocTypeNodeChange = [
     InsertionPoint,
     '#doctype' | StringReference,
     StringOrStringReference,
@@ -371,133 +371,133 @@ export declare type AddDocTypeNodeChange = [
 /**
  * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
  */
-export declare type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = string | StringReference;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export declare type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export declare type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export declare type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
  * @minItems 2
  */
-export declare type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
+export type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
 /**
  * Schema representing the addition of a new #shadow-root node.
  *
  * @minItems 2
  */
-export declare type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export declare type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
-export declare type RemoveNodeChange = number;
+export type RemoveNodeChange = number;
 /**
  * Browser-specific. Schema representing a change to an node's attributes.
  *
  * @minItems 1
  */
-export declare type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
+export type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
 /**
  * Browser-specific. Schema representing the ID of a DOM node.
  */
-export declare type NodeId = number;
+export type NodeId = number;
 /**
  * Schema representing a change to an attribute, either by assignment of a new value or by deletion of the attribute.
  */
-export declare type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
+export type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
 /**
  * Schema representing the deletion of an attribute.
  *
  * @minItems 1
  */
-export declare type AttributeDeletion = [StringOrStringReference];
+export type AttributeDeletion = [StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change to the text content of a #text node.
  *
  * @minItems 2
  */
-export declare type TextChange = [NodeId, StringOrStringReference];
+export type TextChange = [NodeId, StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change in an element's size.
  *
  * @minItems 3
  */
-export declare type SizeChange = [NodeId, number, number];
+export type SizeChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing a scroll position change.
  *
  * @minItems 3
  */
-export declare type ScrollPositionChange = [NodeId, number, number];
+export type ScrollPositionChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing the addition of a new stylesheet to the document.
  */
-export declare type AddStyleSheetChange = StyleSheetSnapshot;
+export type AddStyleSheetChange = StyleSheetSnapshot;
 /**
  * Schema representing a snapshot of a CSS stylesheet.
  *
  * @minItems 1
  */
-export declare type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */
-export declare type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
+export type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
 /**
  * If non-empty, the list of medias for which this stylesheet is active. Defaults to the empty list if not present.
  */
-export declare type StyleSheetMediaList = StringOrStringReference[];
+export type StyleSheetMediaList = StringOrStringReference[];
 /**
  * Browser-specific. Schema representing a change to the stylesheets attached to a DOM node. For <link> or <style> elements, which use classic CSSOM APIs, at most one stylesheet can be attached. For #document, #document-fragment, or #shadow-root nodes, which use the `adoptedStyleSheets` API, any number of stylesheets can be attached.
  *
  * @minItems 1
  */
-export declare type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
+export type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
 /**
  * Browser-specific. Schema representing the ID of a stylesheet.
  */
-export declare type StyleSheetId = number;
+export type StyleSheetId = number;
 /**
  * Browser-specific. Schema representing a change to the playback state of the media associated with an <audio> or <video> element.
  *
  * @minItems 2
  */
-export declare type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
+export type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
 /**
  * A playback state indicating that the associated media is playing.
  */
-export declare type PlaybackStatePlaying = 0;
+export type PlaybackStatePlaying = 0;
 /**
  * A playback state indicating that the associated media is paused.
  */
-export declare type PlaybackStatePaused = 1;
+export type PlaybackStatePaused = 1;
 /**
  * Browser-specific. Schema representing a change to the visual viewport, defined in terms of the web platform VisualViewport API.
  *
  * @minItems 7
  */
-export declare type VisualViewportChange = [
+export type VisualViewportChange = [
     VisualViewportOffsetLeft,
     VisualViewportOffsetTop,
     VisualViewportPageLeft,
@@ -509,31 +509,31 @@ export declare type VisualViewportChange = [
 /**
  * The offset of the left edge of the visual viewport from the left edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetLeft = number;
+export type VisualViewportOffsetLeft = number;
 /**
  * The offset of the top edge of the visual viewport from the top edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetTop = number;
+export type VisualViewportOffsetTop = number;
 /**
  * The x coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageLeft = number;
+export type VisualViewportPageLeft = number;
 /**
  * The y coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageTop = number;
+export type VisualViewportPageTop = number;
 /**
  * The width of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportWidth = number;
+export type VisualViewportWidth = number;
 /**
  * The height of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportHeight = number;
+export type VisualViewportHeight = number;
 /**
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
-export declare type VisualViewportScale = number;
+export type VisualViewportScale = number;
 /**
  * Schema of a Session Replay Segment context.
  */

--- a/lib/esm/generated/mobileProfiling.d.ts
+++ b/lib/esm/generated/mobileProfiling.d.ts
@@ -4,7 +4,7 @@
 /**
  * Schema of the Mobile SDK Profile Event metadata.
  */
-export declare type MobileProfileEvent = ProfileCommonProperties & {
+export type MobileProfileEvent = ProfileCommonProperties & {
     /**
      * The RUM Vital this profile event is associated with.
      */

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -4,7 +4,7 @@
 /**
  * Mobile-specific. Schema of a Session Replay data Segment.
  */
-export declare type MobileSegment = MobileSegmentMetadata & {
+export type MobileSegment = MobileSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -13,7 +13,7 @@ export declare type MobileSegment = MobileSegmentMetadata & {
 /**
  * Mobile-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -22,11 +22,11 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
 /**
  * Mobile-specific. Schema of a Session Replay Record.
  */
-export declare type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
+export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -41,11 +41,11 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
+export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
-export declare type ShapeWireframe = CommonShapeWireframe & {
+export type ShapeWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -54,14 +54,14 @@ export declare type ShapeWireframe = CommonShapeWireframe & {
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
  */
-export declare type CommonShapeWireframe = CommonWireframe & {
+export type CommonShapeWireframe = CommonWireframe & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * The style of this wireframe.
  */
-export declare type ShapeStyle = {
+export type ShapeStyle = {
     /**
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
@@ -78,7 +78,7 @@ export declare type ShapeStyle = {
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
-export declare type ShapeBorder = {
+export type ShapeBorder = {
     /**
      * The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
@@ -91,7 +91,7 @@ export declare type ShapeBorder = {
 /**
  * Schema of all properties of a TextWireframe.
  */
-export declare type TextWireframe = CommonShapeWireframe & {
+export type TextWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -106,7 +106,7 @@ export declare type TextWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a TextStyle.
  */
-export declare type TextStyle = {
+export type TextStyle = {
     /**
      * The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif
      */
@@ -127,7 +127,7 @@ export declare type TextStyle = {
 /**
  * Schema of all properties of a TextPosition.
  */
-export declare type TextPosition = {
+export type TextPosition = {
     readonly padding?: {
         /**
          * The top padding in pixels. The default value is 0.
@@ -160,7 +160,7 @@ export declare type TextPosition = {
 /**
  * Schema of all properties of a ImageWireframe.
  */
-export declare type ImageWireframe = CommonShapeWireframe & {
+export type ImageWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -185,7 +185,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframe = CommonWireframe & {
+export type PlaceholderWireframe = CommonWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -198,7 +198,7 @@ export declare type PlaceholderWireframe = CommonWireframe & {
 /**
  * Schema of all properties of a WebviewWireframe.
  */
-export declare type WebviewWireframe = CommonShapeWireframe & {
+export type WebviewWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -215,7 +215,7 @@ export declare type WebviewWireframe = CommonShapeWireframe & {
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -225,11 +225,11 @@ export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
-export declare type MobileMutationData = {
+export type MobileMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -238,11 +238,11 @@ export declare type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
-export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
+export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -257,14 +257,14 @@ export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
  */
-export declare type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
  */
-export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -273,7 +273,7 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a ImageWireframeUpdate.
  */
-export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -298,7 +298,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
+export type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -311,7 +311,7 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
 /**
  * Schema of all properties of a WebviewWireframeUpdate.
  */
-export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -328,7 +328,7 @@ export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of a TouchData.
  */
-export declare type TouchData = {
+export type TouchData = {
     /**
      * The source of this type of incremental data.
      */
@@ -358,7 +358,7 @@ export declare type TouchData = {
 /**
  * Schema of a ViewportResizeData.
  */
-export declare type ViewportResizeData = {
+export type ViewportResizeData = {
     /**
      * The source of this type of incremental data.
      */
@@ -367,7 +367,7 @@ export declare type ViewportResizeData = {
 /**
  * Schema of a PointerInteractionData.
  */
-export declare type PointerInteractionData = {
+export type PointerInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -376,7 +376,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
+export type MetaRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -402,7 +402,7 @@ export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of common properties for a Record event type that is supported by slots.
  */
-export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -411,7 +411,7 @@ export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
+export type FocusRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -426,7 +426,7 @@ export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
+export type ViewEndRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -435,7 +435,7 @@ export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
+export type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;

--- a/lib/esm/generated/profiling.d.ts
+++ b/lib/esm/generated/profiling.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of RUM Profiling.
  */
-export declare type Profiling = BrowserProfileEvent | MobileProfileEvent;
+export type Profiling = BrowserProfileEvent | MobileProfileEvent;
 /**
  * Browser SDK profiling payload.
  */
-export declare type BrowserProfileEvent = ProfileCommonProperties & {
+export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Profile data format.
      */
@@ -28,7 +28,7 @@ export declare type BrowserProfileEvent = ProfileCommonProperties & {
 /**
  * Mobile SDK profiling event.
  */
-export declare type MobileProfileEvent = ProfileCommonProperties & {
+export type MobileProfileEvent = ProfileCommonProperties & {
     /**
      * The RUM Vital this profile event is associated with.
      */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -870,50 +870,62 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & Stre
          */
         readonly time_spent: number;
         /**
+         * @deprecated
          * Duration in ns to the first rendering (deprecated in favor of `view.performance.fcp.timestamp`)
          */
         readonly first_contentful_paint?: number;
         /**
+         * @deprecated
          * Duration in ns to the largest contentful paint (deprecated in favor of `view.performance.lcp.timestamp`)
          */
         readonly largest_contentful_paint?: number;
         /**
+         * @deprecated
          * CSS selector path of the largest contentful paint element (deprecated in favor of `view.performance.lcp.target_selector`)
          */
         readonly largest_contentful_paint_target_selector?: string;
         /**
+         * @deprecated
          * Duration in ns of the first input event delay (deprecated in favor of `view.performance.fid.duration`)
          */
         readonly first_input_delay?: number;
         /**
+         * @deprecated
          * Duration in ns to the first input (deprecated in favor of `view.performance.fid.timestamp`)
          */
         readonly first_input_time?: number;
         /**
+         * @deprecated
          * CSS selector path of the first input target element (deprecated in favor of `view.performance.fid.target_selector`)
          */
         readonly first_input_target_selector?: string;
         /**
+         * @deprecated
          * Longest duration in ns between an interaction and the next paint (deprecated in favor of `view.performance.inp.duration`)
          */
         readonly interaction_to_next_paint?: number;
         /**
+         * @deprecated
          * Duration in ns between start of the view and start of the INP (deprecated in favor of `view.performance.inp.timestamp`)
          */
         readonly interaction_to_next_paint_time?: number;
         /**
+         * @deprecated
          * CSS selector path of the interacted element corresponding to INP (deprecated in favor of `view.performance.inp.target_selector`)
          */
         readonly interaction_to_next_paint_target_selector?: string;
         /**
+         * @deprecated
          * Total layout shift score that occurred on the view (deprecated in favor of `view.performance.cls.score`)
          */
         readonly cumulative_layout_shift?: number;
         /**
+         * @deprecated
          * Duration in ns between start of the view and start of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.timestamp`)
          */
         readonly cumulative_layout_shift_time?: number;
         /**
+         * @deprecated
          * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS (deprecated in favor of `view.performance.cls.target_selector`)
          */
         readonly cumulative_layout_shift_target_selector?: string;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of all properties of a RUM event
  */
-export declare type RumEvent = RumActionEvent | RumTransitionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent | RumVitalEvent;
+export type RumEvent = RumActionEvent | RumTransitionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent | RumVitalEvent;
 /**
  * Schema of all properties of an Action event
  */
-export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
+export type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -154,7 +154,7 @@ export declare type RumActionEvent = CommonProperties & ViewContainerSchema & {
 /**
  * Schema of all properties of an Transition event
  */
-export declare type RumTransitionEvent = CommonProperties & {
+export type RumTransitionEvent = CommonProperties & {
     /**
      * RUM event type
      */
@@ -208,7 +208,7 @@ export declare type RumTransitionEvent = CommonProperties & {
 /**
  * Schema of all properties of an Error event
  */
-export declare type RumErrorEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
+export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -456,7 +456,7 @@ export declare type RumErrorEvent = CommonProperties & ActionChildProperties & V
 /**
  * Schema of all properties of a Long Task event
  */
-export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
+export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -572,7 +572,7 @@ export declare type RumLongTaskEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a Resource event
  */
-export declare type RumResourceEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
+export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -840,7 +840,7 @@ export declare type RumResourceEvent = CommonProperties & ActionChildProperties 
 /**
  * Schema of all properties of a View event
  */
-export declare type RumViewEvent = CommonProperties & ViewContainerSchema & StreamSchema & {
+export type RumViewEvent = CommonProperties & ViewContainerSchema & StreamSchema & {
     /**
      * RUM event type
      */
@@ -1241,11 +1241,11 @@ export declare type RumViewEvent = CommonProperties & ViewContainerSchema & Stre
     };
     [k: string]: unknown;
 };
-export declare type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent | RumVitalAppLaunchEvent;
+export type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent | RumVitalAppLaunchEvent;
 /**
  * Schema for a duration vital event.
  */
-export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
+export type RumVitalDurationEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */
@@ -1265,7 +1265,7 @@ export declare type RumVitalDurationEvent = RumVitalEventCommonProperties & {
 /**
  * Schema of common properties for a Vital event
  */
-export declare type RumVitalEventCommonProperties = CommonProperties & ViewContainerSchema & {
+export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSchema & {
     /**
      * RUM event type
      */
@@ -1293,7 +1293,7 @@ export declare type RumVitalEventCommonProperties = CommonProperties & ViewConta
 /**
  * Schema for a vital operation step event.
  */
-export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
+export type RumVitalOperationStepEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */
@@ -1321,7 +1321,7 @@ export declare type RumVitalOperationStepEvent = RumVitalEventCommonProperties &
 /**
  * Schema for app launch metrics.
  */
-export declare type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
+export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
     /**
      * Vital properties
      */

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -4,15 +4,15 @@
 /**
  * Schema of all properties of Session Replay
  */
-export declare type SessionReplay = Segment & SegmentMetadata & Record & FullSnapshotRecord & IncrementalSnapshotRecord & IncrementalData & MutationData & MutationPayload;
+export type SessionReplay = Segment & SegmentMetadata & Record & FullSnapshotRecord & IncrementalSnapshotRecord & IncrementalData & MutationData & MutationPayload;
 /**
  * Schema of a Session Replay data Segment.
  */
-export declare type Segment = BrowserSegment | MobileSegment;
+export type Segment = BrowserSegment | MobileSegment;
 /**
  * Browser-specific. Schema of a Session Replay data Segment.
  */
-export declare type BrowserSegment = BrowserSegmentMetadata & {
+export type BrowserSegment = BrowserSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -21,7 +21,7 @@ export declare type BrowserSegment = BrowserSegmentMetadata & {
 /**
  * Browser-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -31,15 +31,15 @@ export declare type BrowserSegmentMetadata = SegmentContext & CommonSegmentMetad
 /**
  * The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.
  */
-export declare type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
+export type CreationReason = 'init' | 'segment_duration_limit' | 'segment_bytes_limit' | 'view_change' | 'before_unload' | 'visibility_hidden' | 'page_frozen';
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */
-export declare type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
+export type BrowserRecord = BrowserFullSnapshotRecord | BrowserIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord | FrustrationRecord | BrowserChangeRecord;
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -49,7 +49,7 @@ export declare type BrowserFullSnapshotRecord = SlotSupportedCommonRecordSchema 
 /**
  * Schema of common properties for a Record event type that is supported by slots.
  */
-export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -58,17 +58,17 @@ export declare type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNodeWithId = {
+export type SerializedNodeWithId = {
     id: number;
 } & SerializedNode;
 /**
  * Serialized node contained by this Record.
  */
-export declare type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
+export type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeNode | ElementNode | TextNode | CDataNode;
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -79,11 +79,11 @@ export declare type BrowserIncrementalSnapshotRecord = SlotSupportedCommonRecord
 /**
  * Browser-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
+export type BrowserIncrementalData = BrowserMutationData | MousemoveData | MouseInteractionData | ScrollData | InputData | MediaInteractionData | StyleSheetRuleData | ViewportResizeData | PointerInteractionData;
 /**
  * Browser-specific. Schema of a MutationData.
  */
-export declare type BrowserMutationData = {
+export type BrowserMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -92,7 +92,7 @@ export declare type BrowserMutationData = {
 /**
  * Browser-specific. Schema of a MutationPayload.
  */
-export declare type BrowserMutationPayload = {
+export type BrowserMutationPayload = {
     /**
      * Contains the newly added nodes.
      */
@@ -113,7 +113,7 @@ export declare type BrowserMutationPayload = {
 /**
  * Browser-specific. Schema of a MouseInteractionData.
  */
-export declare type MouseInteractionData = {
+export type MouseInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -122,7 +122,7 @@ export declare type MouseInteractionData = {
 /**
  * Browser-specific. Schema of a MouseInteraction.
  */
-export declare type MouseInteraction = {
+export type MouseInteraction = {
     /**
      * The type of MouseInteraction: 0=mouseup, 1=mousedown, 2=click, 3=contextmenu, 4=dblclick, 7=touchstart, 9=touchend
      */
@@ -152,7 +152,7 @@ export declare type MouseInteraction = {
 /**
  * Browser-specific. Schema of a ScrollData.
  */
-export declare type ScrollData = {
+export type ScrollData = {
     /**
      * The source of this type of incremental data.
      */
@@ -161,7 +161,7 @@ export declare type ScrollData = {
 /**
  * Browser-specific. Schema of an InputData.
  */
-export declare type InputData = {
+export type InputData = {
     /**
      * The source of this type of incremental data.
      */
@@ -174,7 +174,7 @@ export declare type InputData = {
 /**
  * Browser-specific. Schema of an InputState.
  */
-export declare type InputState = {
+export type InputState = {
     /**
      * Text value for this InputState.
      */
@@ -188,7 +188,7 @@ export declare type InputState = {
 /**
  * Browser-specific. Schema of a MediaInteractionData.
  */
-export declare type MediaInteractionData = {
+export type MediaInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -197,7 +197,7 @@ export declare type MediaInteractionData = {
 /**
  * Browser-specific. Schema of a StyleSheetRuleData.
  */
-export declare type StyleSheetRuleData = {
+export type StyleSheetRuleData = {
     /**
      * The source of this type of incremental data.
      */
@@ -206,7 +206,7 @@ export declare type StyleSheetRuleData = {
 /**
  * Schema of a ViewportResizeData.
  */
-export declare type ViewportResizeData = {
+export type ViewportResizeData = {
     /**
      * The source of this type of incremental data.
      */
@@ -215,7 +215,7 @@ export declare type ViewportResizeData = {
 /**
  * Schema of a PointerInteractionData.
  */
-export declare type PointerInteractionData = {
+export type PointerInteractionData = {
     /**
      * The source of this type of incremental data.
      */
@@ -224,7 +224,7 @@ export declare type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
+export type MetaRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -250,7 +250,7 @@ export declare type MetaRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
+export type FocusRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -265,7 +265,7 @@ export declare type FocusRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
+export type ViewEndRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -274,7 +274,7 @@ export declare type ViewEndRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
+export type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
     data: {
         height: number;
         offsetLeft: number;
@@ -292,7 +292,7 @@ export declare type VisualViewportRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
+export type FrustrationRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -314,7 +314,7 @@ export declare type FrustrationRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema of a record type which represents changes using a compact encoding. (Experimental; subject to change.)
  */
-export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
+export type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -325,51 +325,51 @@ export declare type BrowserChangeRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export declare type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
 /**
  * Browser-specific. Schema representing the addition of a string to the string table.
  */
-export declare type AddStringChange = string;
+export type AddStringChange = string;
 /**
  * Browser-specific. Schema representing the addition of a new node to the document.
  */
-export declare type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
+export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | AddDocumentNodeChange | AddDocumentFragmentNodeChange | AddElementNodeChange | AddShadowRootNodeChange | AddTextNodeChange;
 /**
  * Schema representing the addition of a new #cdata-section node.
  *
  * @minItems 2
  */
-export declare type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
-export declare type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
+export type InsertionPoint = AppendChildInsertionPoint | InsertAfterPreviousInsertionPoint | InsertBeforeInsertionPoint | RootInsertionPoint;
 /**
  * A positive integer insertion point. Inserting a node at positive integer N indicates that the new node's parent is the node with an id N lower than the new node, and that we should insert the new node at the end of its parent's child list, as if the DOM method appendChild() was being used.
  */
-export declare type AppendChildInsertionPoint = number;
+export type AppendChildInsertionPoint = number;
 /**
  * A zero insertion point. Inserting a node at zero indicates that the new node should be inserted after the node with an id one lower than the new node, as if the DOM method after() is being used. Using a zero insertion point repeatedly is thus a quick way to insert a sequence of sibling elements.
  */
-export declare type InsertAfterPreviousInsertionPoint = 0;
+export type InsertAfterPreviousInsertionPoint = 0;
 /**
  * A negative integer insertion point. Inserting a node at negative integer -N indicates that the new node's next sibling is the node with an id N lower than the new node, and that we should insert the new node before its next sibling, as if the DOM method insertBefore() was being used.
  */
-export declare type InsertBeforeInsertionPoint = number;
+export type InsertBeforeInsertionPoint = number;
 /**
  * A null insertion point, indicating that the node should be inserted at the root of the document.
  */
-export declare type RootInsertionPoint = null;
+export type RootInsertionPoint = null;
 /**
  * Browser-specific. Schema representing a string, expressed as an index into the string table.
  */
-export declare type StringReference = number;
+export type StringReference = number;
 /**
  * Schema representing the addition of a new #doctype node, using the format [#doctype, name, public ID, system ID].
  *
  * @minItems 5
  */
-export declare type AddDocTypeNodeChange = [
+export type AddDocTypeNodeChange = [
     InsertionPoint,
     '#doctype' | StringReference,
     StringOrStringReference,
@@ -379,133 +379,133 @@ export declare type AddDocTypeNodeChange = [
 /**
  * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
  */
-export declare type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = string | StringReference;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export declare type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export declare type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export declare type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
  * @minItems 2
  */
-export declare type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
+export type AttributeAssignment = [StringOrStringReference, StringOrStringReference];
 /**
  * Schema representing the addition of a new #shadow-root node.
  *
  * @minItems 2
  */
-export declare type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export declare type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
-export declare type RemoveNodeChange = number;
+export type RemoveNodeChange = number;
 /**
  * Browser-specific. Schema representing a change to an node's attributes.
  *
  * @minItems 1
  */
-export declare type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
+export type AttributeChange = [NodeId, ...AttributeAssignmentOrDeletion[]];
 /**
  * Browser-specific. Schema representing the ID of a DOM node.
  */
-export declare type NodeId = number;
+export type NodeId = number;
 /**
  * Schema representing a change to an attribute, either by assignment of a new value or by deletion of the attribute.
  */
-export declare type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
+export type AttributeAssignmentOrDeletion = AttributeAssignment | AttributeDeletion;
 /**
  * Schema representing the deletion of an attribute.
  *
  * @minItems 1
  */
-export declare type AttributeDeletion = [StringOrStringReference];
+export type AttributeDeletion = [StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change to the text content of a #text node.
  *
  * @minItems 2
  */
-export declare type TextChange = [NodeId, StringOrStringReference];
+export type TextChange = [NodeId, StringOrStringReference];
 /**
  * Browser-specific. Schema representing a change in an element's size.
  *
  * @minItems 3
  */
-export declare type SizeChange = [NodeId, number, number];
+export type SizeChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing a scroll position change.
  *
  * @minItems 3
  */
-export declare type ScrollPositionChange = [NodeId, number, number];
+export type ScrollPositionChange = [NodeId, number, number];
 /**
  * Browser-specific. Schema representing the addition of a new stylesheet to the document.
  */
-export declare type AddStyleSheetChange = StyleSheetSnapshot;
+export type AddStyleSheetChange = StyleSheetSnapshot;
 /**
  * Schema representing a snapshot of a CSS stylesheet.
  *
  * @minItems 1
  */
-export declare type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */
-export declare type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
+export type StyleSheetRules = StringOrStringReference | StringOrStringReference[];
 /**
  * If non-empty, the list of medias for which this stylesheet is active. Defaults to the empty list if not present.
  */
-export declare type StyleSheetMediaList = StringOrStringReference[];
+export type StyleSheetMediaList = StringOrStringReference[];
 /**
  * Browser-specific. Schema representing a change to the stylesheets attached to a DOM node. For <link> or <style> elements, which use classic CSSOM APIs, at most one stylesheet can be attached. For #document, #document-fragment, or #shadow-root nodes, which use the `adoptedStyleSheets` API, any number of stylesheets can be attached.
  *
  * @minItems 1
  */
-export declare type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
+export type AttachedStyleSheetsChange = [NodeId, ...StyleSheetId[]];
 /**
  * Browser-specific. Schema representing the ID of a stylesheet.
  */
-export declare type StyleSheetId = number;
+export type StyleSheetId = number;
 /**
  * Browser-specific. Schema representing a change to the playback state of the media associated with an <audio> or <video> element.
  *
  * @minItems 2
  */
-export declare type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
+export type MediaPlaybackStateChange = [NodeId, PlaybackStatePlaying | PlaybackStatePaused];
 /**
  * A playback state indicating that the associated media is playing.
  */
-export declare type PlaybackStatePlaying = 0;
+export type PlaybackStatePlaying = 0;
 /**
  * A playback state indicating that the associated media is paused.
  */
-export declare type PlaybackStatePaused = 1;
+export type PlaybackStatePaused = 1;
 /**
  * Browser-specific. Schema representing a change to the visual viewport, defined in terms of the web platform VisualViewport API.
  *
  * @minItems 7
  */
-export declare type VisualViewportChange = [
+export type VisualViewportChange = [
     VisualViewportOffsetLeft,
     VisualViewportOffsetTop,
     VisualViewportPageLeft,
@@ -517,35 +517,35 @@ export declare type VisualViewportChange = [
 /**
  * The offset of the left edge of the visual viewport from the left edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetLeft = number;
+export type VisualViewportOffsetLeft = number;
 /**
  * The offset of the top edge of the visual viewport from the top edge of the layout viewport in CSS pixels.
  */
-export declare type VisualViewportOffsetTop = number;
+export type VisualViewportOffsetTop = number;
 /**
  * The x coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageLeft = number;
+export type VisualViewportPageLeft = number;
 /**
  * The y coordinate of the visual viewport relative to the initial containing block origin of the top edge in CSS pixels.
  */
-export declare type VisualViewportPageTop = number;
+export type VisualViewportPageTop = number;
 /**
  * The width of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportWidth = number;
+export type VisualViewportWidth = number;
 /**
  * The height of the visual viewport in CSS pixels.
  */
-export declare type VisualViewportHeight = number;
+export type VisualViewportHeight = number;
 /**
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
-export declare type VisualViewportScale = number;
+export type VisualViewportScale = number;
 /**
  * Mobile-specific. Schema of a Session Replay data Segment.
  */
-export declare type MobileSegment = MobileSegmentMetadata & {
+export type MobileSegment = MobileSegmentMetadata & {
     /**
      * The records contained by this Segment.
      */
@@ -554,7 +554,7 @@ export declare type MobileSegment = MobileSegmentMetadata & {
 /**
  * Mobile-specific. Schema of a Session Replay Segment metadata.
  */
-export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
+export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema & {
     /**
      * The source of this record
      */
@@ -563,11 +563,11 @@ export declare type MobileSegmentMetadata = SegmentContext & CommonSegmentMetada
 /**
  * Mobile-specific. Schema of a Session Replay Record.
  */
-export declare type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
+export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord | VisualViewportRecord;
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -582,11 +582,11 @@ export declare type MobileFullSnapshotRecord = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export declare type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
+export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
  * Schema of all properties of a ShapeWireframe.
  */
-export declare type ShapeWireframe = CommonShapeWireframe & {
+export type ShapeWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -595,14 +595,14 @@ export declare type ShapeWireframe = CommonShapeWireframe & {
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
  */
-export declare type CommonShapeWireframe = CommonWireframe & {
+export type CommonShapeWireframe = CommonWireframe & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * The style of this wireframe.
  */
-export declare type ShapeStyle = {
+export type ShapeStyle = {
     /**
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
@@ -619,7 +619,7 @@ export declare type ShapeStyle = {
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
-export declare type ShapeBorder = {
+export type ShapeBorder = {
     /**
      * The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
      */
@@ -632,7 +632,7 @@ export declare type ShapeBorder = {
 /**
  * Schema of all properties of a TextWireframe.
  */
-export declare type TextWireframe = CommonShapeWireframe & {
+export type TextWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -647,7 +647,7 @@ export declare type TextWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a TextStyle.
  */
-export declare type TextStyle = {
+export type TextStyle = {
     /**
      * The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif
      */
@@ -668,7 +668,7 @@ export declare type TextStyle = {
 /**
  * Schema of all properties of a TextPosition.
  */
-export declare type TextPosition = {
+export type TextPosition = {
     readonly padding?: {
         /**
          * The top padding in pixels. The default value is 0.
@@ -701,7 +701,7 @@ export declare type TextPosition = {
 /**
  * Schema of all properties of a ImageWireframe.
  */
-export declare type ImageWireframe = CommonShapeWireframe & {
+export type ImageWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -726,7 +726,7 @@ export declare type ImageWireframe = CommonShapeWireframe & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframe = CommonWireframe & {
+export type PlaceholderWireframe = CommonWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -739,7 +739,7 @@ export declare type PlaceholderWireframe = CommonWireframe & {
 /**
  * Schema of all properties of a WebviewWireframe.
  */
-export declare type WebviewWireframe = CommonShapeWireframe & {
+export type WebviewWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
@@ -756,7 +756,7 @@ export declare type WebviewWireframe = CommonShapeWireframe & {
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -766,11 +766,11 @@ export declare type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export declare type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
-export declare type MobileMutationData = {
+export type MobileMutationData = {
     /**
      * The source of this type of incremental data.
      */
@@ -779,11 +779,11 @@ export declare type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export declare type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
-export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
+export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -798,14 +798,14 @@ export declare type TextWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
  */
-export declare type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
     shapeStyle?: ShapeStyle;
     border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
  */
-export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -814,7 +814,7 @@ export declare type ShapeWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a ImageWireframeUpdate.
  */
-export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
+export type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -839,7 +839,7 @@ export declare type ImageWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of all properties of a PlaceholderWireframe.
  */
-export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
+export type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -852,7 +852,7 @@ export declare type PlaceholderWireframeUpdate = CommonWireframeUpdate & {
 /**
  * Schema of all properties of a WebviewWireframeUpdate.
  */
-export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
+export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     /**
      * The type of the wireframe.
      */
@@ -869,7 +869,7 @@ export declare type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
 /**
  * Schema of a TouchData.
  */
-export declare type TouchData = {
+export type TouchData = {
     /**
      * The source of this type of incremental data.
      */
@@ -899,31 +899,31 @@ export declare type TouchData = {
 /**
  * Schema of a Session Replay SegmentMetadata.
  */
-export declare type SegmentMetadata = BrowserSegmentMetadata | MobileSegmentMetadata;
+export type SegmentMetadata = BrowserSegmentMetadata | MobileSegmentMetadata;
 /**
  * Schema of a Session Replay Record.
  */
-export declare type Record = BrowserRecord | MobileRecord;
+export type Record = BrowserRecord | MobileRecord;
 /**
  * Schema of a Record type which contains the full snapshot of a screen.
  */
-export declare type FullSnapshotRecord = BrowserFullSnapshotRecord | MobileFullSnapshotRecord;
+export type FullSnapshotRecord = BrowserFullSnapshotRecord | MobileFullSnapshotRecord;
 /**
  * Schema of a Record type which contains mutations of a screen.
  */
-export declare type IncrementalSnapshotRecord = BrowserIncrementalSnapshotRecord | MobileIncrementalSnapshotRecord;
+export type IncrementalSnapshotRecord = BrowserIncrementalSnapshotRecord | MobileIncrementalSnapshotRecord;
 /**
  * Schema of a Session Replay IncrementalData type.
  */
-export declare type IncrementalData = BrowserIncrementalData | MobileIncrementalData;
+export type IncrementalData = BrowserIncrementalData | MobileIncrementalData;
 /**
  * Schema of a MutationData.
  */
-export declare type MutationData = BrowserMutationData | MobileMutationData;
+export type MutationData = BrowserMutationData | MobileMutationData;
 /**
  * Schema of a MutationPayload.
  */
-export declare type MutationPayload = BrowserMutationPayload | MobileMutationPayload;
+export type MutationPayload = BrowserMutationPayload | MobileMutationPayload;
 /**
  * Schema of a Session Replay Segment context.
  */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -4,11 +4,11 @@
 /**
  * Schema of all properties of a telemetry event
  */
-export declare type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent | TelemetryUsageEvent;
+export type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent | TelemetryUsageEvent;
 /**
  * Schema of all properties of a telemetry error event
  */
-export declare type TelemetryErrorEvent = CommonTelemetryProperties & {
+export type TelemetryErrorEvent = CommonTelemetryProperties & {
     /**
      * The telemetry log information
      */
@@ -46,7 +46,7 @@ export declare type TelemetryErrorEvent = CommonTelemetryProperties & {
 /**
  * Schema of all properties of a telemetry debug event
  */
-export declare type TelemetryDebugEvent = CommonTelemetryProperties & {
+export type TelemetryDebugEvent = CommonTelemetryProperties & {
     /**
      * The telemetry log information
      */
@@ -70,7 +70,7 @@ export declare type TelemetryDebugEvent = CommonTelemetryProperties & {
 /**
  * Schema of all properties of a telemetry configuration event
  */
-export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
+export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
     /**
      * The telemetry configuration information
      */
@@ -474,7 +474,7 @@ export declare type TelemetryConfigurationEvent = CommonTelemetryProperties & {
 /**
  * Schema of all properties of a telemetry usage event
  */
-export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
+export type TelemetryUsageEvent = CommonTelemetryProperties & {
     /**
      * The telemetry usage information
      */
@@ -491,15 +491,15 @@ export declare type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export declare type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital;
+export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital;
 /**
  * Schema of browser specific features usage
  */
-export declare type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
 /**
  * Schema of mobile specific features usage
  */
-export declare type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView;
+export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView;
 /**
  * Schema of common properties of Telemetry events
  */

--- a/lib/esm/src/session-replay-browser.d.ts
+++ b/lib/esm/src/session-replay-browser.d.ts
@@ -6,7 +6,7 @@ export * from '../generated/browserSessionReplay';
 export declare const BrowserSource: {
     readonly Browser: "browser";
 };
-export declare type BrowserSource = typeof BrowserSource[keyof typeof BrowserSource];
+export type BrowserSource = (typeof BrowserSource)[keyof typeof BrowserSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.BrowserFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.BrowserIncrementalSnapshotRecord['type'];
@@ -17,7 +17,7 @@ export declare const RecordType: {
     FrustrationRecord: SessionReplay.FrustrationRecord['type'];
     Change: SessionReplay.BrowserChangeRecord['type'];
 };
-export declare type RecordType = typeof RecordType[keyof typeof RecordType];
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
 export declare const NodeType: {
     Document: SessionReplay.DocumentNode['type'];
     DocumentType: SessionReplay.DocumentTypeNode['type'];
@@ -26,7 +26,7 @@ export declare const NodeType: {
     CDATA: SessionReplay.CDataNode['type'];
     DocumentFragment: SessionReplay.DocumentFragmentNode['type'];
 };
-export declare type NodeType = typeof NodeType[keyof typeof NodeType];
+export type NodeType = (typeof NodeType)[keyof typeof NodeType];
 export declare const IncrementalSource: {
     Mutation: SessionReplay.BrowserMutationData['source'];
     MouseMove: Exclude<SessionReplay.MousemoveData['source'], 6>;
@@ -39,7 +39,7 @@ export declare const IncrementalSource: {
     StyleSheetRule: SessionReplay.StyleSheetRuleData['source'];
     PointerInteraction: SessionReplay.PointerInteractionData['source'];
 };
-export declare type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource];
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];
 export declare const MouseInteractionType: {
     readonly MouseUp: 0;
     readonly MouseDown: 1;
@@ -51,13 +51,13 @@ export declare const MouseInteractionType: {
     readonly TouchStart: 7;
     readonly TouchEnd: 9;
 };
-export declare type MouseInteractionType = typeof MouseInteractionType[keyof typeof MouseInteractionType];
+export type MouseInteractionType = (typeof MouseInteractionType)[keyof typeof MouseInteractionType];
 export declare const MediaInteractionType: {
     readonly Play: 0;
     readonly Pause: 1;
 };
-export declare type MediaInteractionType = typeof MediaInteractionType[keyof typeof MediaInteractionType];
-declare type ChangeTypeId<Id, Data> = [Id, ...Data[]] extends SessionReplay.Change ? Id : never;
+export type MediaInteractionType = (typeof MediaInteractionType)[keyof typeof MediaInteractionType];
+type ChangeTypeId<Id, Data> = [Id, ...Data[]] extends SessionReplay.Change ? Id : never;
 export declare const ChangeType: {
     AddString: ChangeTypeId<0, SessionReplay.AddStringChange>;
     AddNode: ChangeTypeId<1, SessionReplay.AddNodeChange>;
@@ -71,9 +71,9 @@ export declare const ChangeType: {
     MediaPlaybackState: ChangeTypeId<9, SessionReplay.MediaPlaybackStateChange>;
     VisualViewport: ChangeTypeId<10, SessionReplay.VisualViewportChange>;
 };
-export declare type ChangeType = typeof ChangeType[keyof typeof ChangeType];
+export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType];
 export declare const PlaybackState: {
     Playing: SessionReplay.PlaybackStatePlaying;
     Paused: SessionReplay.PlaybackStatePaused;
 };
-export declare type PlaybackState = typeof PlaybackState[keyof typeof PlaybackState];
+export type PlaybackState = (typeof PlaybackState)[keyof typeof PlaybackState];

--- a/lib/esm/src/session-replay-mobile.d.ts
+++ b/lib/esm/src/session-replay-mobile.d.ts
@@ -7,7 +7,7 @@ export declare const MobileSource: {
     readonly ReactNative: "react-native";
     readonly KotlinMultiplatform: "kotlin-multiplatform";
 };
-export declare type MobileSource = typeof MobileSource[keyof typeof MobileSource];
+export type MobileSource = (typeof MobileSource)[keyof typeof MobileSource];
 export declare const RecordType: {
     FullSnapshot: SessionReplay.MobileFullSnapshotRecord['type'];
     IncrementalSnapshot: SessionReplay.MobileIncrementalSnapshotRecord['type'];
@@ -16,16 +16,16 @@ export declare const RecordType: {
     ViewEnd: SessionReplay.ViewEndRecord['type'];
     VisualViewport: SessionReplay.VisualViewportRecord['type'];
 };
-export declare type RecordType = typeof RecordType[keyof typeof RecordType];
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
 export declare const WireframeType: {
     Shape: SessionReplay.ShapeWireframe['type'];
     Text: SessionReplay.TextWireframe['type'];
 };
-export declare type WireframeType = typeof WireframeType[keyof typeof WireframeType];
+export type WireframeType = (typeof WireframeType)[keyof typeof WireframeType];
 export declare const IncrementalSource: {
     Mutation: SessionReplay.MobileMutationData['source'];
     Touch: SessionReplay.TouchData['source'];
     ViewportResize: SessionReplay.ViewportResizeData['source'];
     PointerInteraction: SessionReplay.PointerInteractionData['source'];
 };
-export declare type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource];
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];

--- a/lib/esm/src/session-replay.d.ts
+++ b/lib/esm/src/session-replay.d.ts
@@ -15,26 +15,26 @@ export declare const RecordType: {
     MobileIncrementalSnapshot: typeof MobileRecordType.IncrementalSnapshot;
     BrowserChange: typeof BrowserRecordType.Change;
 };
-export declare type RecordType = typeof RecordType[keyof typeof RecordType];
-export declare type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource;
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
+export type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource;
 export declare const PointerEventType: {
     readonly PointerDown: "down";
     readonly PointerUp: "up";
     readonly PointerMove: "move";
 };
-export declare type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType];
+export type PointerEventType = (typeof PointerEventType)[keyof typeof PointerEventType];
 export declare const PointerType: {
     readonly Mouse: "mouse";
     readonly Touch: "touch";
     readonly Pen: "pen";
 };
-export declare type PointerType = typeof PointerType[keyof typeof PointerType];
-export declare type NodeId = number & {
+export type PointerType = (typeof PointerType)[keyof typeof PointerType];
+export type NodeId = number & {
     __brand: 'NodeId';
 };
-export declare type StringId = number & {
+export type StringId = number & {
     __brand: 'StringId';
 };
-export declare type StyleSheetId = number & {
+export type StyleSheetId = number & {
     __brand: 'StyleSheetId';
 };

--- a/lib/src/session-replay-browser.ts
+++ b/lib/src/session-replay-browser.ts
@@ -9,7 +9,7 @@ export const BrowserSource = {
   Browser: 'browser',
 } as const
 
-export type BrowserSource = typeof BrowserSource[keyof typeof BrowserSource]
+export type BrowserSource = (typeof BrowserSource)[keyof typeof BrowserSource]
 
 export const RecordType: {
   FullSnapshot: SessionReplay.BrowserFullSnapshotRecord['type']
@@ -31,7 +31,7 @@ export const RecordType: {
   Change: 12,
 } as const
 
-export type RecordType = typeof RecordType[keyof typeof RecordType]
+export type RecordType = (typeof RecordType)[keyof typeof RecordType]
 
 export const NodeType: {
   Document: SessionReplay.DocumentNode['type']
@@ -49,7 +49,7 @@ export const NodeType: {
   DocumentFragment: 11,
 } as const
 
-export type NodeType = typeof NodeType[keyof typeof NodeType]
+export type NodeType = (typeof NodeType)[keyof typeof NodeType]
 
 export const IncrementalSource: {
   Mutation: SessionReplay.BrowserMutationData['source']
@@ -76,7 +76,7 @@ export const IncrementalSource: {
   // Font : 10,
 } as const
 
-export type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource]
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource]
 
 export const MouseInteractionType = {
   MouseUp: 0,
@@ -90,14 +90,14 @@ export const MouseInteractionType = {
   TouchEnd: 9,
 } as const
 
-export type MouseInteractionType = typeof MouseInteractionType[keyof typeof MouseInteractionType]
+export type MouseInteractionType = (typeof MouseInteractionType)[keyof typeof MouseInteractionType]
 
 export const MediaInteractionType = {
   Play: 0,
   Pause: 1,
 } as const
 
-export type MediaInteractionType = typeof MediaInteractionType[keyof typeof MediaInteractionType]
+export type MediaInteractionType = (typeof MediaInteractionType)[keyof typeof MediaInteractionType]
 
 // ChangeTypeId evaluates to Id if [Id, ...Data[]] is a valid variant of Change;
 // otherwise, it triggers a compile-time error.
@@ -129,7 +129,7 @@ export const ChangeType: {
   VisualViewport: 10,
 } as const
 
-export type ChangeType = typeof ChangeType[keyof typeof ChangeType]
+export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType]
 
 export const PlaybackState: {
   Playing: SessionReplay.PlaybackStatePlaying
@@ -139,4 +139,4 @@ export const PlaybackState: {
   Paused: 1,
 } as const
 
-export type PlaybackState = typeof PlaybackState[keyof typeof PlaybackState]
+export type PlaybackState = (typeof PlaybackState)[keyof typeof PlaybackState]

--- a/lib/src/session-replay-mobile.ts
+++ b/lib/src/session-replay-mobile.ts
@@ -10,7 +10,7 @@ export const MobileSource = {
   KotlinMultiplatform: 'kotlin-multiplatform',
 } as const
 
-export type MobileSource = typeof MobileSource[keyof typeof MobileSource]
+export type MobileSource = (typeof MobileSource)[keyof typeof MobileSource]
 
 export const RecordType: {
   FullSnapshot: SessionReplay.MobileFullSnapshotRecord['type']
@@ -28,7 +28,7 @@ export const RecordType: {
   VisualViewport: 8,
 } as const
 
-export type RecordType = typeof RecordType[keyof typeof RecordType]
+export type RecordType = (typeof RecordType)[keyof typeof RecordType]
 
 export const WireframeType: {
   Shape: SessionReplay.ShapeWireframe['type']
@@ -38,7 +38,7 @@ export const WireframeType: {
   Text: 'text',
 } as const
 
-export type WireframeType = typeof WireframeType[keyof typeof WireframeType]
+export type WireframeType = (typeof WireframeType)[keyof typeof WireframeType]
 
 export const IncrementalSource: {
   Mutation: SessionReplay.MobileMutationData['source']
@@ -52,4 +52,4 @@ export const IncrementalSource: {
   PointerInteraction: 9,
 } as const
 
-export type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource]
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource]

--- a/lib/src/session-replay.ts
+++ b/lib/src/session-replay.ts
@@ -44,7 +44,7 @@ export const RecordType: {
   BrowserChange: 12,
 } as const
 
-export type RecordType = typeof RecordType[keyof typeof RecordType]
+export type RecordType = (typeof RecordType)[keyof typeof RecordType]
 
 export type IncrementalSource = BrowserIncrementalSource | MobileIncrementalSource
 
@@ -54,7 +54,7 @@ export const PointerEventType = {
   PointerMove: 'move',
 } as const
 
-export type PointerEventType = typeof PointerEventType[keyof typeof PointerEventType]
+export type PointerEventType = (typeof PointerEventType)[keyof typeof PointerEventType]
 
 export const PointerType = {
   Mouse: 'mouse',
@@ -62,7 +62,7 @@ export const PointerType = {
   Pen: 'pen',
 } as const
 
-export type PointerType = typeof PointerType[keyof typeof PointerType]
+export type PointerType = (typeof PointerType)[keyof typeof PointerType]
 
 export type NodeId = number & { __brand: 'NodeId' }
 export type StringId = number & { __brand: 'StringId' }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "validate": "node scripts/validate.mjs"
   },
   "devDependencies": {
-    "ajv": "8.11.0",
+    "ajv": "^8.17.1",
     "json-schema-to-typescript": "bcaudan/json-schema-to-typescript#bcaudan/add-readonly-support",
-    "prettier": "2.7.1",
-    "typescript": ">=4.5"
+    "prettier": "^3.8.1",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=12.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@apidevtools/json-schema-ref-parser@https://github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d":
-  version "0.0.0-dev"
-  resolved "https://github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d"
+"@apidevtools/json-schema-ref-parser@^11.5.5":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz#0e0c9061fc41cf03737d499a4e6a8299fdd2bfa7"
+  integrity sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==
   dependencies:
     "@jsdevtools/ono" "^7.1.3"
-    "@types/json-schema" "^7.0.6"
-    call-me-maybe "^1.0.1"
+    "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
 "@jsdevtools/ono@^7.1.3":
@@ -16,38 +16,15 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@types/glob@^7.1.3":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
-  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
+"@types/json-schema@^7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/json-schema@^7.0.11", "@types/json-schema@^7.0.6":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
-"@types/lodash@^4.14.182":
-  version "4.14.182"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
-  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
-
-"@types/minimatch@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
-  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
-
-"@types/node@*":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
-  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
-
-"@types/prettier@^2.6.1":
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.4.tgz#ad899dad022bab6b5a9f0a0fe67c2f7a4a8950ed"
-  integrity sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==
+"@types/lodash@^4.17.7":
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.23.tgz#c1bb06db218acc8fc232da0447473fc2fb9d9841"
+  integrity sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==
 
 ajv@8.11.0:
   version "8.11.0"
@@ -59,172 +36,20 @@ ajv@8.11.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-any-promise@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
-
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-call-me-maybe@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
-  integrity sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw==
-
-cli-color@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-2.0.3.tgz#73769ba969080629670f3f2ef69a4bf4e7cc1879"
-  integrity sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.61"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.15"
-    timers-ext "^0.1.7"
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
-
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@^0.10.61, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.61"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.61.tgz#311de37949ef86b6b0dcea894d1ffedb909d3269"
-  integrity sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    next-tick "^1.1.0"
-
-es6-iterator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
-es6-weak-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
-
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-ext@^1.1.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
-  integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
-  dependencies:
-    type "^2.5.0"
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-get-stdin@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
-  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
-
-glob-promise@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-4.2.2.tgz#15f44bcba0e14219cd93af36da6bb905ff007877"
-  integrity sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==
-  dependencies:
-    "@types/glob" "^7.1.3"
-
-glob@^7.1.6:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-is-extglob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
-
-is-glob@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
-  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 js-yaml@^4.1.0:
   version "4.1.0"
@@ -234,23 +59,17 @@ js-yaml@^4.1.0:
     argparse "^2.0.1"
 
 json-schema-to-typescript@bcaudan/json-schema-to-typescript#bcaudan/add-readonly-support:
-  version "11.0.1"
-  resolved "https://codeload.github.com/bcaudan/json-schema-to-typescript/tar.gz/ff8616a2dd2dd9f370b3bcab5ec5522a32c31429"
+  version "15.0.3"
+  resolved "https://codeload.github.com/bcaudan/json-schema-to-typescript/tar.gz/406ce54242635f4a0181bd573a3cbc896707e4cc"
   dependencies:
-    "@apidevtools/json-schema-ref-parser" "https://github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d"
-    "@types/json-schema" "^7.0.11"
-    "@types/lodash" "^4.14.182"
-    "@types/prettier" "^2.6.1"
-    cli-color "^2.0.2"
-    get-stdin "^8.0.0"
-    glob "^7.1.6"
-    glob-promise "^4.2.2"
-    is-glob "^4.0.3"
+    "@apidevtools/json-schema-ref-parser" "^11.5.5"
+    "@types/json-schema" "^7.0.15"
+    "@types/lodash" "^4.17.7"
+    js-yaml "^4.1.0"
     lodash "^4.17.21"
-    minimist "^1.2.6"
-    mkdirp "^1.0.4"
-    mz "^2.7.0"
-    prettier "^2.6.2"
+    minimist "^1.2.8"
+    prettier "^3.2.5"
+    tinyglobby "^0.2.9"
 
 json-schema-traverse@^1.0.0:
   version "1.0.0"
@@ -262,79 +81,25 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  integrity sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==
-  dependencies:
-    es5-ext "~0.10.2"
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-memoizee@^0.4.15:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
-  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
-minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimist@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
-
-mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mz@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
-  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
-  dependencies:
-    any-promise "^1.0.0"
-    object-assign "^4.0.1"
-    thenify-all "^1.0.0"
-
-next-tick@1, next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
-object-assign@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
-  dependencies:
-    wrappy "1"
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
-
-prettier@2.7.1, prettier@^2.6.2:
+prettier@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+prettier@^3.2.5:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.1.tgz#edf48977cf991558f4fcbd8a3ba6015ba2a3a173"
+  integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -346,37 +111,13 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-thenify-all@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
-  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+tinyglobby@^0.2.9:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
   dependencies:
-    thenify ">= 3.1.0 < 4"
-
-"thenify@>= 3.1.0 < 4":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
-  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
-  dependencies:
-    any-promise "^1.0.0"
-
-timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
-  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
-  integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
 
 typescript@>=4.5:
   version "4.7.4"
@@ -389,8 +130,3 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,25 +26,30 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.23.tgz#c1bb06db218acc8fc232da0447473fc2fb9d9841"
   integrity sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==
 
-ajv@8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+ajv@^8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
   dependencies:
-    fast-deep-equal "^3.1.1"
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
-    uri-js "^4.2.2"
 
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
 fdir@^6.5.0:
   version "6.5.0"
@@ -91,20 +96,10 @@ picomatch@^4.0.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
-prettier@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
-
-prettier@^3.2.5:
+prettier@^3.2.5, prettier@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.1.tgz#edf48977cf991558f4fcbd8a3ba6015ba2a3a173"
   integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
-
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -119,14 +114,7 @@ tinyglobby@^0.2.9:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
-typescript@>=4.5:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
-uri-js@^4.2.2:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
-  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
-  dependencies:
-    punycode "^2.1.0"
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
This PR updates JS dependencies, notably:
* json-schema-to-typescript has been updated with the latest changes from upstream (see https://github.com/bcaudan/json-schema-to-typescript/pull/4). Most notable change was to add `@deperecated` JSDoc attributes to type definitions
* typescript has been updated from 4.x to 5.x, which brought a bunch of minor changes in built files
* prettier has been updated from 2.x to 3.x which also brought a bunch of small format changes