### PR TITLE
[RUM-11993] Add trace context and graphql fields to error event schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -800,7 +800,13 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
     /**
      * Internal properties
      */
-    readonly _dd?: RumTrace;
+    readonly _dd?: RumTrace & {
+        /**
+         * Whether the resource should be discarded or indexed
+         */
+        readonly discarded?: boolean;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -463,7 +463,13 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     /**
      * Internal properties
      */
-    readonly _dd?: RumTrace;
+    readonly _dd?: RumTrace & {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -965,6 +971,16 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
         readonly description?: string;
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -1027,16 +1043,6 @@ export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
          * If the app launch had a saved instance state bundle.
          */
         readonly has_saved_instance_state_bundle?: boolean;
-        [k: string]: unknown;
-    };
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-        /**
-         * Profiling context
-         */
-        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -325,64 +325,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
                 readonly type?: 'ad' | 'advertising' | 'analytics' | 'cdn' | 'content' | 'customer-success' | 'first party' | 'hosting' | 'marketing' | 'other' | 'social' | 'tag-manager' | 'utility' | 'video';
                 [k: string]: unknown;
             };
-            /**
-             * GraphQL requests parameters
-             */
-            readonly graphql?: {
-                /**
-                 * Type of the GraphQL operation
-                 */
-                readonly operationType?: 'query' | 'mutation' | 'subscription';
-                /**
-                 * Name of the GraphQL operation
-                 */
-                readonly operationName?: string;
-                /**
-                 * Content of the GraphQL operation
-                 */
-                payload?: string;
-                /**
-                 * String representation of the operation variables
-                 */
-                variables?: string;
-                /**
-                 * Number of GraphQL errors in the response
-                 */
-                readonly error_count?: number;
-                /**
-                 * Array of GraphQL errors from the response
-                 */
-                readonly errors?: {
-                    /**
-                     * Error message
-                     */
-                    readonly message: string;
-                    /**
-                     * Error code (used by some providers)
-                     */
-                    readonly code?: string;
-                    /**
-                     * Array of error locations in the GraphQL query
-                     */
-                    readonly locations?: {
-                        /**
-                         * Line number where the error occurred
-                         */
-                        readonly line: number;
-                        /**
-                         * Column number where the error occurred
-                         */
-                        readonly column: number;
-                        [k: string]: unknown;
-                    }[];
-                    /**
-                     * Path to the field that caused the error
-                     */
-                    readonly path?: (string | number)[];
-                    [k: string]: unknown;
-                }[];
-                [k: string]: unknown;
-            };
+            readonly graphql?: RumGraphql;
             [k: string]: unknown;
         };
         /**
@@ -520,25 +463,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     /**
      * Internal properties
      */
