### PR TITLE
🎨 Rename use_track_resource_headers to track_resource_headers

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -783,7 +783,7 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             /**
              * HTTP headers of the resource request
              */
-            readonly headers?: {
+            headers?: {
                 [k: string]: string;
             };
             [k: string]: unknown;
@@ -795,7 +795,7 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             /**
              * HTTP headers of the resource response
              */
-            readonly headers?: {
+            headers?: {
                 [k: string]: string;
             };
             [k: string]: unknown;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -464,7 +464,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * How the SDK tracks resource request/response headers
              */
-            use_track_resource_headers?: 'default_headers' | 'custom';
+            track_resource_headers?: 'default_headers' | 'custom';
             /**
              * Whether the beta encode cookie options is enabled
              */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -783,7 +783,7 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             /**
              * HTTP headers of the resource request
              */
-            readonly headers?: {
+            headers?: {
                 [k: string]: string;
             };
             [k: string]: unknown;
@@ -795,7 +795,7 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
             /**
              * HTTP headers of the resource response
              */
-            readonly headers?: {
+            headers?: {
                 [k: string]: string;
             };
             [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -464,7 +464,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
             /**
              * How the SDK tracks resource request/response headers
              */
-            use_track_resource_headers?: 'default_headers' | 'custom';
+            track_resource_headers?: 'default_headers' | 'custom';
             /**
              * Whether the beta encode cookie options is enabled
              */

--- a/samples/telemetry-events/configuration.json
+++ b/samples/telemetry-events/configuration.json
@@ -38,7 +38,7 @@
       "silent_multiple_init": false,
       "track_session_across_subdomains": true,
       "track_resources": true,
-      "use_track_resource_headers": "default_headers",
+      "track_resource_headers": "default_headers",
       "track_long_task": true,
       "track_bfcache_views": true,
       "use_cross_site_session_cookie": false,

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -307,7 +307,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "readOnly": true
+                  "readOnly": false
                 }
               },
               "readOnly": true
@@ -325,7 +325,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "readOnly": true
+                  "readOnly": false
                 }
               },
               "readOnly": true

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -515,7 +515,7 @@
                   "description": "Whether trace baggage is propagated to child spans",
                   "readOnly": false
                 },
-                "use_track_resource_headers": {
+                "track_resource_headers": {
                   "type": "string",
                   "description": "How the SDK tracks resource request/response headers",
                   "enum": ["default_headers", "custom"],


### PR DESCRIPTION
## Motivation

The `use_` prefix convention in the telemetry configuration schema is reserved for boolean telemetry fields tracking the usage of rich configuration options.

`use_track_resource_headers` is a string enum (`"default_headers" | "custom"`), so it breaks this convention.

## Changes

- Rename `use_track_resource_headers` to `track_resource_headers` in the schema, sample, and generated TS definitions.
- Also mark the `headers` field as writable, since the users are able to override the `headers` object at collection with the `beforeSend` hook in browser-sdk

## Test instructions

- `yarn validate` passes
- `yarn build` passes
- `yarn format -w` passes