### PR TITLE
feat(rum): add tab.id to common schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1242,6 +1242,16 @@ export interface CommonProperties {
         [k: string]: unknown;
     };
     /**
+     * Tab properties
+     */
+    readonly tab?: {
+        /**
+         * UUID of the browser tab
+         */
+        readonly id: string;
+        [k: string]: unknown;
+    };
+    /**
      * Device connectivity properties
      */
     connectivity?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1242,6 +1242,16 @@ export interface CommonProperties {
         [k: string]: unknown;
     };
     /**
+     * Tab properties
+     */
+    readonly tab?: {
+        /**
+         * UUID of the browser tab
+         */
+        readonly id: string;
+        [k: string]: unknown;
+    };
+    /**
      * Device connectivity properties
      */
     connectivity?: {

--- a/samples/rum-events/view-with-tab.json
+++ b/samples/rum-events/view-with-tab.json
@@ -1,0 +1,33 @@
+{
+  "type": "view",
+  "date": 1591283924940,
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599",
+    "type": "user"
+  },
+  "source": "browser",
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
+    "url": "https://app.datadoghq.com/rum/explorer",
+    "time_spent": 245512755000,
+    "action": {
+      "count": 0
+    },
+    "error": {
+      "count": 0
+    },
+    "resource": {
+      "count": 3
+    }
+  },
+  "tab": {
+    "id": "b7e2a1f4-3c8d-4e5f-9a0b-1d2e3f4a5b6c"
+  },
+  "_dd": {
+    "document_version": 1,
+    "format_version": 2
+  }
+}

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -176,7 +176,6 @@
       "type": "object",
       "description": "Tab properties",
       "required": ["id"],
-      "additionalProperties": true,
       "properties": {
         "id": {
           "type": "string",

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -174,7 +174,7 @@
     },
     "tab": {
       "type": "object",
-      "description": "Browser tab properties",
+      "description": "Tab properties",
       "required": ["id"],
       "additionalProperties": true,
       "properties": {

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -172,6 +172,21 @@
       },
       "readOnly": true
     },
+    "tab": {
+      "type": "object",
+      "description": "Browser tab properties",
+      "required": ["id"],
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the browser tab",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
     "connectivity": {
       "type": "object",
       "description": "Device connectivity properties",


### PR DESCRIPTION
## Motivation

The Browser SDK shares session state across tabs via cookies/localStorage, but has no way to identify which specific tab produced a given event. Adding `tab.id` enables distinguishing events from different tabs within the same session, enabling tab-level correlation between RUM and Logs.

Reference: [browser-sdk#4184](https://github.com/DataDog/browser-sdk/pull/4184)

## Changes

- Add optional `tab` object with required `id` (UUID) to `_common-schema.json`, at the top level alongside `usr`, `account`, `connectivity`, etc.
- Regenerate TypeScript definitions
- Add `samples/rum-events/view-with-tab.json` as a sample event exercising the new field

## Schema

```json
"tab": {
  "type": "object",
  "description": "Tab properties",
  "required": ["id"],
  "additionalProperties": true,
  "properties": {
    "id": {
      "type": "string",
      "description": "UUID of the browser tab",
      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
      "readOnly": true
    }
  },
  "readOnly": true
}
```

## Notes

- `tab` is optional at the top level — only browser emits it; existing non-browser events remain valid
- `id` is required when `tab` is present (consistent with `account`)
- `additionalProperties: true` for future enrichment (consistent with `usr` and `account`)