-    readonly _dd?: {
-        /**
-         * span identifier in decimal format
-         */
-        readonly span_id?: string;
-        /**
-         * parent span identifier in decimal format
-         */
-        readonly parent_span_id?: string;
-        /**
-         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
-         */
-        readonly trace_id?: string;
-        /**
-         * trace sample rate in decimal format
-         */
-        readonly rule_psr?: number;
-        [k: string]: unknown;
-    };
+    readonly _dd?: RumTrace;
     [k: string]: unknown;
 };
 /**
@@ -869,92 +794,13 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             };
             [k: string]: unknown;
         };
-        /**
-         * GraphQL requests parameters
-         */
-        readonly graphql?: {
-            /**
-             * Type of the GraphQL operation
-             */
-            readonly operationType?: 'query' | 'mutation' | 'subscription';
-            /**
-             * Name of the GraphQL operation
-             */
-            readonly operationName?: string;
-            /**
-             * Content of the GraphQL operation
-             */
-            payload?: string;
-            /**
-             * String representation of the operation variables
-             */
-            variables?: string;
-            /**
-             * Number of GraphQL errors in the response
-             */
-            readonly error_count?: number;
-            /**
-             * Array of GraphQL errors from the response
-             */
-            readonly errors?: {
-                /**
-                 * Error message
-                 */
-                readonly message: string;
-                /**
-                 * Error code (used by some providers)
-                 */
-                readonly code?: string;
-                /**
-                 * Array of error locations in the GraphQL query
-                 */
-                readonly locations?: {
-                    /**
-                     * Line number where the error occurred
-                     */
-                    readonly line: number;
-                    /**
-                     * Column number where the error occurred
-                     */
-                    readonly column: number;
-                    [k: string]: unknown;
-                }[];
-                /**
-                 * Path to the field that caused the error
-                 */
-                readonly path?: (string | number)[];
-                [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-        };
+        readonly graphql?: RumGraphql;
         [k: string]: unknown;
     };
     /**
      * Internal properties
      */
-    readonly _dd?: {
-        /**
-         * span identifier in decimal format
-         */
-        readonly span_id?: string;
-        /**
-         * parent span identifier in decimal format
-         */
-        readonly parent_span_id?: string;
-        /**
-         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
-         */
-        readonly trace_id?: string;
-        /**
-         * trace sample rate in decimal format
-         */
-        readonly rule_psr?: number;
-        /**
-         * Whether the resource should be discarded or indexed
-         */
-        readonly discarded?: boolean;
-        [k: string]: unknown;
-    };
+    readonly _dd?: RumTrace;
     [k: string]: unknown;
 };
 /**
@@ -1587,6 +1433,86 @@ export interface ActionChildProperties {
         readonly id: string | string[];
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/**
+ * GraphQL request parameters
+ */
+export interface RumGraphql {
+    /**
+     * Type of the GraphQL operation
+     */
+    readonly operationType?: 'query' | 'mutation' | 'subscription';
+    /**
+     * Name of the GraphQL operation
+     */
+    readonly operationName?: string;
+    /**
+     * Content of the GraphQL operation
+     */
+    payload?: string;
+    /**
+     * String representation of the operation variables
+     */
+    variables?: string;
+    /**
+     * Number of GraphQL errors in the response
+     */
+    readonly error_count?: number;
+    /**
+     * Array of GraphQL errors from the response
+     */
+    readonly errors?: {
+        /**
+         * Error message
+         */
+        readonly message: string;
+        /**
+         * Error code (used by some providers)
+         */
+        readonly code?: string;
+        /**
+         * Array of error locations in the GraphQL query
+         */
+        readonly locations?: {
+            /**
+             * Line number where the error occurred
+             */
+            readonly line: number;
+            /**
+             * Column number where the error occurred
+             */
+            readonly column: number;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Path to the field that caused the error
+         */
+        readonly path?: (string | number)[];
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/**
+ * Trace context properties
+ */
+export interface RumTrace {
+    /**
+     * span identifier in decimal format
+     */
+    readonly span_id?: string;
+    /**
+     * parent span identifier in decimal format
+     */
+    readonly parent_span_id?: string;
+    /**
+     * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
+     */
+    readonly trace_id?: string;
+    /**
+     * trace sample rate in decimal format
+     */
+    readonly rule_psr?: number;
     [k: string]: unknown;
 }
 /**

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -325,6 +325,64 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
                 readonly type?: 'ad' | 'advertising' | 'analytics' | 'cdn' | 'content' | 'customer-success' | 'first party' | 'hosting' | 'marketing' | 'other' | 'social' | 'tag-manager' | 'utility' | 'video';
                 [k: string]: unknown;
             };
+            /**
+             * GraphQL requests parameters
+             */
+            readonly graphql?: {
+                /**
+                 * Type of the GraphQL operation
+                 */
+                readonly operationType?: 'query' | 'mutation' | 'subscription';
+                /**
+                 * Name of the GraphQL operation
+                 */
+                readonly operationName?: string;
+                /**
+                 * Content of the GraphQL operation
+                 */
+                payload?: string;
+                /**
+                 * String representation of the operation variables
+                 */
+                variables?: string;
+                /**
+                 * Number of GraphQL errors in the response
+                 */
+                readonly error_count?: number;
+                /**
+                 * Array of GraphQL errors from the response
+                 */
+                readonly errors?: {
+                    /**
+                     * Error message
+                     */
+                    readonly message: string;
+                    /**
+                     * Error code (used by some providers)
+                     */
+                    readonly code?: string;
+                    /**
+                     * Array of error locations in the GraphQL query
+                     */
+                    readonly locations?: {
+                        /**
+                         * Line number where the error occurred
+                         */
+                        readonly line: number;
+                        /**
+                         * Column number where the error occurred
+                         */
+                        readonly column: number;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Path to the field that caused the error
+                     */
+                    readonly path?: (string | number)[];
+                    [k: string]: unknown;
+                }[];
+                [k: string]: unknown;
+            };
             [k: string]: unknown;
         };
         /**
@@ -464,9 +522,21 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
      */
     readonly _dd?: {
         /**
-         * Profiling context
+         * span identifier in decimal format
          */
-        profiling?: ProfilingInternalContextSchema;
+        readonly span_id?: string;
+        /**
+         * parent span identifier in decimal format
+         */
+        readonly parent_span_id?: string;
+        /**
+         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
+         */
+        readonly trace_id?: string;
+        /**
+         * trace sample rate in decimal format
+         */
+        readonly rule_psr?: number;
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -1043,16 +1113,6 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
         readonly description?: string;
         [k: string]: unknown;
     };
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-        /**
-         * Profiling context
-         */
-        profiling?: ProfilingInternalContextSchema;
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
@@ -1115,6 +1175,16 @@ export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
          * If the app launch had a saved instance state bundle.
          */
         readonly has_saved_instance_state_bundle?: boolean;
+        [k: string]: unknown;
+    };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -800,7 +800,13 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
     /**
      * Internal properties
      */
-    readonly _dd?: RumTrace;
+    readonly _dd?: RumTrace & {
+        /**
+         * Whether the resource should be discarded or indexed
+         */
+        readonly discarded?: boolean;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -463,7 +463,13 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     /**
      * Internal properties
      */
-    readonly _dd?: RumTrace;
+    readonly _dd?: RumTrace & {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -965,6 +971,16 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
         readonly description?: string;
         [k: string]: unknown;
     };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 /**
@@ -1027,16 +1043,6 @@ export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
          * If the app launch had a saved instance state bundle.
          */
         readonly has_saved_instance_state_bundle?: boolean;
-        [k: string]: unknown;
-    };
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-        /**
-         * Profiling context
-         */
-        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -325,64 +325,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
                 readonly type?: 'ad' | 'advertising' | 'analytics' | 'cdn' | 'content' | 'customer-success' | 'first party' | 'hosting' | 'marketing' | 'other' | 'social' | 'tag-manager' | 'utility' | 'video';
                 [k: string]: unknown;
             };
-            /**
-             * GraphQL requests parameters
-             */
-            readonly graphql?: {
-                /**
-                 * Type of the GraphQL operation
-                 */
-                readonly operationType?: 'query' | 'mutation' | 'subscription';
-                /**
-                 * Name of the GraphQL operation
-                 */
-                readonly operationName?: string;
-                /**
-                 * Content of the GraphQL operation
-                 */
-                payload?: string;
-                /**
-                 * String representation of the operation variables
-                 */
-                variables?: string;
-                /**
-                 * Number of GraphQL errors in the response
-                 */
-                readonly error_count?: number;
-                /**
-                 * Array of GraphQL errors from the response
-                 */
-                readonly errors?: {
-                    /**
-                     * Error message
-                     */
-                    readonly message: string;
-                    /**
-                     * Error code (used by some providers)
-                     */
-                    readonly code?: string;
-                    /**
-                     * Array of error locations in the GraphQL query
-                     */
-                    readonly locations?: {
-                        /**
-                         * Line number where the error occurred
-                         */
-                        readonly line: number;
-                        /**
-                         * Column number where the error occurred
-                         */
-                        readonly column: number;
-                        [k: string]: unknown;
-                    }[];
-                    /**
-                     * Path to the field that caused the error
-                     */
-                    readonly path?: (string | number)[];
-                    [k: string]: unknown;
-                }[];
-                [k: string]: unknown;
-            };
+            readonly graphql?: RumGraphql;
             [k: string]: unknown;
         };
         /**
@@ -520,25 +463,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     /**
      * Internal properties
      */
