### PR TITLE
RUM-14235: Add graphQL to telemetry usage

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -491,7 +491,7 @@ export type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital;
+export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital | GraphQLRequest;
 /**
  * Schema of browser specific features usage
  */
@@ -823,6 +823,13 @@ export interface AddOperationStepVital {
      * Operations step type
      */
     action_type: 'start' | 'succeed' | 'fail';
+    [k: string]: unknown;
+}
+export interface GraphQLRequest {
+    /**
+     * GraphQL request detected
+     */
+    feature: 'graphql-request';
     [k: string]: unknown;
 }
 export interface StartSessionReplayRecording {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -491,7 +491,7 @@ export type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital;
+export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital | GraphQLRequest;
 /**
  * Schema of browser specific features usage
  */
@@ -823,6 +823,13 @@ export interface AddOperationStepVital {
      * Operations step type
      */
     action_type: 'start' | 'succeed' | 'fail';
+    [k: string]: unknown;
+}
+export interface GraphQLRequest {
+    /**
+     * GraphQL request detected
+     */
+    feature: 'graphql-request';
     [k: string]: unknown;
 }
 export interface StartSessionReplayRecording {

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -300,6 +300,17 @@
           "enum": ["start", "succeed", "fail"]
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "title": "GraphQLRequest",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "GraphQL request detected",
+          "const": "graphql-request"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
We want to report telemetry about GraphQL usage and that's why I am adding an attribute to report `GraphQLRequest`.