### PR TITLE
feat: update view schema to support INP subparts RUM-14475

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1935,6 +1935,24 @@ export interface ViewPerformanceData {
          * CSS selector path of the interacted element for the INP interaction
          */
         readonly target_selector?: string;
+        /**
+         * Sub-parts of the INP
+         */
+        sub_parts?: {
+            /**
+             * Time from the start of the input event to the start of the processing of the event
+             */
+            readonly input_delay: number;
+            /**
+             * Event handler execution time
+             */
+            readonly processing_time: number;
+            /**
+             * Rendering time happening after processing
+             */
+            readonly presentation_delay: number;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1935,6 +1935,24 @@ export interface ViewPerformanceData {
          * CSS selector path of the interacted element for the INP interaction
          */
         readonly target_selector?: string;
+        /**
+         * Sub-parts of the INP
+         */
+        sub_parts?: {
+            /**
+             * Time from the start of the input event to the start of the processing of the event
+             */
+            readonly input_delay: number;
+            /**
+             * Event handler execution time
+             */
+            readonly processing_time: number;
+            /**
+             * Rendering time happening after processing
+             */
+            readonly presentation_delay: number;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
     };
     /**

--- a/schemas/rum/_view-performance-schema.json
+++ b/schemas/rum/_view-performance-schema.json
@@ -108,6 +108,31 @@
           "description": "CSS selector path of the interacted element for the INP interaction",
           "$comment": "Replaces the deprecated `view.interaction_to_next_paint_target_selector`",
           "readOnly": true
+        },
+        "sub_parts": {
+          "type": "object",
+          "description": "Sub-parts of the INP",
+          "required": ["input_delay", "processing_time", "presentation_delay"],
+          "properties": {
+            "input_delay": {
+              "type": "integer",
+              "description": "Time from the start of the input event to the start of the processing of the event",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "processing_time": {
+              "type": "integer",
+              "description": "Event handler execution time",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "presentation_delay": {
+              "type": "integer",
+              "description": "Rendering time happening after processing",
+              "minimum": 0,
+              "readOnly": true
+            }
+          }
         }
       },
       "readOnly": true


### PR DESCRIPTION
[Similar to what we did for LCP subparts](https://github.com/DataDog/rum-events-format/pull/340), this PR update the view schema to support INP subparts.

[Browser SDK PR](https://github.com/DataDog/browser-sdk/pull/4158) 