### PR TITLE
[RUM-15273] Add telemetry for trackResourceHeaders

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -462,6 +462,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             propagate_trace_baggage?: boolean;
             /**
+             * How the SDK tracks resource request/response headers
+             */
+            use_track_resource_headers?: 'default_headers' | 'custom';
+            /**
              * Whether the beta encode cookie options is enabled
              */
             beta_encode_cookie_options?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -462,6 +462,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             propagate_trace_baggage?: boolean;
             /**
+             * How the SDK tracks resource request/response headers
+             */
+            use_track_resource_headers?: 'default_headers' | 'custom';
+            /**
              * Whether the beta encode cookie options is enabled
              */
             beta_encode_cookie_options?: boolean;

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -38,6 +38,7 @@
       "silent_multiple_init": false,
       "track_session_across_subdomains": true,
       "track_resources": true,
+      "use_track_resource_headers": "default_headers",
       "track_long_task": true,
       "track_bfcache_views": true,
       "use_cross_site_session_cookie": false,

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -515,6 +515,12 @@
                   "description": "Whether trace baggage is propagated to child spans",
                   "readOnly": false
                 },
+                "use_track_resource_headers": {
+                  "type": "string",
+                  "description": "How the SDK tracks resource request/response headers",
+                  "enum": ["default_headers", "custom"],
+                  "readOnly": false
+                },
                 "beta_encode_cookie_options": {
                   "type": "boolean",
                   "description": "Whether the beta encode cookie options is enabled",


### PR DESCRIPTION
## Summary

Add optional `use_track_resource_headers` to the telemetry **configuration** event schema (`telemetry/configuration-schema.json`).

- **Type:** string enum: `default_headers` | `custom`
- **Semantics (Browser RUM SDK):**
  - Omitted when `trackResourceHeaders` is `undefined` or `false`
  - `default_headers` when the option is `true` (built-in default header set)
  - `custom` when the option is an array (including empty arrays)

No header names, URLs, or patterns are sent — only how the option was set at init.

## Test plan

- [x] `yarn validate` passes
- [x] `yarn generate` produces updated types
- [x] `yarn format` reports no issues
