### PR TITLE
Add make count field required for crash, long_task, frozen_frame

### DIFF
--- a/schemas/rum/_view-properties.json
+++ b/schemas/rum/_view-properties.json
@@ -209,6 +209,7 @@
         "crash": {
           "type": "object",
           "description": "Properties of the crashes of the view",
+          "required": ["count"],
           "properties": {
             "count": {
               "type": "integer",
@@ -222,6 +223,7 @@
         "long_task": {
           "type": "object",
           "description": "Properties of the long tasks of the view",
+          "required": ["count"],
           "properties": {
             "count": {
               "type": "integer",
@@ -235,6 +237,7 @@
         "frozen_frame": {
           "type": "object",
           "description": "Properties of the frozen frames of the view",
+          "required": ["count"],
           "properties": {
             "count": {
               "type": "integer",


### PR DESCRIPTION
I think we need to return it back to how it was before https://github.com/DataDog/rum-events-format/blob/20f414a59bac7af17845bd5d5724cfe2c62be6e4/schemas/rum/view-schema.json#L245

This pr will be merged into https://github.com/DataDog/rum-events-format/pull/355.