### PR TITLE
RUM-14055 Add request body size metrics to resource schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -754,6 +754,20 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             [k: string]: unknown;
         };
         /**
+         * Request properties
+         */
+        readonly request?: {
+            /**
+             * Size in octet of the request body sent over the network (after encoding)
+             */
+            readonly encoded_body_size?: number;
+            /**
+             * Size in octet of the request body before any encoding
+             */
+            readonly decoded_body_size?: number;
+            [k: string]: unknown;
+        };
+        /**
          * GraphQL requests parameters
          */
         readonly graphql?: {

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -614,15 +614,15 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly size?: number;
         /**
-         * Size in octet of the resource before removing any applied content encodings
+         * Size in octet of the response body before removing any applied content encodings
          */
         readonly encoded_body_size?: number;
         /**
-         * Size in octet of the resource after removing any applied encoding
+         * Size in octet of the response body after removing any applied encoding
          */
         readonly decoded_body_size?: number;
         /**
-         * Size in octet of the fetched resource
+         * Size in octet of the fetched response resource
          */
         readonly transfer_size?: number;
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -754,6 +754,20 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             [k: string]: unknown;
         };
         /**
+         * Request properties
+         */
+        readonly request?: {
+            /**
+             * Size in octet of the request body sent over the network (after encoding)
+             */
+            readonly encoded_body_size?: number;
+            /**
+             * Size in octet of the request body before any encoding
+             */
+            readonly decoded_body_size?: number;
+            [k: string]: unknown;
+        };
+        /**
          * GraphQL requests parameters
          */
         readonly graphql?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -614,15 +614,15 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly size?: number;
         /**
-         * Size in octet of the resource before removing any applied content encodings
+         * Size in octet of the response body before removing any applied content encodings
          */
         readonly encoded_body_size?: number;
         /**
-         * Size in octet of the resource after removing any applied encoding
+         * Size in octet of the response body after removing any applied encoding
          */
         readonly decoded_body_size?: number;
         /**
-         * Size in octet of the fetched resource
+         * Size in octet of the fetched response resource
          */
         readonly transfer_size?: number;
         /**

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -39,7 +39,11 @@
       "start": 88945000
     },
     "protocol": "HTTP/1.1",
-    "delivery_type": "cache"
+    "delivery_type": "cache",
+    "request": {
+      "encoded_body_size": 512,
+      "decoded_body_size": 1024
+    }
   },
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -71,19 +71,19 @@
             },
             "encoded_body_size": {
               "type": "integer",
-              "description": "Size in octet of the resource before removing any applied content encodings",
+              "description": "Size in octet of the response body before removing any applied content encodings",
               "minimum": 0,
               "readOnly": true
             },
             "decoded_body_size": {
               "type": "integer",
-              "description": "Size in octet of the resource after removing any applied encoding",
+              "description": "Size in octet of the response body after removing any applied encoding",
               "minimum": 0,
               "readOnly": true
             },
             "transfer_size": {
               "type": "integer",
-              "description": "Size in octet of the fetched resource",
+              "description": "Size in octet of the fetched response resource",
               "minimum": 0,
               "readOnly": true
             },

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -282,6 +282,25 @@
               },
               "readOnly": true
             },
+            "request": {
+              "type": "object",
+              "description": "Request properties",
+              "properties": {
+                "encoded_body_size": {
+                  "type": "integer",
+                  "description": "Size in octet of the request body sent over the network (after encoding)",
+                  "minimum": 0,
+                  "readOnly": true
+                },
+                "decoded_body_size": {
+                  "type": "integer",
+                  "description": "Size in octet of the request body before any encoding",
+                  "minimum": 0,
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            },
             "graphql": {
               "type": "object",
               "description": "GraphQL requests parameters",


### PR DESCRIPTION
Following the proposal shared on the #rum-rfc Slack channel, this PR introduces the `resource.request` object to the RUM resource event schema with two new fields: `encoded_body_size` (bytes sent over the network after encoding) and `decoded_body_size` (bytes before any encoding).