### PR TITLE
[PANA-6072] update action schema to contain new field `composed_path_selector`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -132,6 +132,10 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly selector?: string;
                 /**
+                 * Selector data based on the click event composed path
+                 */
+                readonly composed_path_selector?: string;
+                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -132,6 +132,10 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly selector?: string;
                 /**
+                 * Selector data based on the click event composed path
+                 */
+                readonly composed_path_selector?: string;
+                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -180,6 +180,11 @@
                       "description": "CSS selector path of the target element",
                       "readOnly": true
                     },
+                    "composed_path_selector": {
+                      "type": "string",
+                      "description": "Selector data based on the click event composed path",
+                      "readOnly": true
+                    },
                     "width": {
                       "type": "integer",
                       "description": "Width of the target element (in pixels)",


### PR DESCRIPTION
This updates action schema to add new field `composed_path_selector` under `_dd.action.target.composed_path_selector` path.

required for [this PR](https://github.com/DataDog/browser-sdk/pull/4211)