### PR TITLE
[RUM 15920] Add .NET MAUI source

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -17,7 +17,7 @@ export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform' | 'maui';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -290,7 +290,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */
-        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku' | 'ndk' | 'ios+il2cpp' | 'ndk+il2cpp' | 'windows' | 'macos' | 'linux';
+        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku' | 'ndk' | 'ios+il2cpp' | 'ndk+il2cpp' | 'windows' | 'macos' | 'linux' | 'maui';
         /**
          * Resource properties of the error
          */
@@ -1110,7 +1110,7 @@ export interface CommonProperties {
     /**
      * The source of this event
      */
-    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp';
+    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
     /**
      * View properties
      */
@@ -1436,7 +1436,7 @@ export interface ViewContainerSchema {
         /**
          * Source of the parent view
          */
-        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp';
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -582,7 +582,7 @@ export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform' | 'maui';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -438,7 +438,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             sdk_version?: string;
             /**
-             * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+             * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
              */
             source?: string;
             /**
@@ -533,7 +533,7 @@ export interface CommonTelemetryProperties {
     /**
      * The source of this event
      */
-    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp';
+    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
     /**
      * The version of the SDK generating the telemetry event
      */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -380,6 +380,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             unity_version?: string;
             /**
+             * The version of MAUI used in a .NET MAUI application
+             */
+            maui_version?: string;
+            /**
              * The threshold used for iOS App Hangs monitoring (in milliseconds)
              */
             app_hang_threshold?: number;

--- a/lib/cjs/src/session-replay-mobile.d.ts
+++ b/lib/cjs/src/session-replay-mobile.d.ts
@@ -6,6 +6,7 @@ export declare const MobileSource: {
     readonly Flutter: "flutter";
     readonly ReactNative: "react-native";
     readonly KotlinMultiplatform: "kotlin-multiplatform";
+    readonly Maui: "maui";
 };
 export type MobileSource = (typeof MobileSource)[keyof typeof MobileSource];
 export declare const RecordType: {

--- a/lib/cjs/src/session-replay-mobile.js
+++ b/lib/cjs/src/session-replay-mobile.js
@@ -22,6 +22,7 @@ exports.MobileSource = {
     Flutter: 'flutter',
     ReactNative: 'react-native',
     KotlinMultiplatform: 'kotlin-multiplatform',
+    Maui: 'maui',
 };
 exports.RecordType = {
     FullSnapshot: 10,

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -17,7 +17,7 @@ export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform' | 'maui';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -290,7 +290,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
         /**
          * Source type of the error (the language or platform impacting the error stacktrace format)
          */
-        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku' | 'ndk' | 'ios+il2cpp' | 'ndk+il2cpp' | 'windows' | 'macos' | 'linux';
+        readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku' | 'ndk' | 'ios+il2cpp' | 'ndk+il2cpp' | 'windows' | 'macos' | 'linux' | 'maui';
         /**
          * Resource properties of the error
          */
@@ -1110,7 +1110,7 @@ export interface CommonProperties {
     /**
      * The source of this event
      */
-    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp';
+    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
     /**
      * View properties
      */
@@ -1436,7 +1436,7 @@ export interface ViewContainerSchema {
         /**
          * Source of the parent view
          */
-        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp';
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -582,7 +582,7 @@ export type MobileSegmentMetadata = SegmentContext & CommonSegmentMetadataSchema
     /**
      * The source of this record
      */
-    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform';
+    source: 'android' | 'ios' | 'flutter' | 'react-native' | 'kotlin-multiplatform' | 'maui';
 };
 /**
  * Mobile-specific. Schema of a Session Replay Record.

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -438,7 +438,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             sdk_version?: string;
             /**
-             * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+             * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
              */
             source?: string;
             /**
@@ -533,7 +533,7 @@ export interface CommonTelemetryProperties {
     /**
      * The source of this event
      */
-    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp';
+    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
     /**
      * The version of the SDK generating the telemetry event
      */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -380,6 +380,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             unity_version?: string;
             /**
+             * The version of MAUI used in a .NET MAUI application
+             */
+            maui_version?: string;
+            /**
              * The threshold used for iOS App Hangs monitoring (in milliseconds)
              */
             app_hang_threshold?: number;

--- a/lib/esm/src/session-replay-mobile.d.ts
+++ b/lib/esm/src/session-replay-mobile.d.ts
@@ -6,6 +6,7 @@ export declare const MobileSource: {
     readonly Flutter: "flutter";
     readonly ReactNative: "react-native";
     readonly KotlinMultiplatform: "kotlin-multiplatform";
+    readonly Maui: "maui";
 };
 export type MobileSource = (typeof MobileSource)[keyof typeof MobileSource];
 export declare const RecordType: {

--- a/lib/esm/src/session-replay-mobile.js
+++ b/lib/esm/src/session-replay-mobile.js
@@ -5,6 +5,7 @@ export var MobileSource = {
     Flutter: 'flutter',
     ReactNative: 'react-native',
     KotlinMultiplatform: 'kotlin-multiplatform',
+    Maui: 'maui',
 };
 export var RecordType = {
     FullSnapshot: 10,

--- a/lib/src/session-replay-mobile.ts
+++ b/lib/src/session-replay-mobile.ts
@@ -8,6 +8,7 @@ export const MobileSource = {
   Flutter: 'flutter',
   ReactNative: 'react-native',
   KotlinMultiplatform: 'kotlin-multiplatform',
+  Maui: 'maui',
 } as const
 
 export type MobileSource = (typeof MobileSource)[keyof typeof MobileSource]

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -92,7 +92,8 @@
         "unity",
         "kotlin-multiplatform",
         "electron",
-        "rum-cpp"
+        "rum-cpp",
+        "maui"
       ],
       "readOnly": true
     },

--- a/schemas/rum/_view-container-schema.json
+++ b/schemas/rum/_view-container-schema.json
@@ -37,7 +37,8 @@
             "unity",
             "kotlin-multiplatform",
             "electron",
-            "rum-cpp"
+            "rum-cpp",
+            "maui"
           ],
           "readOnly": true
         }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -130,7 +130,8 @@
                 "ndk+il2cpp",
                 "windows",
                 "macos",
-                "linux"
+                "linux",
+                "maui"
               ],
               "readOnly": true
             },

--- a/schemas/session-replay/mobile/segment-metadata-schema.json
+++ b/schemas/session-replay/mobile/segment-metadata-schema.json
@@ -17,7 +17,7 @@
         "source": {
           "type": "string",
           "description": "The source of this record",
-          "enum": ["android", "ios", "flutter", "react-native", "kotlin-multiplatform"]
+          "enum": ["android", "ios", "flutter", "react-native", "kotlin-multiplatform", "maui"]
         }
       }
     }

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -46,7 +46,8 @@
         "unity",
         "kotlin-multiplatform",
         "electron",
-        "rum-cpp"
+        "rum-cpp",
+        "maui"
       ],
       "readOnly": true
     },

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -485,7 +485,7 @@
                 },
                 "source": {
                   "type": "string",
-                  "description": "The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.",
+                  "description": "The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.",
                   "readOnly": false
                 },
                 "variant": {

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -407,6 +407,11 @@
                   "description": "The version of Unity used in a Unity application",
                   "readOnly": false
                 },
+                "maui_version": {
+                  "type": "string",
+                  "description": "The version of MAUI used in a .NET MAUI application",
+                  "readOnly": false
+                },
                 "app_hang_threshold": {
                   "type": "integer",
                   "description": "The threshold used for iOS App Hangs monitoring (in milliseconds)"


### PR DESCRIPTION
It adds the "maui" source to support the .NET MAUI SDK.

It also sets up maui_version to be used on telemetry.