### PR TITLE
RUM-12636: [Android only] Supporting new API usage for cronet/okhttp integration

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -499,7 +499,7 @@ export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartD
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView;
+export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView | AndroidNetworkInstrumentation;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -888,5 +888,16 @@ export interface TrackWebView {
      * trackWebView API
      */
     feature: 'trackWebView';
+    [k: string]: unknown;
+}
+export interface AndroidNetworkInstrumentation {
+    /**
+     * Android network instrumentation
+     */
+    feature: 'androidNetworkInstrumentation';
+    /**
+     * The network instrumentation API used
+     */
+    type: 'CRONET' | 'OKHTTP';
     [k: string]: unknown;
 }

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -499,7 +499,7 @@ export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartD
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView;
+export type TelemetryMobileFeaturesUsage = AddViewLoadingTime | TrackWebView | AndroidNetworkInstrumentation;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -888,5 +888,16 @@ export interface TrackWebView {
      * trackWebView API
      */
     feature: 'trackWebView';
+    [k: string]: unknown;
+}
+export interface AndroidNetworkInstrumentation {
+    /**
+     * Android network instrumentation
+     */
+    feature: 'androidNetworkInstrumentation';
+    /**
+     * The network instrumentation API used
+     */
+    type: 'CRONET' | 'OKHTTP';
     [k: string]: unknown;
 }

--- a/schemas/telemetry/usage/mobile-features-schema.json
+++ b/schemas/telemetry/usage/mobile-features-schema.json
@@ -38,6 +38,22 @@
           "const": "trackWebView"
         }
       }
+    },
+    {
+      "required": ["feature", "type"],
+      "title": "AndroidNetworkInstrumentation",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "Android network instrumentation",
+          "const": "androidNetworkInstrumentation"
+        },
+        "type": {
+          "type": "string",
+          "description": "The network instrumentation API used",
+          "enum": ["CRONET", "OKHTTP"]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds new apiUsage telemetry event only for android in order to instrument cronet/okhttp usage