-    readonly _dd?: {
-        /**
-         * span identifier in decimal format
-         */
-        readonly span_id?: string;
-        /**
-         * parent span identifier in decimal format
-         */
-        readonly parent_span_id?: string;
-        /**
-         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
-         */
-        readonly trace_id?: string;
-        /**
-         * trace sample rate in decimal format
-         */
-        readonly rule_psr?: number;
-        [k: string]: unknown;
-    };
+    readonly _dd?: RumTrace;
     [k: string]: unknown;
 };
 /**
@@ -869,92 +794,13 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             };
             [k: string]: unknown;
         };
-        /**
-         * GraphQL requests parameters
-         */
-        readonly graphql?: {
-            /**
-             * Type of the GraphQL operation
-             */
-            readonly operationType?: 'query' | 'mutation' | 'subscription';
-            /**
-             * Name of the GraphQL operation
-             */
-            readonly operationName?: string;
-            /**
-             * Content of the GraphQL operation
-             */
-            payload?: string;
-            /**
-             * String representation of the operation variables
-             */
-            variables?: string;
-            /**
-             * Number of GraphQL errors in the response
-             */
-            readonly error_count?: number;
-            /**
-             * Array of GraphQL errors from the response
-             */
-            readonly errors?: {
-                /**
-                 * Error message
-                 */
-                readonly message: string;
-                /**
-                 * Error code (used by some providers)
-                 */
-                readonly code?: string;
-                /**
-                 * Array of error locations in the GraphQL query
-                 */
-                readonly locations?: {
-                    /**
-                     * Line number where the error occurred
-                     */
-                    readonly line: number;
-                    /**
-                     * Column number where the error occurred
-                     */
-                    readonly column: number;
-                    [k: string]: unknown;
-                }[];
-                /**
-                 * Path to the field that caused the error
-                 */
-                readonly path?: (string | number)[];
-                [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-        };
+        readonly graphql?: RumGraphql;
         [k: string]: unknown;
     };
     /**
      * Internal properties
      */
-    readonly _dd?: {
-        /**
-         * span identifier in decimal format
-         */
-        readonly span_id?: string;
-        /**
-         * parent span identifier in decimal format
-         */
-        readonly parent_span_id?: string;
-        /**
-         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
-         */
-        readonly trace_id?: string;
-        /**
-         * trace sample rate in decimal format
-         */
-        readonly rule_psr?: number;
-        /**
-         * Whether the resource should be discarded or indexed
-         */
-        readonly discarded?: boolean;
-        [k: string]: unknown;
-    };
+    readonly _dd?: RumTrace;
     [k: string]: unknown;
 };
 /**
@@ -1587,6 +1433,86 @@ export interface ActionChildProperties {
         readonly id: string | string[];
         [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/**
+ * GraphQL request parameters
+ */
+export interface RumGraphql {
+    /**
+     * Type of the GraphQL operation
+     */
+    readonly operationType?: 'query' | 'mutation' | 'subscription';
+    /**
+     * Name of the GraphQL operation
+     */
+    readonly operationName?: string;
+    /**
+     * Content of the GraphQL operation
+     */
+    payload?: string;
+    /**
+     * String representation of the operation variables
+     */
+    variables?: string;
+    /**
+     * Number of GraphQL errors in the response
+     */
+    readonly error_count?: number;
+    /**
+     * Array of GraphQL errors from the response
+     */
+    readonly errors?: {
+        /**
+         * Error message
+         */
+        readonly message: string;
+        /**
+         * Error code (used by some providers)
+         */
+        readonly code?: string;
+        /**
+         * Array of error locations in the GraphQL query
+         */
+        readonly locations?: {
+            /**
+             * Line number where the error occurred
+             */
+            readonly line: number;
+            /**
+             * Column number where the error occurred
+             */
+            readonly column: number;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Path to the field that caused the error
+         */
+        readonly path?: (string | number)[];
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/**
+ * Trace context properties
+ */
+export interface RumTrace {
+    /**
+     * span identifier in decimal format
+     */
+    readonly span_id?: string;
+    /**
+     * parent span identifier in decimal format
+     */
+    readonly parent_span_id?: string;
+    /**
+     * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
+     */
+    readonly trace_id?: string;
+    /**
+     * trace sample rate in decimal format
+     */
+    readonly rule_psr?: number;
     [k: string]: unknown;
 }
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -325,6 +325,64 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
                 readonly type?: 'ad' | 'advertising' | 'analytics' | 'cdn' | 'content' | 'customer-success' | 'first party' | 'hosting' | 'marketing' | 'other' | 'social' | 'tag-manager' | 'utility' | 'video';
                 [k: string]: unknown;
             };
+            /**
+             * GraphQL requests parameters
+             */
+            readonly graphql?: {
+                /**
+                 * Type of the GraphQL operation
+                 */
+                readonly operationType?: 'query' | 'mutation' | 'subscription';
+                /**
+                 * Name of the GraphQL operation
+                 */
+                readonly operationName?: string;
+                /**
+                 * Content of the GraphQL operation
+                 */
+                payload?: string;
+                /**
+                 * String representation of the operation variables
+                 */
+                variables?: string;
+                /**
+                 * Number of GraphQL errors in the response
+                 */
+                readonly error_count?: number;
+                /**
+                 * Array of GraphQL errors from the response
+                 */
+                readonly errors?: {
+                    /**
+                     * Error message
+                     */
+                    readonly message: string;
+                    /**
+                     * Error code (used by some providers)
+                     */
+                    readonly code?: string;
+                    /**
+                     * Array of error locations in the GraphQL query
+                     */
+                    readonly locations?: {
+                        /**
+                         * Line number where the error occurred
+                         */
+                        readonly line: number;
+                        /**
+                         * Column number where the error occurred
+                         */
+                        readonly column: number;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Path to the field that caused the error
+                     */
+                    readonly path?: (string | number)[];
+                    [k: string]: unknown;
+                }[];
+                [k: string]: unknown;
+            };
             [k: string]: unknown;
         };
         /**
@@ -464,9 +522,21 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
      */
     readonly _dd?: {
         /**
-         * Profiling context
+         * span identifier in decimal format
          */
-        profiling?: ProfilingInternalContextSchema;
+        readonly span_id?: string;
+        /**
+         * parent span identifier in decimal format
+         */
+        readonly parent_span_id?: string;
+        /**
+         * trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
+         */
+        readonly trace_id?: string;
+        /**
+         * trace sample rate in decimal format
+         */
+        readonly rule_psr?: number;
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -1043,16 +1113,6 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
         readonly description?: string;
         [k: string]: unknown;
     };
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-        /**
-         * Profiling context
-         */
-        profiling?: ProfilingInternalContextSchema;
-        [k: string]: unknown;
-    };
     [k: string]: unknown;
 };
 /**
@@ -1115,6 +1175,16 @@ export type RumVitalAppLaunchEvent = RumVitalEventCommonProperties & {
          * If the app launch had a saved instance state bundle.
          */
         readonly has_saved_instance_state_bundle?: boolean;
