### PR TITLE
[RUM-14619] Add AddViewLoadingTime telemetry to browser schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -491,7 +491,7 @@ export type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital | GraphQLRequest;
+export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital | GraphQLRequest | AddViewLoadingTime;
 /**
  * Schema of browser specific features usage
  */
@@ -499,7 +499,7 @@ export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartD
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView | AndroidNetworkInstrumentation;
+export type TelemetryMobileFeaturesUsage = TrackWebView | AndroidNetworkInstrumentation;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -832,6 +832,25 @@ export interface GraphQLRequest {
     feature: 'graphql-request';
     [k: string]: unknown;
 }
+export interface AddViewLoadingTime {
+    /**
+     * addViewLoadingTime API
+     */
+    feature: 'addViewLoadingTime';
+    /**
+     * Whether the view is not available
+     */
+    no_view?: boolean;
+    /**
+     * Whether the available view is not active
+     */
+    no_active_view?: boolean;
+    /**
+     * Whether this call overwrote a previously set loading time
+     */
+    overwritten?: boolean;
+    [k: string]: unknown;
+}
 export interface StartSessionReplayRecording {
     /**
      * startSessionReplayRecording API
@@ -890,25 +909,6 @@ export interface StopResource {
      * stopResource API
      */
     feature: 'stop-resource';
-    [k: string]: unknown;
-}
-export interface AddViewLoadingTime {
-    /**
-     * addViewLoadingTime API
-     */
-    feature: 'addViewLoadingTime';
-    /**
-     * Whether the view is not available
-     */
-    no_view: boolean;
-    /**
-     * Whether the available view is not active
-     */
-    no_active_view: boolean;
-    /**
-     * Whether the loading time was overwritten
-     */
-    overwritten: boolean;
     [k: string]: unknown;
 }
 export interface TrackWebView {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -491,7 +491,7 @@ export type TelemetryUsageEvent = CommonTelemetryProperties & {
 /**
  * Schema of features usage common across SDKs
  */
-export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital | GraphQLRequest;
+export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | StartView | SetViewContext | SetViewContextProperty | SetViewName | GetViewContext | AddAction | AddError | GetGlobalContext | SetGlobalContext | SetGlobalContextProperty | RemoveGlobalContextProperty | ClearGlobalContext | GetUser | SetUser | SetUserProperty | RemoveUserProperty | ClearUser | GetAccount | SetAccount | SetAccountProperty | RemoveAccountProperty | ClearAccount | AddFeatureFlagEvaluation | AddOperationStepVital | GraphQLRequest | AddViewLoadingTime;
 /**
  * Schema of browser specific features usage
  */
@@ -499,7 +499,7 @@ export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartD
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView | AndroidNetworkInstrumentation;
+export type TelemetryMobileFeaturesUsage = TrackWebView | AndroidNetworkInstrumentation;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -832,6 +832,25 @@ export interface GraphQLRequest {
     feature: 'graphql-request';
     [k: string]: unknown;
 }
+export interface AddViewLoadingTime {
+    /**
+     * addViewLoadingTime API
+     */
+    feature: 'addViewLoadingTime';
+    /**
+     * Whether the view is not available
+     */
+    no_view?: boolean;
+    /**
+     * Whether the available view is not active
+     */
+    no_active_view?: boolean;
+    /**
+     * Whether this call overwrote a previously set loading time
+     */
+    overwritten?: boolean;
+    [k: string]: unknown;
+}
 export interface StartSessionReplayRecording {
     /**
      * startSessionReplayRecording API
@@ -890,25 +909,6 @@ export interface StopResource {
      * stopResource API
      */
     feature: 'stop-resource';
-    [k: string]: unknown;
-}
-export interface AddViewLoadingTime {
-    /**
-     * addViewLoadingTime API
-     */
-    feature: 'addViewLoadingTime';
-    /**
-     * Whether the view is not available
-     */
-    no_view: boolean;
-    /**
-     * Whether the available view is not active
-     */
-    no_active_view: boolean;
-    /**
-     * Whether the loading time was overwritten
-     */
-    overwritten: boolean;
     [k: string]: unknown;
 }
 export interface TrackWebView {

--- a/samples/telemetry-events/usage-add-view-loading-time-browser.json
+++ b/samples/telemetry-events/usage-add-view-loading-time-browser.json
@@ -1,0 +1,29 @@
+{
+  "_dd": {
+    "format_version": 2
+  },
+  "type": "telemetry",
+  "date": 1591284175342,
+  "service": "browser-sdk",
+  "source": "browser",
+  "version": "1.2.3",
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599"
+  },
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6"
+  },
+  "action": {
+    "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+  },
+  "experimental_features": [],
+  "telemetry": {
+    "type": "usage",
+    "usage": {
+      "feature": "addViewLoadingTime"
+    }
+  }
+}

--- a/samples/telemetry-events/usage-add-view-loading-time-mobile.json
+++ b/samples/telemetry-events/usage-add-view-loading-time-mobile.json
@@ -1,0 +1,31 @@
+{
+  "_dd": {
+    "format_version": 2
+  },
+  "type": "telemetry",
+  "date": 1591284175342,
+  "service": "mobile-sdk",
+  "source": "ios",
+  "version": "1.2.3",
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599"
+  },
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6"
+  },
+  "action": {
+    "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+  },
+  "experimental_features": [],
+  "telemetry": {
+    "type": "usage",
+    "usage": {
+      "feature": "addViewLoadingTime",
+      "no_view": true,
+      "overwritten": false
+    }
+  }
+}

--- a/schemas/telemetry/usage/common-features-schema.json
+++ b/schemas/telemetry/usage/common-features-schema.json
@@ -311,6 +311,29 @@
           "const": "graphql-request"
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "title": "AddViewLoadingTime",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "addViewLoadingTime API",
+          "const": "addViewLoadingTime"
+        },
+        "no_view": {
+          "type": "boolean",
+          "description": "Whether the view is not available"
+        },
+        "no_active_view": {
+          "type": "boolean",
+          "description": "Whether the available view is not active"
+        },
+        "overwritten": {
+          "type": "boolean",
+          "description": "Whether this call overwrote a previously set loading time"
+        }
+      }
     }
   ]
 }

