### PR TITLE
allow additional properties on @synthetics

### DIFF
--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -244,6 +244,7 @@
       "type": "object",
       "description": "Synthetics properties",
       "required": ["test_id", "result_id"],
+      "additionalProperties": true,
       "properties": {
         "test_id": {
           "type": "string",


### PR DESCRIPTION
Be explicit that we accept additional properties for `@synthetics`. This doesn't change anything in practice since we are accepting additional properties in most places by default.