+        [k: string]: unknown;
+    };
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+        /**
+         * Profiling context
+         */
+        profiling?: ProfilingInternalContextSchema;
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/schemas/rum/_graphql-schema.json
+++ b/schemas/rum/_graphql-schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_graphql-schema.json",
+  "title": "RumGraphql",
+  "type": "object",
+  "description": "GraphQL request parameters",
+  "properties": {
+    "operationType": {
+      "type": "string",
+      "description": "Type of the GraphQL operation",
+      "enum": ["query", "mutation", "subscription"],
+      "readOnly": true
+    },
+    "operationName": {
+      "type": "string",
+      "description": "Name of the GraphQL operation",
+      "readOnly": true
+    },
+    "payload": {
+      "type": "string",
+      "description": "Content of the GraphQL operation",
+      "readOnly": false
+    },
+    "variables": {
+      "type": "string",
+      "description": "String representation of the operation variables",
+      "readOnly": false
+    },
+    "error_count": {
+      "type": "integer",
+      "description": "Number of GraphQL errors in the response",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "errors": {
+      "type": "array",
+      "description": "Array of GraphQL errors from the response",
+      "items": {
+        "type": "object",
+        "description": "GraphQL error details",
+        "required": ["message"],
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Error message",
+            "readOnly": true
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code (used by some providers)",
+            "readOnly": true
+          },
+          "locations": {
+            "type": "array",
+            "description": "Array of error locations in the GraphQL query",
+            "items": {
+              "type": "object",
+              "description": "Error location",
+              "required": ["line", "column"],
+              "properties": {
+                "line": {
+                  "type": "integer",
+                  "description": "Line number where the error occurred",
+                  "minimum": 1,
+                  "readOnly": true
+                },
+                "column": {
+                  "type": "integer",
+                  "description": "Column number where the error occurred",
+                  "minimum": 1,
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            },
+            "readOnly": true
+          },
+          "path": {
+            "type": "array",
+            "description": "Path to the field that caused the error",
+            "items": {
+              "oneOf": [{ "type": "string" }, { "type": "integer" }]
+            },
+            "readOnly": true
+          }
+        },
+        "readOnly": true
+      },
+      "readOnly": true
+    }
+  },
+  "readOnly": true
+}

