### PR TITLE
fix: make frustration.count required in view-properties schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1793,7 +1793,7 @@ export interface ViewProperties {
             /**
              * Number of frustrations that occurred on the view
              */
-            readonly count?: number;
+            readonly count: number;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1793,7 +1793,7 @@ export interface ViewProperties {
             /**
              * Number of frustrations that occurred on the view
              */
-            readonly count?: number;
+            readonly count: number;
             [k: string]: unknown;
         };
         /**

--- a/schemas/rum/_view-properties-schema.json
+++ b/schemas/rum/_view-properties-schema.json
@@ -290,6 +290,7 @@
         "frustration": {
           "type": "object",
           "description": "Properties of the frustrations of the view",
+          "required": ["count"],
           "properties": {
             "count": {
               "type": "integer",


### PR DESCRIPTION
## Summary

- Add `"required": ["count"]` to the `frustration` object in `schemas/rum/_view-properties-schema.json`, making it consistent with the sibling `resource` object which already had it.
- Regenerate `lib/cjs/generated/rum.d.ts` and `lib/esm/generated/rum.d.ts`: `ViewProperties.frustration.count` is now `number` (non-optional) instead of `number | undefined`.

## Context

PR #355 extracted all optional view-specific fields into the shared `_view-properties-schema.json` with "no `required` fields at any level". In doing so, `frustration.count` lost the `required` constraint it had on the original `view-schema.json`, causing SDK consumers (e.g. Android) to receive a nullable/optional type for a field that was previously always present. This was an unintended breaking change for typed SDKs relying on `frustration.count` being always present.

The fix is a one-line schema change matching the pattern already used by `resource.count`.

## Test plan

- [ ] `yarn validate` — all samples pass
- [ ] `yarn generate` — `ViewProperties.frustration.count` regenerated as non-optional
- [ ] `yarn build` — CJS + ESM compile cleanly