### PR TITLE
RUM-13951 Add track_resource_headers to telemetry configuration schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -316,6 +316,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_network_requests?: boolean;
             /**
+             * Whether and how HTTP resource header capture is configured: 'default' uses a predefined set of headers, 'custom' uses a user-provided list of header names. Absent when disabled.
+             */
+            track_resource_headers?: 'default' | 'custom';
+            /**
              * Whether tracing features are enabled
              */
             use_tracing?: boolean;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -316,9 +316,9 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_network_requests?: boolean;
             /**
-             * Whether and how HTTP resource header capture is configured: 'default' uses a predefined set of headers, 'custom' uses a user-provided list of header names. Absent when disabled.
+             * Whether HTTP resource header capture is enabled
              */
-            track_resource_headers?: 'default' | 'custom';
+            track_resource_headers?: boolean;
             /**
              * Whether tracing features are enabled
              */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -316,6 +316,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_network_requests?: boolean;
             /**
+             * Whether and how HTTP resource header capture is configured: 'default' uses a predefined set of headers, 'custom' uses a user-provided list of header names. Absent when disabled.
+             */
+            track_resource_headers?: 'default' | 'custom';
+            /**
              * Whether tracing features are enabled
              */
             use_tracing?: boolean;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -316,9 +316,9 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             track_network_requests?: boolean;
             /**
-             * Whether and how HTTP resource header capture is configured: 'default' uses a predefined set of headers, 'custom' uses a user-provided list of header names. Absent when disabled.
+             * Whether HTTP resource header capture is enabled
              */
-            track_resource_headers?: 'default' | 'custom';
+            track_resource_headers?: boolean;
             /**
              * Whether tracing features are enabled
              */

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -85,7 +85,7 @@
         "vital"
       ],
       "remote_configuration_id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c",
-      "track_resource_headers": "default"
+      "track_resource_headers": true
     }
   }
 }

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -19,7 +19,9 @@
   "action": {
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
   },
-  "experimental_features": ["foo"],
+  "experimental_features": [
+    "foo"
+  ],
   "telemetry": {
     "type": "configuration",
     "configuration": {
@@ -59,7 +61,10 @@
       "track_views_manually": true,
       "track_interactions": true,
       "track_user_interactions": true,
-      "forward_console_logs": ["log", "debug"],
+      "forward_console_logs": [
+        "log",
+        "debug"
+      ],
       "forward_errors_to_logs": false,
       "forward_reports": "all",
       "view_tracking_strategy": "ActivityViewTrackingStrategy",
@@ -74,8 +79,13 @@
           "option_foo": "bar"
         }
       ],
-      "track_feature_flags_for_events": ["long_task", "resource", "vital"],
-      "remote_configuration_id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+      "track_feature_flags_for_events": [
+        "long_task",
+        "resource",
+        "vital"
+      ],
+      "remote_configuration_id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c",
+      "track_resource_headers": "default"
     }
   }
 }

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -332,6 +332,12 @@
                   "description": "Whether automatic collection of network requests is enabled",
                   "readOnly": false
                 },
+                "track_resource_headers": {
+                  "type": "string",
+                  "enum": ["default", "custom"],
+                  "description": "Whether and how HTTP resource header capture is configured: 'default' uses a predefined set of headers, 'custom' uses a user-provided list of header names. Absent when disabled.",
+                  "readOnly": false
+                },
                 "use_tracing": {
                   "type": "boolean",
                   "description": "Whether tracing features are enabled"

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -333,9 +333,8 @@
                   "readOnly": false
                 },
                 "track_resource_headers": {
-                  "type": "string",
-                  "enum": ["default", "custom"],
-                  "description": "Whether and how HTTP resource header capture is configured: 'default' uses a predefined set of headers, 'custom' uses a user-provided list of header names. Absent when disabled.",
+                  "type": "boolean",
+                  "description": "Whether HTTP resource header capture is enabled",
                   "readOnly": false
                 },
                 "use_tracing": {


### PR DESCRIPTION
### What and why?

Adds `track_resource_headers` (boolean) to the telemetry configuration schema to measure adoption of the HTTP header capture feature in the iOS SDK (RUM-13951). Reports `true` when header capture is enabled, absent when disabled.