### PR TITLE
Support Vitals array instead of a single value for Mobile profiles

### DIFF
--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -37,20 +37,6 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly label: string[];
         [k: string]: unknown;
     };
-    /**
-     * Vital properties.
-     */
-    readonly vital?: {
-        /**
-         * Array of vital IDs.
-         */
-        readonly id: string[];
-        /**
-         * Array of vital labels.
-         */
-        readonly label: string[];
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
@@ -99,6 +85,20 @@ export interface ProfileCommonProperties {
          * Array of long task IDs.
          */
         readonly id: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital?: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/mobileProfiling.d.ts
+++ b/lib/cjs/generated/mobileProfiling.d.ts
@@ -4,19 +4,7 @@
 /**
  * Schema of the Mobile SDK Profile Event metadata.
  */
-export type MobileProfileEvent = ProfileCommonProperties & {
-    /**
-     * The RUM Vital this profile event is associated with.
-     */
-    readonly vital: {
-        /**
-         * Unique identifier of RUM Vital in the UUID format.
-         */
-        readonly id: string;
-        [k: string]: unknown;
-    };
-    [k: string]: unknown;
-};
+export type MobileProfileEvent = ProfileCommonProperties;
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */
@@ -63,6 +51,20 @@ export interface ProfileCommonProperties {
          * Array of long task IDs.
          */
         readonly id: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital?: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
         [k: string]: unknown;
     };
     /**

--- a/lib/cjs/generated/profiling.d.ts
+++ b/lib/cjs/generated/profiling.d.ts
@@ -37,38 +37,12 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly label: string[];
         [k: string]: unknown;
     };
-    /**
-     * Vital properties.
-     */
-    readonly vital?: {
-        /**
-         * Array of vital IDs.
-         */
-        readonly id: string[];
-        /**
-         * Array of vital labels.
-         */
-        readonly label: string[];
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
  * Mobile SDK profiling event.
  */
-export type MobileProfileEvent = ProfileCommonProperties & {
-    /**
-     * The RUM Vital this profile event is associated with.
-     */
-    readonly vital: {
-        /**
-         * Unique identifier of RUM Vital in the UUID format.
-         */
-        readonly id: string;
-        [k: string]: unknown;
-    };
-    [k: string]: unknown;
-};
+export type MobileProfileEvent = ProfileCommonProperties;
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */
@@ -115,6 +89,20 @@ export interface ProfileCommonProperties {
          * Array of long task IDs.
          */
         readonly id: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital?: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -37,20 +37,6 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly label: string[];
         [k: string]: unknown;
     };
-    /**
-     * Vital properties.
-     */
-    readonly vital?: {
-        /**
-         * Array of vital IDs.
-         */
-        readonly id: string[];
-        /**
-         * Array of vital labels.
-         */
-        readonly label: string[];
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
@@ -99,6 +85,20 @@ export interface ProfileCommonProperties {
          * Array of long task IDs.
          */
         readonly id: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital?: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/mobileProfiling.d.ts
+++ b/lib/esm/generated/mobileProfiling.d.ts
@@ -4,19 +4,7 @@
 /**
  * Schema of the Mobile SDK Profile Event metadata.
  */
-export type MobileProfileEvent = ProfileCommonProperties & {
-    /**
-     * The RUM Vital this profile event is associated with.
-     */
-    readonly vital: {
-        /**
-         * Unique identifier of RUM Vital in the UUID format.
-         */
-        readonly id: string;
-        [k: string]: unknown;
-    };
-    [k: string]: unknown;
-};
+export type MobileProfileEvent = ProfileCommonProperties;
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */
@@ -63,6 +51,20 @@ export interface ProfileCommonProperties {
          * Array of long task IDs.
          */
         readonly id: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital?: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
         [k: string]: unknown;
     };
     /**

--- a/lib/esm/generated/profiling.d.ts
+++ b/lib/esm/generated/profiling.d.ts
@@ -37,38 +37,12 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
         readonly label: string[];
         [k: string]: unknown;
     };
-    /**
-     * Vital properties.
-     */
-    readonly vital?: {
-        /**
-         * Array of vital IDs.
-         */
-        readonly id: string[];
-        /**
-         * Array of vital labels.
-         */
-        readonly label: string[];
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
  * Mobile SDK profiling event.
  */
-export type MobileProfileEvent = ProfileCommonProperties & {
-    /**
-     * The RUM Vital this profile event is associated with.
-     */
-    readonly vital: {
-        /**
-         * Unique identifier of RUM Vital in the UUID format.
-         */
-        readonly id: string;
-        [k: string]: unknown;
-    };
-    [k: string]: unknown;
-};
+export type MobileProfileEvent = ProfileCommonProperties;
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */
@@ -115,6 +89,20 @@ export interface ProfileCommonProperties {
          * Array of long task IDs.
          */
         readonly id: string[];
+        [k: string]: unknown;
+    };
+    /**
+     * Vital properties.
+     */
+    readonly vital?: {
+        /**
+         * Array of vital IDs.
+         */
+        readonly id: string[];
+        /**
+         * Array of vital labels.
+         */
+        readonly label: string[];
         [k: string]: unknown;
     };
     /**

--- a/samples/profiling/mobile/profile-event/profile-event.json
+++ b/samples/profiling/mobile/profile-event/profile-event.json
@@ -13,7 +13,8 @@
     "id": ["0e6071e2-e4ae-4605-8dfe-9f3551a172f9", "c40f0593-ae2c-416f-8abb-4d3ec4b68e2e"]
   },
   "vital": {
-    "id": "b3f8c1a2-9d4e-4f5a-8b7c-2e1d3f4a5b6c"
+    "id": ["b3f8c1a2-9d4e-4f5a-8b7c-2e1d3f4a5b6c"],
+    "label": ["time_to_initial_display"]
   },
   "attachments": ["wall-time.json"],
   "start": "2025-12-02T13:32:04.886Z",

--- a/schemas/profiling/_common-schema.json
+++ b/schemas/profiling/_common-schema.json
@@ -72,6 +72,30 @@
       },
       "readOnly": true
     },
+    "vital": {
+      "type": "object",
+      "description": "Vital properties.",
+      "required": ["id", "label"],
+      "properties": {
+        "id": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of vital IDs.",
+          "readOnly": true
+        },
+        "label": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of vital labels.",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
     "attachments": {
       "type": "array",
       "items": {

--- a/schemas/profiling/browser/profile-event-schema.json
+++ b/schemas/profiling/browser/profile-event-schema.json
@@ -54,30 +54,6 @@
             }
           },
           "readOnly": true
-        },
-        "vital": {
-          "type": "object",
-          "description": "Vital properties.",
-          "required": ["id", "label"],
-          "properties": {
-            "id": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Array of vital IDs.",
-              "readOnly": true
-            },
-            "label": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Array of vital labels.",
-              "readOnly": true
-            }
-          },
-          "readOnly": true
         }
       }
     }

--- a/schemas/profiling/mobile/profile-event-schema.json
+++ b/schemas/profiling/mobile/profile-event-schema.json
@@ -6,25 +6,6 @@
   "allOf": [
     {
       "$ref": "../_common-schema.json"
-    },
-    {
-      "type": "object",
-      "required": ["vital"],
-      "properties": {
-        "vital": {
-          "type": "object",
-          "description": "The RUM Vital this profile event is associated with.",
-          "readOnly": true,
-          "properties": {
-            "id": {
-              "type": "string",
-              "description": "Unique identifier of RUM Vital in the UUID format.",
-              "readOnly": true
-            }
-          },
-          "required": ["id"]
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
Mobile profiles schema was describing a single value for Vital, but now with Feature Operations support + continuous profiling we can have multiple vitals belonging to the same profile.

`mobile/profile-event-schema.json` is now empty, all the properties are inherited from `_common-schema.json`, but let's keep a separate file for the future still.

This is a backward-compatible change, because Profiling Backend supports both a single value and array-type property.