--- a/schemas/telemetry/usage/mobile-features-schema.json
+++ b/schemas/telemetry/usage/mobile-features-schema.json
@@ -6,29 +6,6 @@
   "description": "Schema of mobile specific features usage",
   "oneOf": [
     {
-      "required": ["feature", "no_view", "no_active_view", "overwritten"],
-      "title": "AddViewLoadingTime",
-      "properties": {
-        "feature": {
-          "type": "string",
-          "description": "addViewLoadingTime API",
-          "const": "addViewLoadingTime"
-        },
-        "no_view": {
-          "type": "boolean",
-          "description": "Whether the view is not available"
-        },
-        "no_active_view": {
-          "type": "boolean",
-          "description": "Whether the available view is not active"
-        },
-        "overwritten": {
-          "type": "boolean",
-          "description": "Whether the loading time was overwritten"
-        }
-      }
-    },
-    {
       "required": ["feature"],
       "title": "TrackWebView",
       "properties": {


### PR DESCRIPTION
## What does this PR do?

Adds `AddViewLoadingTime` to the **shared** telemetry features schema (`common-features-schema.json`), enabling both Browser and Mobile SDKs to track usage of the `addViewLoadingTime` API.

## Why?

The Browser SDK is adding a new `setViewLoadingTime({ overwrite })` API for manually reporting view loading times ([DataDog/browser-sdk#4180](https://github.com/DataDog/browser-sdk/pull/4180)). This schema change enables telemetry tracking aligned with the mobile SDK's existing pattern.

The type is placed in the **common** schema (not browser-only) because both mobile and browser SDKs share the same `addViewLoadingTime` API surface and telemetry fields.

## Changes

- Added `AddViewLoadingTime` entry to `schemas/telemetry/usage/common-features-schema.json` with:
  - `feature: "addViewLoadingTime"` (const, required)
  - `overwritten: boolean` (optional) — whether this call overwrote a previously set loading time
  - `no_view: boolean` (optional) — API called with no view tracking (mobile only)
  - `no_active_view: boolean` (optional) — API called when no view is active (mobile only)
- Removed duplicate `AddViewLoadingTime` from `schemas/telemetry/usage/mobile-features-schema.json` (moved to common)
- Regenerated TypeScript types in `lib/cjs/generated/telemetry.d.ts` and `lib/esm/generated/telemetry.d.ts`
- Added browser and mobile event samples

### Why are all fields except `feature` optional?

- `no_view` / `no_active_view`: The browser SDK always creates a view on `init()`, so these are mobile-only. The browser omits them entirely rather than sending `false`.
- `overwritten`: The browser SDK does not send this field for now. Mobile SDKs already report it. Kept optional so each SDK can adopt it independently.

## Impact

- Shared across Browser and Mobile SDKs via common schema
- Additive change — no breaking changes to existing telemetry types
- After merge: Browser SDK schema sync will replace the manually-added `AddViewLoadingTime` type in `telemetryEvent.types.ts`