### PR TITLE
PANA-5615: Fix `permanent_id` property ordering for Android compatibility

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -50,6 +50,10 @@ export type ShapeWireframe = CommonShapeWireframe & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
@@ -102,6 +106,10 @@ export type TextWireframe = CommonShapeWireframe & {
     text: string;
     textStyle: TextStyle;
     textPosition?: TextPosition;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextStyle.
@@ -181,6 +189,10 @@ export type ImageWireframe = CommonShapeWireframe & {
      * Flag describing an image wireframe that should render an empty state placeholder
      */
     isEmpty?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a PlaceholderWireframe.
@@ -194,6 +206,10 @@ export type PlaceholderWireframe = CommonWireframe & {
      * Label of the placeholder
      */
     label?: string;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a WebviewWireframe.
@@ -211,6 +227,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
      * Whether this webview is visible or not.
      */
     readonly isVisible?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -541,10 +561,6 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -132,10 +132,6 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly selector?: string;
                 /**
-                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
-                 */
-                readonly permanent_id?: string;
-                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;
@@ -143,6 +139,10 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  * Height of the target element (in pixels)
                  */
                 readonly height?: number;
+                /**
+                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                 */
+                readonly permanent_id?: string;
                 [k: string]: unknown;
             };
             /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -591,6 +591,10 @@ export type ShapeWireframe = CommonShapeWireframe & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
@@ -643,6 +647,10 @@ export type TextWireframe = CommonShapeWireframe & {
     text: string;
     textStyle: TextStyle;
     textPosition?: TextPosition;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextStyle.
@@ -722,6 +730,10 @@ export type ImageWireframe = CommonShapeWireframe & {
      * Flag describing an image wireframe that should render an empty state placeholder
      */
     isEmpty?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a PlaceholderWireframe.
@@ -735,6 +747,10 @@ export type PlaceholderWireframe = CommonWireframe & {
      * Label of the placeholder
      */
     label?: string;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a WebviewWireframe.
@@ -752,6 +768,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
      * Whether this webview is visible or not.
      */
     readonly isVisible?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -1347,10 +1367,6 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -50,6 +50,10 @@ export type ShapeWireframe = CommonShapeWireframe & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
@@ -102,6 +106,10 @@ export type TextWireframe = CommonShapeWireframe & {
     text: string;
     textStyle: TextStyle;
     textPosition?: TextPosition;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextStyle.
@@ -181,6 +189,10 @@ export type ImageWireframe = CommonShapeWireframe & {
      * Flag describing an image wireframe that should render an empty state placeholder
      */
     isEmpty?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a PlaceholderWireframe.
@@ -194,6 +206,10 @@ export type PlaceholderWireframe = CommonWireframe & {
      * Label of the placeholder
      */
     label?: string;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a WebviewWireframe.
@@ -211,6 +227,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
      * Whether this webview is visible or not.
      */
     readonly isVisible?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -541,10 +561,6 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -132,10 +132,6 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly selector?: string;
                 /**
-                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
-                 */
-                readonly permanent_id?: string;
-                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;
@@ -143,6 +139,10 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  * Height of the target element (in pixels)
                  */
                 readonly height?: number;
+                /**
+                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                 */
+                readonly permanent_id?: string;
                 [k: string]: unknown;
             };
             /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -591,6 +591,10 @@ export type ShapeWireframe = CommonShapeWireframe & {
      * The type of the wireframe.
      */
     readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of common properties for ShapeWireframe events type and all its sub - types.
@@ -643,6 +647,10 @@ export type TextWireframe = CommonShapeWireframe & {
     text: string;
     textStyle: TextStyle;
     textPosition?: TextPosition;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextStyle.
@@ -722,6 +730,10 @@ export type ImageWireframe = CommonShapeWireframe & {
      * Flag describing an image wireframe that should render an empty state placeholder
      */
     isEmpty?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a PlaceholderWireframe.
@@ -735,6 +747,10 @@ export type PlaceholderWireframe = CommonWireframe & {
      * Label of the placeholder
      */
     label?: string;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a WebviewWireframe.
@@ -752,6 +768,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
      * Whether this webview is visible or not.
      */
     readonly isVisible?: boolean;
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
@@ -1347,10 +1367,6 @@ export interface CommonWireframe {
      */
     readonly height: number;
     clip?: WireframeClip;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
 }
 /**
  * Schema of clipping information for a Wireframe.

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -180,11 +180,6 @@
                       "description": "CSS selector path of the target element",
                       "readOnly": true
                     },
-                    "permanent_id": {
-                      "type": "string",
-                      "description": "Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.",
-                      "readOnly": true
-                    },
                     "width": {
                       "type": "integer",
                       "description": "Width of the target element (in pixels)",
@@ -193,6 +188,11 @@
                     "height": {
                       "type": "integer",
                       "description": "Height of the target element (in pixels)",
+                      "readOnly": true
+                    },
+                    "permanent_id": {
+                      "type": "string",
+                      "description": "Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.",
                       "readOnly": true
                     }
                   }

--- a/schemas/session-replay/mobile/_common-wireframe-schema.json
+++ b/schemas/session-replay/mobile/_common-wireframe-schema.json
@@ -33,11 +33,6 @@
     },
     "clip": {
       "$ref": "wireframe-clip-schema.json"
-    },
-    "permanentId": {
-      "type": "string",
-      "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
-      "readOnly": true
     }
   }
 }

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -36,6 +36,11 @@
           "type": "boolean",
           "description": "Flag describing an image wireframe that should render an empty state placeholder",
           "readOnly": false
+        },
+        "permanentId": {
+          "type": "string",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "readOnly": true
         }
       }
     }

--- a/schemas/session-replay/mobile/placeholder-wireframe-schema.json
+++ b/schemas/session-replay/mobile/placeholder-wireframe-schema.json
@@ -21,6 +21,11 @@
           "type": "string",
           "description": "Label of the placeholder",
           "readOnly": false
+        },
+        "permanentId": {
+          "type": "string",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "readOnly": true
         }
       }
     }

--- a/schemas/session-replay/mobile/shape-wireframe-schema.json
+++ b/schemas/session-replay/mobile/shape-wireframe-schema.json
@@ -16,6 +16,11 @@
           "description": "The type of the wireframe.",
           "const": "shape",
           "readOnly": true
+        },
+        "permanentId": {
+          "type": "string",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "readOnly": true
         }
       }
     }

--- a/schemas/session-replay/mobile/text-wireframe-schema.json
+++ b/schemas/session-replay/mobile/text-wireframe-schema.json
@@ -27,6 +27,11 @@
         },
         "textPosition": {
           "$ref": "text-position-schema.json"
+        },
+        "permanentId": {
+          "type": "string",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "readOnly": true
         }
       }
     }

--- a/schemas/session-replay/mobile/webview-wireframe-schema.json
+++ b/schemas/session-replay/mobile/webview-wireframe-schema.json
@@ -26,6 +26,11 @@
           "type": "boolean",
           "description": "Whether this webview is visible or not.",
           "readOnly": true
+        },
+        "permanentId": {
+          "type": "string",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "readOnly": true
         }
       }
     }


### PR DESCRIPTION
### Summary

Fixes the positional ordering of `permanentId/permanent_id` in the JSON schemas to ensure Android code generation produces backwards-compatible constructor signatures.

This change is safe since `permanentId/permanent_id` is not yet used in production by any platform.

### Changes

- Moved `permanent_id` to the end of the target properties in `action-schema.json` (after width and height)
- Removed `permanentId` from `_common-wireframe-schema.json` and added it as the last property in each leaf wireframe schema:
  - `ShapeWireframe`
  - `TextWireframe`
  - `ImageWireframe`
  - `PlaceholderWireframe`
  - `WebviewWireframe`

### Context

Android uses the schema JSON positionally when generating constructor signatures. Because wireframe schemas use `allOf` to extend from common schemas, having `permanentId` in `_common-wireframe-schema.json` caused it to appear in the middle of the generated argument lists, breaking backwards compatibility.

Moving it to the end of each leaf node ensures it's always last in the generated signatures.