### PR TITLE
[Profiler] Add `quota_reason` field to profiling internal context schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1562,6 +1562,19 @@ export interface ProfilingInternalContextSchema {
      * - `unexpected-exception`: An exception occurred when starting the Profiler.
      */
     readonly error_reason?: 'not-supported-by-browser' | 'failed-to-lazy-load' | 'missing-document-policy-header' | 'unexpected-exception';
+    /**
+     * The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+     *
+     * Possible values:
+     * - `quota_ok`: Quota check passed.
+     * - `quota_exceeded`: The organization has exceeded its profiling quota.
+     * - `org_disabled`: The organization has profiling disabled.
+     * - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+     * - `undefined`: The quota reason is undefined.
+     * - `timeout`: The quota check timed out on the client side.
+     * - `api-error`: An API error occurred on the client side.
+     */
+    readonly quota_reason?: 'quota_ok' | 'quota_exceeded' | 'org_disabled' | 'backend_unavailable' | 'undefined' | 'timeout' | 'api-error';
     [k: string]: unknown;
 }
 /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1562,6 +1562,19 @@ export interface ProfilingInternalContextSchema {
      * - `unexpected-exception`: An exception occurred when starting the Profiler.
      */
     readonly error_reason?: 'not-supported-by-browser' | 'failed-to-lazy-load' | 'missing-document-policy-header' | 'unexpected-exception';
+    /**
+     * The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+     *
+     * Possible values:
+     * - `quota_ok`: Quota check passed.
+     * - `quota_exceeded`: The organization has exceeded its profiling quota.
+     * - `org_disabled`: The organization has profiling disabled.
+     * - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+     * - `undefined`: The quota reason is undefined.
+     * - `timeout`: The quota check timed out on the client side.
+     * - `api-error`: An API error occurred on the client side.
+     */
+    readonly quota_reason?: 'quota_ok' | 'quota_exceeded' | 'org_disabled' | 'backend_unavailable' | 'undefined' | 'timeout' | 'api-error';
     [k: string]: unknown;
 }
 /**

--- a/schemas/rum/_profiling-internal-context-schema.json
+++ b/schemas/rum/_profiling-internal-context-schema.json
@@ -21,6 +21,20 @@
         "unexpected-exception"
       ],
       "readOnly": true
+    },
+    "quota_reason": {
+      "type": "string",
+      "description": "The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.\n\nPossible values:\n- `quota_ok`: Quota check passed.\n- `quota_exceeded`: The organization has exceeded its profiling quota.\n- `org_disabled`: The organization has profiling disabled.\n- `backend_unavailable`: The quota admission API is unavailable or not initialized.\n- `undefined`: The quota reason is undefined.\n- `timeout`: The quota check timed out on the client side.\n- `api-error`: An API error occurred on the client side.",
+      "enum": [
+        "quota_ok",
+        "quota_exceeded",
+        "org_disabled",
+        "backend_unavailable",
+        "undefined",
+        "timeout",
+        "api-error"
+      ],
+      "readOnly": true
     }
   }
 }


### PR DESCRIPTION
## Motivation

The browser SDK's profiler stops profiling when the quota admission API denies the session, and tracks the reason via a new `quota_reason` field on the `ProfilingInternalContextSchema`.

Related SDK PR: [DataDog/browser-sdk#4514](https://github.com/DataDog/browser-sdk/pull/4514)  
Ticket: [PROF-13798](https://datadoghq.atlassian.net/browse/PROF-13798)

## Changes

- `schemas/rum/_profiling-internal-context-schema.json`: adds a new `quota_reason` field with 8 possible values matching the SDK's `QuotaReason` type (`quota_ok`, `quota_exceeded`, `org_disabled`, `backend_unavailable`, `undefined`, `timeout`, `api-error`); `error_reason` is unchanged.
- `lib/cjs/generated/rum.d.ts`, `lib/esm/generated/rum.d.ts`: regenerated.

## Follow-up in browser-sdk

Once this PR is merged, `browser-sdk` needs `yarn json-schemas:sync` to pull in the updated types.

[PROF-13798]: https://datadoghq.atlassian.net/browse/PROF-13798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