--- a/schemas/rum/_trace-schema.json
+++ b/schemas/rum/_trace-schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_trace-schema.json",
+  "title": "RumTrace",
+  "type": "object",
+  "description": "Trace context properties",
+  "properties": {
+    "span_id": {
+      "type": "string",
+      "description": "span identifier in decimal format",
+      "pattern": "^[0-9]+$",
+      "readOnly": true
+    },
+    "parent_span_id": {
+      "type": "string",
+      "description": "parent span identifier in decimal format",
+      "pattern": "^[0-9]+$",
+      "readOnly": true
+    },
+    "trace_id": {
+      "type": "string",
+      "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
+      "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
+      "readOnly": true
+    },
+    "rule_psr": {
+      "type": "number",
+      "description": "trace sample rate in decimal format",
+      "minimum": 0,
+      "maximum": 1,
+      "readOnly": true
+    }
+  },
+  "readOnly": true
+}

--- a/schemas/rum/_trace-schema.json
+++ b/schemas/rum/_trace-schema.json
@@ -20,7 +20,7 @@
     "trace_id": {
       "type": "string",
       "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
-      "pattern": "^[0-9]{1,20}$|^[0-9a-fA-F]{32}$",
+      "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
       "readOnly": true
     },
     "rule_psr": {

--- a/schemas/rum/_trace-schema.json
+++ b/schemas/rum/_trace-schema.json
@@ -20,7 +20,7 @@
     "trace_id": {
       "type": "string",
       "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
-      "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
+      "pattern": "^[0-9]{1,20}$|^[0-9a-fA-F]{32}$",
       "readOnly": true
     },
     "rule_psr": {

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -195,93 +195,7 @@
                   "readOnly": true
                 },
                 "graphql": {
-                  "type": "object",
-                  "description": "GraphQL requests parameters",
-                  "properties": {
-                    "operationType": {
-                      "type": "string",
-                      "description": "Type of the GraphQL operation",
-                      "enum": ["query", "mutation", "subscription"],
-                      "readOnly": true
-                    },
-                    "operationName": {
-                      "type": "string",
-                      "description": "Name of the GraphQL operation",
-                      "readOnly": true
-                    },
-                    "payload": {
-                      "type": "string",
-                      "description": "Content of the GraphQL operation",
-                      "readOnly": false
-                    },
-                    "variables": {
-                      "type": "string",
-                      "description": "String representation of the operation variables",
-                      "readOnly": false
-                    },
-                    "error_count": {
-                      "type": "integer",
-                      "description": "Number of GraphQL errors in the response",
-                      "minimum": 0,
-                      "readOnly": true
-                    },
-                    "errors": {
-                      "type": "array",
-                      "description": "Array of GraphQL errors from the response",
-                      "items": {
-                        "type": "object",
-                        "description": "GraphQL error details",
-                        "required": ["message"],
-                        "properties": {
-                          "message": {
-                            "type": "string",
-                            "description": "Error message",
-                            "readOnly": true
-                          },
-                          "code": {
-                            "type": "string",
-                            "description": "Error code (used by some providers)",
-                            "readOnly": true
-                          },
-                          "locations": {
-                            "type": "array",
-                            "description": "Array of error locations in the GraphQL query",
-                            "items": {
-                              "type": "object",
-                              "description": "Error location",
-                              "required": ["line", "column"],
-                              "properties": {
-                                "line": {
-                                  "type": "integer",
-                                  "description": "Line number where the error occurred",
-                                  "minimum": 1,
-                                  "readOnly": true
-                                },
-                                "column": {
-                                  "type": "integer",
-                                  "description": "Column number where the error occurred",
-                                  "minimum": 1,
-                                  "readOnly": true
-                                }
-                              },
-                              "readOnly": true
-                            },
-                            "readOnly": true
-                          },
-                          "path": {
-                            "type": "array",
-                            "description": "Path to the field that caused the error",
-                            "items": {
-                              "oneOf": [{ "type": "string" }, { "type": "integer" }]
-                            },
-                            "readOnly": true
-                          }
-                        },
-                        "readOnly": true
-                      },
-                      "readOnly": true
-                    }
-                  },
+                  "allOf": [{ "$ref": "_graphql-schema.json" }],
                   "readOnly": true
                 }
               },
