### PR TITLE
RUM-16231: Create schema for RUM events metadata sent with profiling events on Mobile SDKs

### DIFF
--- a/schemas/profiling-mobile-rum-metadata-event-schema.json
+++ b/schemas/profiling-mobile-rum-metadata-event-schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "profiling-mobile-rum-metadata-event-schema.json",
+  "title": "MobileProfileRumMetadataEvent",
+  "description": "Schema of the Mobile SDK RUM Metadata event(s) attached as auxiliary array to Profile Event.",
+  "$ref": "profiling/mobile/profile-rum-metadata-event-schema.json"
+}

--- a/schemas/profiling/mobile/profile-rum-metadata-event-schema.json
+++ b/schemas/profiling/mobile/profile-rum-metadata-event-schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "profiling/mobile/profile-rum-metadata-event-schema.json",
+  "title": "MobileRumMetadataEvent",
+  "description": "Schema of the RUM event attachment (rum-mobile-events.json) uploaded alongside a Mobile SDK (Android or iOS) profile. The payload is a flat array of RUM events used to match profiling samples to RUM events by timestamp, enabling profile slicing by event type. Events may be already finished or still ongoing at the time the profile is submitted.",
+  "type": "object",
+  "required": ["type", "id", "start_ns"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "Type of the RUM event.",
+      "enum": ["vital", "long_task", "error"],
+      "readOnly": true
+    },
+    "id": {
+      "type": "string",
+      "description": "RUM event id.",
+      "readOnly": true
+    },
+    "name": {
+      "type": "string",
+      "description": "Optional human-readable name of the event (e.g. the vital label).",
+      "readOnly": true
+    },
+    "start_ns": {
+      "type": "integer",
+      "description": "Event start timestamp in nanoseconds, using the same clock as the profiling samples.",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "duration_ns": {
+      "type": "integer",
+      "description": "Event duration in nanoseconds. If absent, the event is considered ongoing at the time the profile was submitted.",
+      "minimum": 0,
+      "readOnly": true
+    }
+  }
+}

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -28,6 +28,7 @@ const DEFINITIONS = [
   { source: 'profiling-browser-schema.json', name: 'browserProfiling' },
   { source: 'profiling-mobile-schema.json', name: 'mobileProfiling' },
   { source: 'profiling-schema.json', name: 'profiling' },
+  { source: 'profiling-mobile-rum-metadata-event-schema.json', name: 'mobileProfilingRumMetadata' },
 ]
 
 const GENERATED_PATH = path.normalize(pkg.config['path:generated'])

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -26,6 +26,7 @@ function validateSchemasObjectsPropertiesCase() {
     [`${SCHEMAS_DIRECTORY}/rum/_graphql-schema.json`, ['operationType', 'operationName']],
     [`${SCHEMAS_DIRECTORY}/profiling/_common-schema.json`, ['long_task', 'tags_profiler']],
     [`${SCHEMAS_DIRECTORY}/profiling/browser/profile-event-schema.json`, ['_dd', 'clock_drift']],
+    [`${SCHEMAS_DIRECTORY}/profiling/mobile/profile-rum-metadata-event-schema.json`, ['duration_ns', 'start_ns']],
   ])
 
   let displayConvention = false


### PR DESCRIPTION
This PR creates schema for the RUM events metadata sent as a part of the profiling event upload in a dedicated file.

It is used to associate profiling samples with the timeframe of the particular RUM event represented by the start timestamp and duration (optional, can be missing if event is still ongoing by the time profile event ends).