### PR TITLE
✨[RUM-15126] Allow updates of `error.handling_stack`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -282,7 +282,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
         /**
          * Handling call stack
          */
-        readonly handling_stack?: string;
+        handling_stack?: string;
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -282,7 +282,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
         /**
          * Handling call stack
          */
-        readonly handling_stack?: string;
+        handling_stack?: string;
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -113,7 +113,7 @@
             "handling_stack": {
               "type": "string",
               "description": "Handling call stack",
-              "readOnly": true
+              "readOnly": false
             },
             "source_type": {
               "type": "string",


### PR DESCRIPTION
# Motivation

Similarly to RUM errors `error.stack` attribute, allow `error.handling_stack` to be updated by customers before being sent. 

# Changes

Remove `readonly` on `error.handling_stack`.