@@ -463,38 +377,18 @@
         "_dd": {
           "type": "object",
           "description": "Internal properties",
-          "properties": {
-            "profiling": {
-              "type": "object",
-              "description": "Profiling context",
-              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
-            },
-            "span_id": {
-              "type": "string",
-              "description": "span identifier in decimal format",
-              "pattern": "^[0-9]+$",
-              "readOnly": true
-            },
-            "parent_span_id": {
-              "type": "string",
-              "description": "parent span identifier in decimal format",
-              "pattern": "^[0-9]+$",
-              "readOnly": true
-            },
-            "trace_id": {
-              "type": "string",
-              "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
-              "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
-              "readOnly": true
-            },
-            "rule_psr": {
-              "type": "number",
-              "description": "trace sample rate in decimal format",
-              "minimum": 0,
-              "maximum": 1,
-              "readOnly": true
+          "allOf": [
+            { "$ref": "_trace-schema.json" },
+            {
+              "properties": {
+                "profiling": {
+                  "type": "object",
+                  "description": "Profiling context",
+                  "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
+                }
+              }
             }
-          },
+          ],
           "readOnly": true
         }
       }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -193,6 +193,96 @@
                     }
                   },
                   "readOnly": true
+                },
+                "graphql": {
+                  "type": "object",
+                  "description": "GraphQL requests parameters",
+                  "properties": {
+                    "operationType": {
+                      "type": "string",
+                      "description": "Type of the GraphQL operation",
+                      "enum": ["query", "mutation", "subscription"],
+                      "readOnly": true
+                    },
+                    "operationName": {
+                      "type": "string",
+                      "description": "Name of the GraphQL operation",
+                      "readOnly": true
+                    },
+                    "payload": {
+                      "type": "string",
+                      "description": "Content of the GraphQL operation",
+                      "readOnly": false
+                    },
+                    "variables": {
+                      "type": "string",
+                      "description": "String representation of the operation variables",
+                      "readOnly": false
+                    },
+                    "error_count": {
+                      "type": "integer",
+                      "description": "Number of GraphQL errors in the response",
+                      "minimum": 0,
+                      "readOnly": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of GraphQL errors from the response",
+                      "items": {
+                        "type": "object",
+                        "description": "GraphQL error details",
+                        "required": ["message"],
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "Error message",
+                            "readOnly": true
+                          },
+                          "code": {
+                            "type": "string",
+                            "description": "Error code (used by some providers)",
+                            "readOnly": true
+                          },
+                          "locations": {
+                            "type": "array",
+                            "description": "Array of error locations in the GraphQL query",
+                            "items": {
+                              "type": "object",
+                              "description": "Error location",
+                              "required": ["line", "column"],
+                              "properties": {
+                                "line": {
+                                  "type": "integer",
+                                  "description": "Line number where the error occurred",
+                                  "minimum": 1,
+                                  "readOnly": true
+                                },
+                                "column": {
+                                  "type": "integer",
+                                  "description": "Column number where the error occurred",
+                                  "minimum": 1,
+                                  "readOnly": true
+                                }
+                              },
+                              "readOnly": true
+                            },
+                            "readOnly": true
+                          },
+                          "path": {
+                            "type": "array",
+                            "description": "Path to the field that caused the error",
+                            "items": {
+                              "oneOf": [{ "type": "string" }, { "type": "integer" }]
+                            },
+                            "readOnly": true
+                          }
+                        },
+                        "readOnly": true
+                      },
+                      "readOnly": true
+                    }
+                  },
+                  "readOnly": true
                 }
               },
               "readOnly": true
