### PR TITLE
[PROF] Add action and vital to profiling event schema

### DIFF
--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -24,6 +24,36 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         [k: string]: unknown;
     };
     [k: string]: unknown;
+} & {
+    /**
+     * Action properties.
+     */
+    readonly action: {
+        /**
+         * Array of action IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of action labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 };
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.

--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -23,12 +23,10 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly clock_drift: number;
         [k: string]: unknown;
     };
-    [k: string]: unknown;
-} & {
     /**
      * Action properties.
      */
-    readonly action: {
+    readonly action?: {
         /**
          * Array of action IDs.
          */
@@ -42,7 +40,7 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Vital properties.
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Array of vital IDs.
          */

--- a/lib/cjs/generated/profiling.d.ts
+++ b/lib/cjs/generated/profiling.d.ts
@@ -24,6 +24,36 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         [k: string]: unknown;
     };
     [k: string]: unknown;
+} & {
+    /**
+     * Action properties.
+     */
+    readonly action: {
+        /**
+         * Array of action IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of action labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 };
 /**
  * Mobile SDK profiling event.

--- a/lib/cjs/generated/profiling.d.ts
+++ b/lib/cjs/generated/profiling.d.ts
@@ -23,12 +23,10 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly clock_drift: number;
         [k: string]: unknown;
     };
-    [k: string]: unknown;
-} & {
     /**
      * Action properties.
      */
-    readonly action: {
+    readonly action?: {
         /**
          * Array of action IDs.
          */
@@ -42,7 +40,7 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Vital properties.
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Array of vital IDs.
          */

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -24,6 +24,36 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         [k: string]: unknown;
     };
     [k: string]: unknown;
+} & {
+    /**
+     * Action properties.
+     */
+    readonly action: {
+        /**
+         * Array of action IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of action labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 };
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -23,12 +23,10 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly clock_drift: number;
         [k: string]: unknown;
     };
-    [k: string]: unknown;
-} & {
     /**
      * Action properties.
      */
-    readonly action: {
+    readonly action?: {
         /**
          * Array of action IDs.
          */
@@ -42,7 +40,7 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Vital properties.
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Array of vital IDs.
          */

--- a/lib/esm/generated/profiling.d.ts
+++ b/lib/esm/generated/profiling.d.ts
@@ -24,6 +24,36 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         [k: string]: unknown;
     };
     [k: string]: unknown;
+} & {
+    /**
+     * Action properties.
+     */
+    readonly action: {
+        /**
+         * Array of action IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of action labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 };
 /**
  * Mobile SDK profiling event.

--- a/lib/esm/generated/profiling.d.ts
+++ b/lib/esm/generated/profiling.d.ts
@@ -23,12 +23,10 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly clock_drift: number;
         [k: string]: unknown;
     };
-    [k: string]: unknown;
-} & {
     /**
      * Action properties.
      */
-    readonly action: {
+    readonly action?: {
         /**
          * Array of action IDs.
          */
@@ -42,7 +40,7 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
     /**
      * Vital properties.
      */
-    readonly vital: {
+    readonly vital?: {
         /**
          * Array of vital IDs.
          */

--- a/samples/profiling/browser/profile-event/profile-event.json
+++ b/samples/profiling/browser/profile-event/profile-event.json
@@ -9,6 +9,14 @@
   "long_task": {
     "id": ["0e6071e2-e4ae-4605-8dfe-9f3551a172f9"]
   },
+  "action": {
+    "id": ["b3f8c1a2-9d4e-4f5a-8b7c-2e1d3f4a5b6c"],
+    "label": ["action-label"]
+  },
+  "vital": {
+    "id": ["d8205161-044f-482c-975e-77992a55d35f"],
+    "label": ["vital-label"]
+  },
   "attachments": ["wall-time.json"],
   "start": "2025-12-02T13:32:04.886Z",
   "end": "2025-12-02T13:33:04.891Z",

--- a/schemas/profiling/browser/profile-event-schema.json
+++ b/schemas/profiling/browser/profile-event-schema.json
@@ -32,6 +32,60 @@
           "readOnly": true
         }
       }
+    },
+    {
+      "type": "object",
+      "required": ["action", "vital"],
+      "properties": {
+        "action": {
+          "type": "object",
+          "description": "Action properties.",
+          "required": ["id", "label"],
+          "properties": {
+            "id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of action IDs.",
+              "readOnly": true
+            },
+            "label": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of action labels.",
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        },
+        "vital": {
+          "type": "object",
+          "description": "Vital properties.",
+          "required": ["id", "label"],
+          "properties": {
+            "id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of vital IDs.",
+              "readOnly": true
+            },
+            "label": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of vital labels.",
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        }
+      }
     }
   ]
 }

--- a/schemas/profiling/browser/profile-event-schema.json
+++ b/schemas/profiling/browser/profile-event-schema.json
@@ -30,13 +30,7 @@
             }
           },
           "readOnly": true
-        }
-      }
-    },
-    {
-      "type": "object",
-      "required": ["action", "vital"],
-      "properties": {
+        },
         "action": {
           "type": "object",
           "description": "Action properties.",


### PR DESCRIPTION
This PR is a follow-up of [that one](https://github.com/DataDog/rum-events-format/pull/345), where I forgot to add my new fields `action` and `vital` to the browser `profiler-event-schema`...