### PR TITLE
fix: wrong inp subpart name

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -2031,7 +2031,7 @@ export interface ViewPerformanceData {
             /**
              * Event handler execution time
              */
-            readonly processing_time: number;
+            readonly processing_duration: number;
             /**
              * Rendering time happening after processing
              */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -2031,7 +2031,7 @@ export interface ViewPerformanceData {
             /**
              * Event handler execution time
              */
-            readonly processing_time: number;
+            readonly processing_duration: number;
             /**
              * Rendering time happening after processing
              */

--- a/schemas/rum/_view-performance-schema.json
+++ b/schemas/rum/_view-performance-schema.json
@@ -112,7 +112,7 @@
         "sub_parts": {
           "type": "object",
           "description": "Sub-parts of the INP",
-          "required": ["input_delay", "processing_time", "presentation_delay"],
+          "required": ["input_delay", "processing_duration", "presentation_delay"],
           "properties": {
             "input_delay": {
               "type": "integer",
@@ -120,7 +120,7 @@
               "minimum": 0,
               "readOnly": true
             },
-            "processing_time": {
+            "processing_duration": {
               "type": "integer",
               "description": "Event handler execution time",
               "minimum": 0,


### PR DESCRIPTION
We wrongly put `processing_time` instead of `processing_duration` in the INP subpart.
This PR fixes it