@@ -378,6 +468,31 @@
               "type": "object",
               "description": "Profiling context",
               "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
+            },
+            "span_id": {
+              "type": "string",
+              "description": "span identifier in decimal format",
+              "pattern": "^[0-9]+$",
+              "readOnly": true
+            },
+            "parent_span_id": {
+              "type": "string",
+              "description": "parent span identifier in decimal format",
+              "pattern": "^[0-9]+$",
+              "readOnly": true
+            },
+            "trace_id": {
+              "type": "string",
+              "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
+              "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
+              "readOnly": true
+            },
+            "rule_psr": {
+              "type": "number",
+              "description": "trace sample rate in decimal format",
+              "minimum": 0,
+              "maximum": 1,
+              "readOnly": true
             }
           },
           "readOnly": true

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -340,14 +340,18 @@
         "_dd": {
           "type": "object",
           "description": "Internal properties",
-          "allOf": [{ "$ref": "_trace-schema.json" }],
-          "properties": {
-            "discarded": {
-              "type": "boolean",
-              "description": "Whether the resource should be discarded or indexed",
-              "readOnly": true
+          "allOf": [
+            { "$ref": "_trace-schema.json" },
+            {
+              "properties": {
+                "discarded": {
+                  "type": "boolean",
+                  "description": "Whether the resource should be discarded or indexed",
+                  "readOnly": true
+                }
+              }
             }
-          },
+          ],
           "readOnly": true
         }
       }

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -331,100 +331,7 @@
               "readOnly": true
             },
             "graphql": {
-              "type": "object",
-              "description": "GraphQL requests parameters",
-              "properties": {
-                "operationType": {
-                  "type": "string",
-                  "description": "Type of the GraphQL operation",
-                  "enum": ["query", "mutation", "subscription"],
-                  "readOnly": true
-                },
-                "operationName": {
-                  "type": "string",
-                  "description": "Name of the GraphQL operation",
-                  "readOnly": true
-                },
-                "payload": {
-                  "type": "string",
-                  "description": "Content of the GraphQL operation",
-                  "readOnly": false
-                },
-                "variables": {
-                  "type": "string",
-                  "description": "String representation of the operation variables",
-                  "readOnly": false
-                },
-                "error_count": {
-                  "type": "integer",
-                  "description": "Number of GraphQL errors in the response",
-                  "minimum": 0,
-                  "readOnly": true
-                },
-                "errors": {
-                  "type": "array",
-                  "description": "Array of GraphQL errors from the response",
-                  "items": {
-                    "type": "object",
-                    "description": "GraphQL error details",
-                    "required": ["message"],
-                    "properties": {
-                      "message": {
-                        "type": "string",
-                        "description": "Error message",
-                        "readOnly": true
-                      },
-                      "code": {
-                        "type": "string",
-                        "description": "Error code (used by some providers)",
-                        "readOnly": true
-                      },
-                      "locations": {
-                        "type": "array",
-                        "description": "Array of error locations in the GraphQL query",
-                        "items": {
-                          "type": "object",
-                          "description": "Error location",
-                          "required": ["line", "column"],
-                          "properties": {
-                            "line": {
-                              "type": "integer",
-                              "description": "Line number where the error occurred",
-                              "minimum": 1,
-                              "readOnly": true
-                            },
-                            "column": {
-                              "type": "integer",
-                              "description": "Column number where the error occurred",
-                              "minimum": 1,
-                              "readOnly": true
-                            }
-                          },
-                          "readOnly": true
-                        },
-                        "readOnly": true
-                      },
-                      "path": {
-                        "type": "array",
-                        "description": "Path to the field that caused the error",
-                        "items": {
-                          "oneOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "integer"
-                            }
-                          ]
-                        },
-                        "readOnly": true
-                      }
-                    },
-                    "readOnly": true
-                  },
-                  "readOnly": true
-                }
-              },
+              "allOf": [{ "$ref": "_graphql-schema.json" }],
               "readOnly": true
             }
           },
