### PR TITLE
PANA-5615: Remove comment about 32 char

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -51,7 +51,7 @@ export type ShapeWireframe = CommonShapeWireframe & {
      */
     readonly type: 'shape';
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -107,7 +107,7 @@ export type TextWireframe = CommonShapeWireframe & {
     textStyle: TextStyle;
     textPosition?: TextPosition;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -190,7 +190,7 @@ export type ImageWireframe = CommonShapeWireframe & {
      */
     isEmpty?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -207,7 +207,7 @@ export type PlaceholderWireframe = CommonWireframe & {
      */
     label?: string;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -228,7 +228,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
      */
     readonly isVisible?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -144,7 +144,7 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly height?: number;
                 /**
-                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                  */
                 readonly permanent_id?: string;
                 [k: string]: unknown;

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -616,7 +616,7 @@ export type ShapeWireframe = CommonShapeWireframe & {
      */
     readonly type: 'shape';
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -672,7 +672,7 @@ export type TextWireframe = CommonShapeWireframe & {
     textStyle: TextStyle;
     textPosition?: TextPosition;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -755,7 +755,7 @@ export type ImageWireframe = CommonShapeWireframe & {
      */
     isEmpty?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -772,7 +772,7 @@ export type PlaceholderWireframe = CommonWireframe & {
      */
     label?: string;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -793,7 +793,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
      */
     readonly isVisible?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -51,7 +51,7 @@ export type ShapeWireframe = CommonShapeWireframe & {
      */
     readonly type: 'shape';
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -107,7 +107,7 @@ export type TextWireframe = CommonShapeWireframe & {
     textStyle: TextStyle;
     textPosition?: TextPosition;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -190,7 +190,7 @@ export type ImageWireframe = CommonShapeWireframe & {
      */
     isEmpty?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -207,7 +207,7 @@ export type PlaceholderWireframe = CommonWireframe & {
      */
     label?: string;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -228,7 +228,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
      */
     readonly isVisible?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -144,7 +144,7 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly height?: number;
                 /**
-                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                 * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                  */
                 readonly permanent_id?: string;
                 [k: string]: unknown;

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -616,7 +616,7 @@ export type ShapeWireframe = CommonShapeWireframe & {
      */
     readonly type: 'shape';
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -672,7 +672,7 @@ export type TextWireframe = CommonShapeWireframe & {
     textStyle: TextStyle;
     textPosition?: TextPosition;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -755,7 +755,7 @@ export type ImageWireframe = CommonShapeWireframe & {
      */
     isEmpty?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -772,7 +772,7 @@ export type PlaceholderWireframe = CommonWireframe & {
      */
     label?: string;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };
@@ -793,7 +793,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
      */
     readonly isVisible?: boolean;
     /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
     readonly permanentId?: string;
 };

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -197,7 +197,7 @@
                     },
                     "permanent_id": {
                       "type": "string",
-                      "description": "Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.",
+                      "description": "Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.",
                       "readOnly": true
                     }
                   }

--- a/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -39,7 +39,7 @@
         },
         "permanentId": {
           "type": "string",
-          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.",
           "readOnly": true
         }
       }

--- a/schemas/session-replay/mobile/placeholder-wireframe-schema.json
+++ b/schemas/session-replay/mobile/placeholder-wireframe-schema.json
@@ -24,7 +24,7 @@
         },
         "permanentId": {
           "type": "string",
-          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.",
           "readOnly": true
         }
       }

--- a/schemas/session-replay/mobile/shape-wireframe-schema.json
+++ b/schemas/session-replay/mobile/shape-wireframe-schema.json
@@ -19,7 +19,7 @@
         },
         "permanentId": {
           "type": "string",
-          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.",
           "readOnly": true
         }
       }

--- a/schemas/session-replay/mobile/text-wireframe-schema.json
+++ b/schemas/session-replay/mobile/text-wireframe-schema.json
@@ -30,7 +30,7 @@
         },
         "permanentId": {
           "type": "string",
-          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.",
           "readOnly": true
         }
       }

--- a/schemas/session-replay/mobile/webview-wireframe-schema.json
+++ b/schemas/session-replay/mobile/webview-wireframe-schema.json
@@ -29,7 +29,7 @@
         },
         "permanentId": {
           "type": "string",
-          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.",
           "readOnly": true
         }
       }


### PR DESCRIPTION
What does it do:
Removes the part of the description from permanentId that implies a specific format ("32 characters").  This is only modifying the description fields and comments.

Motivation:
permanentId hashes are identifiers and should be the decision of each platform. The actual format of the hash doesn't matter as long as the hashes are unique. 