### PR TITLE
Add start-action, stop-action, start-resource, stop-resource to brows…

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -495,7 +495,7 @@ export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | St
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource;
 /**
  * Schema of mobile specific features usage
  */
@@ -862,6 +862,34 @@ export interface AddDurationVital {
      * addDurationVital API
      */
     feature: 'add-duration-vital';
+    [k: string]: unknown;
+}
+export interface StartAction {
+    /**
+     * startAction API
+     */
+    feature: 'start-action';
+    [k: string]: unknown;
+}
+export interface StopAction {
+    /**
+     * stopAction API
+     */
+    feature: 'stop-action';
+    [k: string]: unknown;
+}
+export interface StartResource {
+    /**
+     * startResource API
+     */
+    feature: 'start-resource';
+    [k: string]: unknown;
+}
+export interface StopResource {
+    /**
+     * stopResource API
+     */
+    feature: 'stop-resource';
     [k: string]: unknown;
 }
 export interface AddViewLoadingTime {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -495,7 +495,7 @@ export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | St
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource;
 /**
  * Schema of mobile specific features usage
  */
@@ -862,6 +862,34 @@ export interface AddDurationVital {
      * addDurationVital API
      */
     feature: 'add-duration-vital';
+    [k: string]: unknown;
+}
+export interface StartAction {
+    /**
+     * startAction API
+     */
+    feature: 'start-action';
+    [k: string]: unknown;
+}
+export interface StopAction {
+    /**
+     * stopAction API
+     */
+    feature: 'stop-action';
+    [k: string]: unknown;
+}
+export interface StartResource {
+    /**
+     * startResource API
+     */
+    feature: 'start-resource';
+    [k: string]: unknown;
+}
+export interface StopResource {
+    /**
+     * stopResource API
+     */
+    feature: 'stop-resource';
     [k: string]: unknown;
 }
 export interface AddViewLoadingTime {

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -52,6 +52,50 @@
           "const": "add-duration-vital"
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "title": "StartAction",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "startAction API",
+          "const": "start-action"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "StopAction",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "stopAction API",
+          "const": "stop-action"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "StartResource",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "startResource API",
+          "const": "start-resource"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "StopResource",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "stopResource API",
+          "const": "stop-resource"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds start-action, stop-action, start-resource, stop-resource to browser SDK telemetry. 

After merging [start stop Action API](https://github.com/DataDog/browser-sdk/pull/4038/changes#diff-f16464c555cdc03f7a8b03f1b312bb09ea41cd1acf4fa773629e880a5a1ea72bR175-R184)
Used [here](https://github.com/DataDog/browser-sdk/pull/4110/changes#diff-f16464c555cdc03f7a8b03f1b312bb09ea41cd1acf4fa773629e880a5a1ea72bR737-R753) for actions

And [start stop Resource API](https://github.com/DataDog/browser-sdk/pull/4110/changes#diff-f16464c555cdc03f7a8b03f1b312bb09ea41cd1acf4fa773629e880a5a1ea72bR197-R210)
Used [here](https://github.com/DataDog/browser-sdk/pull/4110/changes#diff-f16464c555cdc03f7a8b03f1b312bb09ea41cd1acf4fa773629e880a5a1ea72bR737-R754) for resources

We can now do:
`addTelemetryUsage({ feature: 'start-resource' })`
`addTelemetryUsage({ feature: 'stop-resource' })`
`addTelemetryUsage({ feature: 'start-action' })`
`addTelemetryUsage({ feature: 'stop-action' })`