### PR TITLE
[RUM / Profiling] Add vital and action entries to profiler trace schema

### DIFF
--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -135,6 +135,14 @@ export interface BrowserProfilerTrace {
      */
     readonly longTasks: RumProfilerLongTaskEntry[];
     /**
+     * List of detected vital entries.
+     */
+    readonly vitalEntries?: RumProfilerVitalEntry[];
+    /**
+     * List of detected action entries.
+     */
+    readonly actionEntries?: RumProfilerActionEntry[];
+    /**
      * List of detected navigation entries.
      */
     readonly views: RumViewEntry[];
@@ -213,13 +221,51 @@ export interface RumProfilerLongTaskEntry {
      */
     readonly id?: string;
     /**
-     * Duration in ns of the long task or long animation frame.
+     * Duration in ms of the long task or long animation frame.
      */
     readonly duration: number;
     /**
      * Type of the event: long task or long animation frame
      */
     readonly entryType: 'longtask' | 'long-animation-frame';
+    startClocks: ClocksState;
+    [k: string]: unknown;
+}
+/**
+ * Schema of a vital entry recorded during profiling.
+ */
+export interface RumProfilerVitalEntry {
+    /**
+     * RUM Vital id.
+     */
+    readonly id: string;
+    /**
+     * RUM Vital label.
+     */
+    readonly label: string;
+    /**
+     * Duration in ms of the duration vital.
+     */
+    readonly duration: number;
+    startClocks: ClocksState;
+    [k: string]: unknown;
+}
+/**
+ * Schema of a action entry recorded during profiling.
+ */
+export interface RumProfilerActionEntry {
+    /**
+     * RUM Action id.
+     */
+    readonly id: string;
+    /**
+     * RUM Action label.
+     */
+    readonly label: string;
+    /**
+     * Duration in ms of the duration vital.
+     */
+    readonly duration: number;
     startClocks: ClocksState;
     [k: string]: unknown;
 }

--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -137,11 +137,11 @@ export interface BrowserProfilerTrace {
     /**
      * List of detected vital entries.
      */
-    readonly vitalEntries?: RumProfilerVitalEntry[];
+    readonly vitals?: RumProfilerVitalEntry[];
     /**
      * List of detected action entries.
      */
-    readonly actionEntries?: RumProfilerActionEntry[];
+    readonly actions?: RumProfilerActionEntry[];
     /**
      * List of detected navigation entries.
      */
@@ -244,7 +244,7 @@ export interface RumProfilerVitalEntry {
      */
     readonly label: string;
     /**
-     * Duration in ms of the duration vital.
+     * Duration in ms of the vital.
      */
     readonly duration: number;
     startClocks: ClocksState;

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -135,6 +135,14 @@ export interface BrowserProfilerTrace {
      */
     readonly longTasks: RumProfilerLongTaskEntry[];
     /**
+     * List of detected vital entries.
+     */
+    readonly vitalEntries?: RumProfilerVitalEntry[];
+    /**
+     * List of detected action entries.
+     */
+    readonly actionEntries?: RumProfilerActionEntry[];
+    /**
      * List of detected navigation entries.
      */
     readonly views: RumViewEntry[];
@@ -213,13 +221,51 @@ export interface RumProfilerLongTaskEntry {
      */
     readonly id?: string;
     /**
-     * Duration in ns of the long task or long animation frame.
+     * Duration in ms of the long task or long animation frame.
      */
     readonly duration: number;
     /**
      * Type of the event: long task or long animation frame
      */
     readonly entryType: 'longtask' | 'long-animation-frame';
+    startClocks: ClocksState;
+    [k: string]: unknown;
+}
+/**
+ * Schema of a vital entry recorded during profiling.
+ */
+export interface RumProfilerVitalEntry {
+    /**
+     * RUM Vital id.
+     */
+    readonly id: string;
+    /**
+     * RUM Vital label.
+     */
+    readonly label: string;
+    /**
+     * Duration in ms of the duration vital.
+     */
+    readonly duration: number;
+    startClocks: ClocksState;
+    [k: string]: unknown;
+}
+/**
+ * Schema of a action entry recorded during profiling.
+ */
+export interface RumProfilerActionEntry {
+    /**
+     * RUM Action id.
+     */
+    readonly id: string;
+    /**
+     * RUM Action label.
+     */
+    readonly label: string;
+    /**
+     * Duration in ms of the duration vital.
+     */
+    readonly duration: number;
     startClocks: ClocksState;
     [k: string]: unknown;
 }

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -137,11 +137,11 @@ export interface BrowserProfilerTrace {
     /**
      * List of detected vital entries.
      */
-    readonly vitalEntries?: RumProfilerVitalEntry[];
+    readonly vitals?: RumProfilerVitalEntry[];
     /**
      * List of detected action entries.
      */
-    readonly actionEntries?: RumProfilerActionEntry[];
+    readonly actions?: RumProfilerActionEntry[];
     /**
      * List of detected navigation entries.
      */
@@ -244,7 +244,7 @@ export interface RumProfilerVitalEntry {
      */
     readonly label: string;
     /**
-     * Duration in ms of the duration vital.
+     * Duration in ms of the vital.
      */
     readonly duration: number;
     startClocks: ClocksState;

--- a/schemas/profiling/browser/profiler-trace-schema.json
+++ b/schemas/profiling/browser/profiler-trace-schema.json
@@ -112,7 +112,7 @@
         },
         "duration": {
           "type": "number",
-          "description": "Duration in ns of the long task or long animation frame.",
+          "description": "Duration in ms of the long task or long animation frame.",
           "minimum": 0,
           "readOnly": true
         },
@@ -120,6 +120,60 @@
           "type": "string",
           "enum": ["longtask", "long-animation-frame"],
           "description": "Type of the event: long task or long animation frame",
+          "readOnly": true
+        },
+        "startClocks": {
+          "$ref": "#/definitions/ClocksState"
+        }
+      }
+    },
+    "VitalEntry": {
+      "title": "RumProfilerVitalEntry",
+      "type": "object",
+      "description": "Schema of a vital entry recorded during profiling.",
+      "required": ["id", "label", "duration", "startClocks"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "RUM Vital id.",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "description": "RUM Vital label.",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "number",
+          "description": "Duration in ms of the duration vital.",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "startClocks": {
+          "$ref": "#/definitions/ClocksState"
+        }
+      }
+    },
+    "ActionEntry": {
+      "title": "RumProfilerActionEntry",
+      "type": "object",
+      "description": "Schema of a action entry recorded during profiling.",
+      "required": ["id", "label", "duration", "startClocks"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "RUM Action id.",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "description": "RUM Action label.",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "number",
+          "description": "Duration in ms of the duration vital.",
+          "minimum": 0,
           "readOnly": true
         },
         "startClocks": {
@@ -202,6 +256,22 @@
         "$ref": "#/definitions/LongTaskEntry"
       },
       "description": "List of detected long tasks.",
+      "readOnly": true
+    },
+    "vitalEntries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/VitalEntry"
+      },
+      "description": "List of detected vital entries.",
+      "readOnly": true
+    },
+    "actionEntries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ActionEntry"
+      },
+      "description": "List of detected action entries.",
       "readOnly": true
     },
     "views": {

--- a/schemas/profiling/browser/profiler-trace-schema.json
+++ b/schemas/profiling/browser/profiler-trace-schema.json
@@ -145,7 +145,7 @@
         },
         "duration": {
           "type": "number",
-          "description": "Duration in ms of the duration vital.",
+          "description": "Duration in ms of the vital.",
           "minimum": 0,
           "readOnly": true
         },
@@ -258,7 +258,7 @@
       "description": "List of detected long tasks.",
       "readOnly": true
     },
-    "vitalEntries": {
+    "vitals": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/VitalEntry"
@@ -266,7 +266,7 @@
       "description": "List of detected vital entries.",
       "readOnly": true
     },
-    "actionEntries": {
+    "actions": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/ActionEntry"


### PR DESCRIPTION
As part of the implementation of profiling aggregation on the backend, we want to include vitals and actions' entries to the profiles' metadata.

This PR updates the schema of the profiler trace to reflect this change.