### PR TITLE
Add DD_SOURCE_CODE_CONTEXT telemetry usage for microfrontends

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -503,7 +503,7 @@ export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | St
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource | SourceCodeContext;
 /**
  * Schema of mobile specific features usage
  */
@@ -917,6 +917,13 @@ export interface StopResource {
      * stopResource API
      */
     feature: 'stop-resource';
+    [k: string]: unknown;
+}
+export interface SourceCodeContext {
+    /**
+     * DD_SOURCE_CODE_CONTEXT global for microfrontends
+     */
+    feature: 'source-code-context';
     [k: string]: unknown;
 }
 export interface TrackWebView {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -503,7 +503,7 @@ export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | St
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource | SourceCodeContext;
 /**
  * Schema of mobile specific features usage
  */
@@ -917,6 +917,13 @@ export interface StopResource {
      * stopResource API
      */
     feature: 'stop-resource';
+    [k: string]: unknown;
+}
+export interface SourceCodeContext {
+    /**
+     * DD_SOURCE_CODE_CONTEXT global for microfrontends
+     */
+    feature: 'source-code-context';
     [k: string]: unknown;
 }
 export interface TrackWebView {

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -96,6 +96,17 @@
           "const": "stop-resource"
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "title": "SourceCodeContext",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "DD_SOURCE_CODE_CONTEXT global for microfrontends",
+          "const": "source-code-context"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
I want to send telemetry from the SDK to detect when customers enable their microfrontend setup through SOURCE_CODE_CONTEXT, because telemetry emitted by the build plugin does not include org information.