### PR TITLE
[RUM/PROF] Make vital and action durations optional in profiles metadata

### DIFF
--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -274,7 +274,7 @@ export interface RumProfilerVitalEntry {
     /**
      * Duration in ms of the vital.
      */
-    readonly duration: number;
+    readonly duration?: number;
     startClocks: ClocksState;
     [k: string]: unknown;
 }
@@ -293,7 +293,7 @@ export interface RumProfilerActionEntry {
     /**
      * Duration in ms of the duration vital.
      */
-    readonly duration: number;
+    readonly duration?: number;
     startClocks: ClocksState;
     [k: string]: unknown;
 }

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -274,7 +274,7 @@ export interface RumProfilerVitalEntry {
     /**
      * Duration in ms of the vital.
      */
-    readonly duration: number;
+    readonly duration?: number;
     startClocks: ClocksState;
     [k: string]: unknown;
 }
@@ -293,7 +293,7 @@ export interface RumProfilerActionEntry {
     /**
      * Duration in ms of the duration vital.
      */
-    readonly duration: number;
+    readonly duration?: number;
     startClocks: ClocksState;
     [k: string]: unknown;
 }

--- a/schemas/profiling/browser/profiler-trace-schema.json
+++ b/schemas/profiling/browser/profiler-trace-schema.json
@@ -131,7 +131,7 @@
       "title": "RumProfilerVitalEntry",
       "type": "object",
       "description": "Schema of a vital entry recorded during profiling.",
-      "required": ["id", "label", "duration", "startClocks"],
+      "required": ["id", "label", "startClocks"],
       "properties": {
         "id": {
           "type": "string",
@@ -158,7 +158,7 @@
       "title": "RumProfilerActionEntry",
       "type": "object",
       "description": "Schema of a action entry recorded during profiling.",
-      "required": ["id", "label", "duration", "startClocks"],
+      "required": ["id", "label", "startClocks"],
       "properties": {
         "id": {
           "type": "string",


### PR DESCRIPTION
We recently added vitals and actions data to profile events metadata.

The duration of vital and action events was mandatory, but we decided to track actions and vitals still ongoing as well, meaning we need to make the duration field potentially undefined. This is what this PR is for.