### PR TITLE
[Android only] RUM-15682: Adding legacy okhttp option

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -930,6 +930,6 @@ export interface AndroidNetworkInstrumentation {
     /**
      * The network instrumentation API used
      */
-    type: 'CRONET' | 'OKHTTP';
+    type: 'CRONET' | 'OKHTTP' | 'LEGACY_OKHTTP';
     [k: string]: unknown;
 }

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -930,6 +930,6 @@ export interface AndroidNetworkInstrumentation {
     /**
      * The network instrumentation API used
      */
-    type: 'CRONET' | 'OKHTTP';
+    type: 'CRONET' | 'OKHTTP' | 'LEGACY_OKHTTP';
     [k: string]: unknown;
 }

--- a/schemas/telemetry/usage/mobile-features-schema.json
+++ b/schemas/telemetry/usage/mobile-features-schema.json
@@ -28,7 +28,7 @@
         "type": {
           "type": "string",
           "description": "The network instrumentation API used",
-          "enum": ["CRONET", "OKHTTP"]
+          "enum": ["CRONET", "OKHTTP", "LEGACY_OKHTTP"]
         }
       }
     }


### PR DESCRIPTION
Adding `LEGACY_OKHTTP` field for networking api usage telemetry on android.

We are migrating to the new infrastructure for the network instrumentation. 
This telemetry would help us to see the adoption rate between old (LEGACY_OKHTTP) and new (OKHTTP) infrastructure and CRONET

