### PR TITLE
Enforce lower-kebab-case for resource http headers

### DIFF
--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -301,6 +301,9 @@
                 "headers": {
                   "type": "object",
                   "description": "HTTP headers of the resource request",
+                  "propertyNames": {
+                    "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+                  },
                   "additionalProperties": {
                     "type": "string"
                   },
@@ -316,6 +319,9 @@
                 "headers": {
                   "type": "object",
                   "description": "HTTP headers of the resource response",
+                  "propertyNames": {
+                    "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+                  },
                   "additionalProperties": {
                     "type": "string"
                   },


### PR DESCRIPTION
# Summary

Add a propertyNames constraint to both request.headers and response.headers in the resource schema, ensuring all header keys follow lowercase kebab-case format (e.g. content-type, x-request-id).

# Motivation

HTTP header names collected in RUM resource events should be normalized to lowercase kebab-case for consistency. This schema-level validation prevents ingestion of headers with mixed casing (e.g. Content-Type) or non-standard separators (e.g. x_request_id), ensuring uniform keys across all resource events.

# Changes

- `schemas/rum/resource-schema.json`: Added propertyNames.pattern set to ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ on the headers object in both resource.request and resource.response.