@@ -433,32 +340,8 @@
         "_dd": {
           "type": "object",
           "description": "Internal properties",
+          "allOf": [{ "$ref": "_trace-schema.json" }],
           "properties": {
-            "span_id": {
-              "type": "string",
-              "description": "span identifier in decimal format",
-              "pattern": "^[0-9]+$",
-              "readOnly": true
-            },
-            "parent_span_id": {
-              "type": "string",
-              "description": "parent span identifier in decimal format",
-              "pattern": "^[0-9]+$",
-              "readOnly": true
-            },
-            "trace_id": {
-              "type": "string",
-              "description": "trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s",
-              "pattern": "^[0-9]{1,20}|[0-9a-fA-F]{32}$",
-              "readOnly": true
-            },
-            "rule_psr": {
-              "type": "number",
-              "description": "trace sample rate in decimal format",
-              "minimum": 0,
-              "maximum": 1,
-              "readOnly": true
-            },
             "discarded": {
               "type": "boolean",
               "description": "Whether the resource should be discarded or indexed",

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -24,6 +24,7 @@ function validateSchemasObjectsPropertiesCase() {
     [`${SCHEMAS_DIRECTORY}/session-replay/browser/segment-metadata-schema.json`, ['creation_reason']],
     [`${SCHEMAS_DIRECTORY}/session-replay/common/focus-record-schema.json`, ['has_focus']],
     [`${SCHEMAS_DIRECTORY}/rum/resource-schema.json`, ['operationType', 'operationName']],
+    [`${SCHEMAS_DIRECTORY}/rum/error-schema.json`, ['operationType', 'operationName']],
     [`${SCHEMAS_DIRECTORY}/profiling/_common-schema.json`, ['long_task', 'tags_profiler']],
     [`${SCHEMAS_DIRECTORY}/profiling/browser/profile-event-schema.json`, ['_dd', 'clock_drift']],
   ])

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -23,8 +23,7 @@ function validateSchemasObjectsPropertiesCase() {
     ],
     [`${SCHEMAS_DIRECTORY}/session-replay/browser/segment-metadata-schema.json`, ['creation_reason']],
     [`${SCHEMAS_DIRECTORY}/session-replay/common/focus-record-schema.json`, ['has_focus']],
-    [`${SCHEMAS_DIRECTORY}/rum/resource-schema.json`, ['operationType', 'operationName']],
-    [`${SCHEMAS_DIRECTORY}/rum/error-schema.json`, ['operationType', 'operationName']],
+    [`${SCHEMAS_DIRECTORY}/rum/_graphql-schema.json`, ['operationType', 'operationName']],
     [`${SCHEMAS_DIRECTORY}/profiling/_common-schema.json`, ['long_task', 'tags_profiler']],
     [`${SCHEMAS_DIRECTORY}/profiling/browser/profile-event-schema.json`, ['_dd', 'clock_drift']],
   ])


### PR DESCRIPTION
 # Motivation    
  When a network resource fails (timeout, no connectivity), the SDK emits a 'RUMErrorEvent'                                                                                                                                                                                   
  Currently the error event schema has no trace context fields ('trace_id', 'span_id', 'parent_span_id', 'rule_psr')
  and no 'graphql' struct on 'error.resource', unlike the success path ('RUMResourceEvent') which already has both.                                                                                                                                                            
                                                                                                                                                                                                                                                                               
  This means cross-platform SDKs (React Native, Flutter) silently lose trace and GraphQL attributes on the error path.                                                                                                                                                         
                                                                                                                                                                                                                                                                               
  # Changes                                                                                                                                                                                                                                                                                  
  - Added trace context fields ('trace_id', 'span_id', 'parent_span_id', 'rule_psr') to '_dd' in the error event schema, mirroring 'RUMResourceEvent._dd'                                                                                                                      
  - Added 'graphql' struct to 'error.resource', mirroring 'RUMResourceEvent.resource.graphql'
  - Added 'error-schema.json' to the casing exceptions in 'scripts/validate.mjs' (same as 'resource-schema.json', since GraphQL field names follow camelCase convention)   