### PR TITLE
Add content_type to resource schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -736,6 +736,10 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
+         * Content type of the resource
+         */
+        readonly content_type?: string;
+        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -736,6 +736,10 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
+         * Content type of the resource
+         */
+        readonly content_type?: string;
+        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/samples/rum-events/resource-graphql.json
+++ b/samples/rum-events/resource-graphql.json
@@ -28,6 +28,7 @@
     "render_blocking_status": "non-blocking",
     "protocol": "HTTP/1.1",
     "delivery_type": "cache",
+    "content_type": "application/json",
     "graphql": {
       "operationType": "query",
       "operationName": "GetUserProfile",

--- a/samples/rum-events/resource.json
+++ b/samples/rum-events/resource.json
@@ -40,6 +40,7 @@
     },
     "protocol": "HTTP/1.1",
     "delivery_type": "cache",
+    "content_type": "application/json",
     "request": {
       "encoded_body_size": 512,
       "decoded_body_size": 1024,

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -244,6 +244,11 @@
               "enum": ["cache", "navigational-prefetch", "other"],
               "readOnly": true
             },
+            "content_type": {
+              "type": "string",
+              "description": "Content type of the resource",
+              "readOnly": true
+            },
             "provider": {
               "type": "object",
               "description": "The provider for this resource",


### PR DESCRIPTION
Add `content_type` to resource schema so we can collect the new `PerformanceResourceTiming.contentType` field.