### PR TITLE
✨ Add websocket resource type

### DIFF
--- a/samples/rum-events/resource-websocket-close.json
+++ b/samples/rum-events/resource-websocket-close.json
@@ -1,0 +1,44 @@
+{
+  "type": "resource",
+  "date": 1591284475328,
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599",
+    "type": "user"
+  },
+  "source": "browser",
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
+    "referrer": "",
+    "url": "https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view"
+  },
+  "resource": {
+    "id": "b83a5d82-cdd1-468d-9bc9-3aa9e54d957a",
+    "type": "websocket",
+    "url": "wss://stream.datadoghq.com/ws",
+    "duration": 300000000000,
+    "websocket": {
+      "id": "d94f7c12-1a2b-4e3f-8c5d-6e7f8a9b0c1d",
+      "type": "close",
+      "message_count": {
+        "sent": 42,
+        "received": 156
+      },
+      "bytes_sent": 8432,
+      "bytes_received": 245760,
+      "close_code": 1000,
+      "close_reason": "Normal closure",
+      "was_clean": true,
+      "was_opened": true,
+      "connection_duration": 300000000000
+    }
+  },
+  "action": {
+    "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+  },
+  "_dd": {
+    "format_version": 2
+  }
+}

--- a/samples/rum-events/resource-websocket-open.json
+++ b/samples/rum-events/resource-websocket-open.json
@@ -1,0 +1,33 @@
+{
+  "type": "resource",
+  "date": 1591284175328,
+  "application": {
+    "id": "ac8218cf-498b-4d33-bd44-151095959547"
+  },
+  "session": {
+    "id": "cacbf45c-3a05-48ce-b066-d76349460599",
+    "type": "user"
+  },
+  "source": "browser",
+  "view": {
+    "id": "623d50fd-75cf-4025-97d2-e51ff94171f6",
+    "referrer": "",
+    "url": "https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view"
+  },
+  "resource": {
+    "id": "b83a5d82-cdd1-468d-9bc9-3aa9e54d957a",
+    "type": "websocket",
+    "url": "wss://stream.datadoghq.com/ws",
+    "duration": 85000000,
+    "websocket": {
+      "id": "d94f7c12-1a2b-4e3f-8c5d-6e7f8a9b0c1d",
+      "type": "open"
+    }
+  },
+  "action": {
+    "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d953c"
+  },
+  "_dd": {
+    "format_version": 2
+  }
+}

--- a/schemas/rum/_websocket-schema.json
+++ b/schemas/rum/_websocket-schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_websocket-schema.json",
+  "title": "RumWebsocket",
+  "type": "object",
+  "description": "WebSocket connection properties",
+  "required": ["id", "type"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "UUID of the WebSocket connection, shared between open and close events",
+      "readOnly": true
+    },
+    "type": {
+      "type": "string",
+      "description": "Type of WebSocket event",
+      "enum": ["open", "close"],
+      "readOnly": true
+    },
+    "protocol": {
+      "type": "string",
+      "description": "Negotiated WebSocket sub-protocol",
+      "readOnly": true
+    },
+    "message_count": {
+      "type": "object",
+      "description": "Aggregate message counts for the connection",
+      "properties": {
+        "sent": {
+          "type": "integer",
+          "description": "Total messages sent",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "received": {
+          "type": "integer",
+          "description": "Total messages received",
+          "minimum": 0,
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "bytes_sent": {
+      "type": "integer",
+      "description": "Total outgoing bytes",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "bytes_received": {
+      "type": "integer",
+      "description": "Total incoming bytes",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "close_code": {
+      "type": "integer",
+      "description": "WebSocket close code (RFC 6455)",
+      "readOnly": true
+    },
+    "close_reason": {
+      "type": "string",
+      "description": "WebSocket close reason string",
+      "readOnly": true
+    },
+    "was_clean": {
+      "type": "boolean",
+      "description": "Whether the connection closed cleanly",
+      "readOnly": true
+    },
+    "was_opened": {
+      "type": "boolean",
+      "description": "Whether the connection was ever successfully opened",
+      "readOnly": true
+    },
+    "connection_duration": {
+      "type": "integer",
+      "description": "Duration in ns of the WebSocket connection (open to close)",
+      "minimum": 0,
+      "readOnly": true
+    }
+  },
+  "readOnly": true
+}

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -37,7 +37,20 @@
             "type": {
               "type": "string",
               "description": "Resource type",
-              "enum": ["document", "xhr", "beacon", "fetch", "css", "js", "image", "font", "media", "other", "native"],
+              "enum": [
+                "document",
+                "xhr",
+                "beacon",
+                "fetch",
+                "css",
+                "js",
+                "image",
+                "font",
+                "media",
+                "other",
+                "native",
+                "websocket"
+              ],
               "readOnly": true
             },
             "method": {
@@ -332,6 +345,10 @@
             },
             "graphql": {
               "allOf": [{ "$ref": "_graphql-schema.json" }],
+              "readOnly": true
+            },
+            "websocket": {
+              "allOf": [{ "$ref": "_websocket-schema.json" }],
               "readOnly": true
             }
           },


### PR DESCRIPTION
## Context
We're prototyping WebSocket capture on the browser-sdk.

## Summary
- Add `websocket` to the resource type enum in `resource-schema.json`
- Add a new `_websocket-schema.json` sub-schema defining WebSocket connection properties (id, type, protocol, message counts, bytes, close code/reason, etc.)
- Add a `websocket` field reference in the resource schema
- Add sample events for websocket open and close resources