### PR TITLE
RUM-14562 Add request and response headers to resource schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -765,6 +765,24 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
              * Size in octet of the request body before any encoding
              */
             readonly decoded_body_size?: number;
+            /**
+             * HTTP headers of the resource request
+             */
+            readonly headers?: {
+                [k: string]: string;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * Response properties
+         */
+        readonly response?: {
+            /**
+             * HTTP headers of the resource response
+             */
+            readonly headers?: {
+                [k: string]: string;
+            };
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -765,6 +765,24 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
              * Size in octet of the request body before any encoding
              */
             readonly decoded_body_size?: number;
+            /**
+             * HTTP headers of the resource request
+             */
+            readonly headers?: {
+                [k: string]: string;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * Response properties
+         */
+        readonly response?: {
+            /**
+             * HTTP headers of the resource response
+             */
+            readonly headers?: {
+                [k: string]: string;
+            };
             [k: string]: unknown;
         };
         /**

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -42,7 +42,18 @@
     "delivery_type": "cache",
     "request": {
       "encoded_body_size": 512,
-      "decoded_body_size": 1024
+      "decoded_body_size": 1024,
+      "headers": {
+        "content-type": "application/json",
+        "cache-control": "no-cache"
+      }
+    },
+    "response": {
+      "headers": {
+        "content-type": "application/json",
+        "cache-control": "max-age=3600",
+        "content-encoding": "gzip"
+      }
     }
   },
   "action": {

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -297,6 +297,29 @@
                   "description": "Size in octet of the request body before any encoding",
                   "minimum": 0,
                   "readOnly": true
+                },
+                "headers": {
+                  "type": "object",
+                  "description": "HTTP headers of the resource request",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            },
+            "response": {
+              "type": "object",
+              "description": "Response properties",
+              "properties": {
+                "headers": {
+                  "type": "object",
+                  "description": "HTTP headers of the resource response",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "readOnly": true
                 }
               },
               "readOnly": true


### PR DESCRIPTION
## What and why?

Add optional `headers` fields to `resource.request` and `resource.response` in the RUM resource event schema, as per the iOS SDK Network Header Capture RFC.