### PR TITLE
RUM-15207: Add profiling schema to vital and error events

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -455,6 +455,16 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     readonly feature_flags?: {
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -1029,6 +1039,16 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
         readonly description?: string;
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -1091,16 +1111,6 @@ export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
          * If the app launch had a saved instance state bundle.
          */
         readonly has_saved_instance_state_bundle?: boolean;
-        [k: string]: unknown;
-    };
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-        /**
-         * Profiling context
-         */
-        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -455,6 +455,16 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     readonly feature_flags?: {
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -1029,6 +1039,16 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
         readonly description?: string;
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -1091,16 +1111,6 @@ export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
          * If the app launch had a saved instance state bundle.
          */
         readonly has_saved_instance_state_bundle?: boolean;
-        [k: string]: unknown;
-    };
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-        /**
-         * Profiling context
-         */
-        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/schemas/rum/_vital-common-schema.json
+++ b/schemas/rum/_vital-common-schema.json
@@ -43,6 +43,18 @@
             }
           },
           "readOnly": true
+        },
+        "_dd": {
+          "type": "object",
+          "description": "Internal properties",
+          "properties": {
+            "profiling": {
+              "type": "object",
+              "description": "Profiling context",
+              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
+            }
+          },
+          "readOnly": true
         }
       }
     }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -369,6 +369,18 @@
           "description": "Feature flags properties",
           "additionalProperties": true,
           "readOnly": true
+        },
+        "_dd": {
+          "type": "object",
+          "description": "Internal properties",
+          "properties": {
+            "profiling": {
+              "type": "object",
+              "description": "Profiling context",
+              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
+            }
+          },
+          "readOnly": true
         }
       }
     }

--- a/schemas/rum/vital-app-launch-schema.json
+++ b/schemas/rum/vital-app-launch-schema.json
@@ -50,19 +50,6 @@
             }
           },
           "readOnly": true
-        },
-
-        "_dd": {
-          "type": "object",
-          "description": "Internal properties",
-          "properties": {
-            "profiling": {
-              "type": "object",
-              "description": "Profiling context",
-              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
-            }
-          },
-          "readOnly": true
         }
       }
     }


### PR DESCRIPTION
This PR attaches the [profiling schema](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/_profiling-internal-context-schema.json) to:
- [All vital events](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/_vital-common-schema.json)
- [RUM error events](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/error-schema.json)