### PR TITLE
🔧 enable ajv strict mode and fix view schema type declaration

### DIFF
--- a/schemas/rum/view-schema.json
+++ b/schemas/rum/view-schema.json
@@ -27,6 +27,7 @@
           "readOnly": true
         },
         "view": {
+          "type": "object",
           "required": ["time_spent", "action", "error", "resource"],
           "properties": {
             "time_spent": { "type": "integer" },

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -90,15 +90,26 @@ function validateSchemasIds() {
 
 function validateSamples() {
   const ajv = new Ajv({
+    strict: true,
     // By default, ajv objects to heterogeneous tuples; the reasoning is that
     // they are awkward to work with in some languages. Disable this warning
     // since we're using this feature extensively and are aware of the tradeoffs.
     strictTuples: false,
+    allowUnionTypes: true,
   })
   forEachFile(SCHEMAS_DIRECTORY, (schemaPath) => ajv.addSchema(readJson(schemaPath)))
   forEachFile(SAMPLES_DIRECTORY, (samplePath) => {
     const schemaId = computeSchemaIdFromSamplePath(samplePath)
-    const valid = ajv.validate(schemaId, readJson(samplePath))
+    let valid
+    try {
+      valid = ajv.validate(schemaId, readJson(samplePath))
+    } catch (error) {
+      console.log(`❌ ${samplePath} had a validation error against ${schemaId}:`)
+      console.log(`   - ${error.message}`)
+      process.exitCode = 1
+      return
+    }
+
     if (valid) {
       console.log(`✅ ${samplePath}`)
     } else {


### PR DESCRIPTION
## Motivation

Previously, ajv was logging strict mode issues to the console but `validate.mjs`
was not returning a non-zero exit code, so CI would pass silently despite schema
problems. This PR makes the script fail properly when schema issues are detected.

## Changes

- Enable `strict: true` in Ajv so schema issues throw instead of just logging
- Add `allowUnionTypes: true` to allow the union types used intentionally
  across our schemas
- Wrap `ajv.validate()` in a try/catch so thrown errors are reported cleanly
  and set a non-zero exit code
- Add `"type": "object"` to the `view` property in view-schema.json, which
  strict mode requires