### PR TITLE
Add error property in mobile profiling schema

### DIFF
--- a/lib/cjs/generated/mobileProfiling.d.ts
+++ b/lib/cjs/generated/mobileProfiling.d.ts
@@ -4,7 +4,19 @@
 /**
  * Schema of the Mobile SDK Profile Event metadata.
  */
-export type MobileProfileEvent = ProfileCommonProperties;
+export type MobileProfileEvent = ProfileCommonProperties & {
+    /**
+     * Error properties.
+     */
+    readonly error?: {
+        /**
+         * Array of error IDs.
+         */
+        readonly id: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */

--- a/lib/cjs/generated/profiling.d.ts
+++ b/lib/cjs/generated/profiling.d.ts
@@ -42,7 +42,19 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
 /**
  * Mobile SDK profiling event.
  */
-export type MobileProfileEvent = ProfileCommonProperties;
+export type MobileProfileEvent = ProfileCommonProperties & {
+    /**
+     * Error properties.
+     */
+    readonly error?: {
+        /**
+         * Array of error IDs.
+         */
+        readonly id: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */

--- a/lib/esm/generated/mobileProfiling.d.ts
+++ b/lib/esm/generated/mobileProfiling.d.ts
@@ -4,7 +4,19 @@
 /**
  * Schema of the Mobile SDK Profile Event metadata.
  */
-export type MobileProfileEvent = ProfileCommonProperties;
+export type MobileProfileEvent = ProfileCommonProperties & {
+    /**
+     * Error properties.
+     */
+    readonly error?: {
+        /**
+         * Array of error IDs.
+         */
+        readonly id: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */

--- a/lib/esm/generated/profiling.d.ts
+++ b/lib/esm/generated/profiling.d.ts
@@ -42,7 +42,19 @@ export type BrowserProfileEvent = ProfileCommonProperties & {
 /**
  * Mobile SDK profiling event.
  */
-export type MobileProfileEvent = ProfileCommonProperties;
+export type MobileProfileEvent = ProfileCommonProperties & {
+    /**
+     * Error properties.
+     */
+    readonly error?: {
+        /**
+         * Array of error IDs.
+         */
+        readonly id: string[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+};
 /**
  * Schema of a Profile Event metadata. Contains attributes shared by all profiles.
  */

--- a/samples/profiling/mobile/profile-event/profile-event.json
+++ b/samples/profiling/mobile/profile-event/profile-event.json
@@ -12,6 +12,9 @@
   "long_task": {
     "id": ["0e6071e2-e4ae-4605-8dfe-9f3551a172f9", "c40f0593-ae2c-416f-8abb-4d3ec4b68e2e"]
   },
+  "error": {
+    "id": ["d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a", "7b3368a8-7f8d-4c3d-b0f6-bb81b5b3adc0"]
+  },
   "vital": {
     "id": ["b3f8c1a2-9d4e-4f5a-8b7c-2e1d3f4a5b6c"],
     "label": ["time_to_initial_display"]

--- a/schemas/profiling/mobile/profile-event-schema.json
+++ b/schemas/profiling/mobile/profile-event-schema.json
@@ -6,6 +6,27 @@
   "allOf": [
     {
       "$ref": "../_common-schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "object",
+          "description": "Error properties.",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of error IDs.",
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds error property in mobile profiling schema which allows ANR errors to be attached with profiling event.