### PR TITLE
[PANA-7586] Add composition tree schema for Mobile Session Replay

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -36,6 +36,7 @@ export type MobileFullSnapshotRecord = CommonRecordSchema & {
          * The Wireframes contained by this Record.
          */
         readonly wireframes: Wireframe[];
+        readonly compositionTree?: CompositionTree;
     };
 };
 /**
@@ -233,6 +234,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
+ * A rendering modifier applied to the composed layer output.
+ */
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -245,7 +250,7 @@ export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData | CompositionTreeMutationData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
@@ -584,6 +589,185 @@ export interface WireframeClip {
     readonly right?: number;
 }
 /**
+ * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+ */
+export interface CompositionTree {
+    root: CompositionLayer;
+    /**
+     * Non-root composition layers referenced by the tree.
+     */
+    readonly layers?: CompositionLayer[];
+}
+/**
+ * A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+ */
+export interface CompositionLayer {
+    /**
+     * Stable layer identifier, persistent throughout the view lifetime.
+     */
+    readonly id: number;
+    /**
+     * The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x: number;
+    /**
+     * The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y: number;
+    /**
+     * The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width: number;
+    /**
+     * The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height: number;
+    /**
+     * Ordered back-to-front references to child wireframes or child layers.
+     */
+    readonly children: CompositionLayerChild[];
+    /**
+     * Ordered list of rendering modifiers applied to the composed layer output in array order.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Operation used when compositing the rendered group into its parent.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
+}
+/**
+ * A reference to a child wireframe or child layer in a composition layer.
+ */
+export interface CompositionLayerChild {
+    /**
+     * The type of the child reference.
+     */
+    readonly type: 'wireframe' | 'layer';
+    /**
+     * The id of the referenced wireframe or layer.
+     */
+    readonly id: number;
+}
+/**
+ * Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.
+ */
+export interface CompositionLayerClipModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'clip';
+    /**
+     * SVG path string defining the clip region, in coordinates local to the layer rectangle.
+     */
+    readonly path: string;
+    /**
+     * Path fill rule. Defaults to 'nonzero'.
+     */
+    readonly fillRule?: 'nonzero' | 'evenodd';
+}
+/**
+ * Opacity applied to the composed layer output at this point in the modifier order.
+ */
+export interface CompositionLayerOpacityModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'opacity';
+    /**
+     * Opacity value from 0 to 1.
+     */
+    readonly value: number;
+}
+/**
+ * Color transformation using a 4x5 matrix applied to the composed layer output.
+ */
+export interface CompositionLayerColorMatrixModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'colorMatrix';
+    /**
+     * 4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.
+     *
+     * @minItems 20
+     * @maxItems 20
+     */
+    readonly matrix: [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+    ];
+}
+/**
+ * Gaussian blur applied to the composed layer output.
+ */
+export interface CompositionLayerGaussianBlurModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'gaussianBlur';
+    /**
+     * Gaussian blur radius.
+     */
+    readonly radius: number;
+}
+/**
+ * Adds a signed brightness bias to the rendered layer contents.
+ */
+export interface CompositionLayerBrightnessBiasModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'brightnessBias';
+    /**
+     * Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.
+     */
+    readonly value: number;
+}
+/**
+ * Applies a saturation adjustment to the rendered layer contents.
+ */
+export interface CompositionLayerSaturateModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'saturate';
+    /**
+     * Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.
+     */
+    readonly value: number;
+}
+/**
+ * Represents a platform background material effect captured as layer rendering state.
+ */
+export interface CompositionLayerBackgroundMaterialModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'backgroundMaterial';
+    /**
+     * Material kind.
+     */
+    readonly kind: 'glass';
+}
+/**
  * Mobile-specific. Schema of a MutationPayload.
  */
 export interface MobileMutationPayload {
@@ -674,4 +858,63 @@ export interface PointerInteraction {
      * Y-axis coordinate for this PointerInteraction.
      */
     y: number;
+}
+/**
+ * Mobile-specific. Incremental data carrying composition tree layer mutations.
+ */
+export interface CompositionTreeMutationData {
+    /**
+     * The source of this type of incremental data.
+     */
+    readonly source: 10;
+    root?: CompositionLayer;
+    /**
+     * Full layer definitions for newly added layers.
+     */
+    readonly adds?: CompositionLayer[];
+    /**
+     * Ids of layers to remove.
+     */
+    readonly removes?: number[];
+    /**
+     * Sparse updates for existing layers.
+     */
+    readonly updates?: CompositionLayerUpdate[];
+}
+/**
+ * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ */
+export interface CompositionLayerUpdate {
+    /**
+     * The id of the layer to update.
+     */
+    readonly id: number;
+    /**
+     * Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x?: number;
+    /**
+     * Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y?: number;
+    /**
+     * Updated width in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width?: number;
+    /**
+     * Updated height in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height?: number;
+    /**
+     * When present, replaces the full child list for this layer.
+     */
+    readonly children?: CompositionLayerChild[];
+    /**
+     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Updated composite operation for this layer.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
 }

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -873,7 +873,7 @@ export interface CompositionTreeMutationData {
      */
     readonly adds?: CompositionLayer[];
     /**
-     * Ids of layers to remove.
+     * Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.
      */
     readonly removes?: number[];
     /**

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -882,7 +882,7 @@ export interface CompositionTreeMutationData {
     readonly updates?: CompositionLayerUpdate[];
 }
 /**
- * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ * Sparse update for a composition layer. Omitted fields are unchanged.
  */
 export interface CompositionLayerUpdate {
     /**
@@ -910,7 +910,7 @@ export interface CompositionLayerUpdate {
      */
     readonly children?: CompositionLayerChild[];
     /**
-     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     * When present, replaces the full modifier list for this layer.
      */
     readonly modifiers?: CompositionLayerModifier[];
     /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -1665,7 +1665,7 @@ export interface CompositionTreeMutationData {
      */
     readonly adds?: CompositionLayer[];
     /**
-     * Ids of layers to remove.
+     * Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.
      */
     readonly removes?: number[];
     /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -1674,7 +1674,7 @@ export interface CompositionTreeMutationData {
     readonly updates?: CompositionLayerUpdate[];
 }
 /**
- * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ * Sparse update for a composition layer. Omitted fields are unchanged.
  */
 export interface CompositionLayerUpdate {
     /**
@@ -1702,7 +1702,7 @@ export interface CompositionLayerUpdate {
      */
     readonly children?: CompositionLayerChild[];
     /**
-     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     * When present, replaces the full modifier list for this layer.
      */
     readonly modifiers?: CompositionLayerModifier[];
     /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -601,6 +601,7 @@ export type MobileFullSnapshotRecord = CommonRecordSchema & {
          * The Wireframes contained by this Record.
          */
         readonly wireframes: Wireframe[];
+        readonly compositionTree?: CompositionTree;
     };
 };
 /**
@@ -798,6 +799,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
+ * A rendering modifier applied to the composed layer output.
+ */
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -810,7 +815,7 @@ export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData | CompositionTreeMutationData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
@@ -1414,6 +1419,185 @@ export interface WireframeClip {
     readonly right?: number;
 }
 /**
+ * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+ */
+export interface CompositionTree {
+    root: CompositionLayer;
+    /**
+     * Non-root composition layers referenced by the tree.
+     */
+    readonly layers?: CompositionLayer[];
+}
+/**
+ * A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+ */
+export interface CompositionLayer {
+    /**
+     * Stable layer identifier, persistent throughout the view lifetime.
+     */
+    readonly id: number;
+    /**
+     * The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x: number;
+    /**
+     * The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y: number;
+    /**
+     * The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width: number;
+    /**
+     * The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height: number;
+    /**
+     * Ordered back-to-front references to child wireframes or child layers.
+     */
+    readonly children: CompositionLayerChild[];
+    /**
+     * Ordered list of rendering modifiers applied to the composed layer output in array order.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Operation used when compositing the rendered group into its parent.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
+}
+/**
+ * A reference to a child wireframe or child layer in a composition layer.
+ */
+export interface CompositionLayerChild {
+    /**
+     * The type of the child reference.
+     */
+    readonly type: 'wireframe' | 'layer';
+    /**
+     * The id of the referenced wireframe or layer.
+     */
+    readonly id: number;
+}
+/**
+ * Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.
+ */
+export interface CompositionLayerClipModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'clip';
+    /**
+     * SVG path string defining the clip region, in coordinates local to the layer rectangle.
+     */
+    readonly path: string;
+    /**
+     * Path fill rule. Defaults to 'nonzero'.
+     */
+    readonly fillRule?: 'nonzero' | 'evenodd';
+}
+/**
+ * Opacity applied to the composed layer output at this point in the modifier order.
+ */
+export interface CompositionLayerOpacityModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'opacity';
+    /**
+     * Opacity value from 0 to 1.
+     */
+    readonly value: number;
+}
+/**
+ * Color transformation using a 4x5 matrix applied to the composed layer output.
+ */
+export interface CompositionLayerColorMatrixModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'colorMatrix';
+    /**
+     * 4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.
+     *
+     * @minItems 20
+     * @maxItems 20
+     */
+    readonly matrix: [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+    ];
+}
+/**
+ * Gaussian blur applied to the composed layer output.
+ */
+export interface CompositionLayerGaussianBlurModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'gaussianBlur';
+    /**
+     * Gaussian blur radius.
+     */
+    readonly radius: number;
+}
+/**
+ * Adds a signed brightness bias to the rendered layer contents.
+ */
+export interface CompositionLayerBrightnessBiasModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'brightnessBias';
+    /**
+     * Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.
+     */
+    readonly value: number;
+}
+/**
+ * Applies a saturation adjustment to the rendered layer contents.
+ */
+export interface CompositionLayerSaturateModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'saturate';
+    /**
+     * Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.
+     */
+    readonly value: number;
+}
+/**
+ * Represents a platform background material effect captured as layer rendering state.
+ */
+export interface CompositionLayerBackgroundMaterialModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'backgroundMaterial';
+    /**
+     * Material kind.
+     */
+    readonly kind: 'glass';
+}
+/**
  * Mobile-specific. Schema of a MutationPayload.
  */
 export interface MobileMutationPayload {
@@ -1466,4 +1650,63 @@ export interface CommonWireframeUpdate {
      */
     readonly height?: number;
     clip?: WireframeClip;
+}
+/**
+ * Mobile-specific. Incremental data carrying composition tree layer mutations.
+ */
+export interface CompositionTreeMutationData {
+    /**
+     * The source of this type of incremental data.
+     */
+    readonly source: 10;
+    root?: CompositionLayer;
+    /**
+     * Full layer definitions for newly added layers.
+     */
+    readonly adds?: CompositionLayer[];
+    /**
+     * Ids of layers to remove.
+     */
+    readonly removes?: number[];
+    /**
+     * Sparse updates for existing layers.
+     */
+    readonly updates?: CompositionLayerUpdate[];
+}
+/**
+ * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ */
+export interface CompositionLayerUpdate {
+    /**
+     * The id of the layer to update.
+     */
+    readonly id: number;
+    /**
+     * Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x?: number;
+    /**
+     * Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y?: number;
+    /**
+     * Updated width in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width?: number;
+    /**
+     * Updated height in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height?: number;
+    /**
+     * When present, replaces the full child list for this layer.
+     */
+    readonly children?: CompositionLayerChild[];
+    /**
+     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Updated composite operation for this layer.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
 }

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -36,6 +36,7 @@ export type MobileFullSnapshotRecord = CommonRecordSchema & {
          * The Wireframes contained by this Record.
          */
         readonly wireframes: Wireframe[];
+        readonly compositionTree?: CompositionTree;
     };
 };
 /**
@@ -233,6 +234,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
+ * A rendering modifier applied to the composed layer output.
+ */
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -245,7 +250,7 @@ export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData | CompositionTreeMutationData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
@@ -584,6 +589,185 @@ export interface WireframeClip {
     readonly right?: number;
 }
 /**
+ * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+ */
+export interface CompositionTree {
+    root: CompositionLayer;
+    /**
+     * Non-root composition layers referenced by the tree.
+     */
+    readonly layers?: CompositionLayer[];
+}
+/**
+ * A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+ */
+export interface CompositionLayer {
+    /**
+     * Stable layer identifier, persistent throughout the view lifetime.
+     */
+    readonly id: number;
+    /**
+     * The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x: number;
+    /**
+     * The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y: number;
+    /**
+     * The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width: number;
+    /**
+     * The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height: number;
+    /**
+     * Ordered back-to-front references to child wireframes or child layers.
+     */
+    readonly children: CompositionLayerChild[];
+    /**
+     * Ordered list of rendering modifiers applied to the composed layer output in array order.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Operation used when compositing the rendered group into its parent.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
+}
+/**
+ * A reference to a child wireframe or child layer in a composition layer.
+ */
+export interface CompositionLayerChild {
+    /**
+     * The type of the child reference.
+     */
+    readonly type: 'wireframe' | 'layer';
+    /**
+     * The id of the referenced wireframe or layer.
+     */
+    readonly id: number;
+}
+/**
+ * Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.
+ */
+export interface CompositionLayerClipModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'clip';
+    /**
+     * SVG path string defining the clip region, in coordinates local to the layer rectangle.
+     */
+    readonly path: string;
+    /**
+     * Path fill rule. Defaults to 'nonzero'.
+     */
+    readonly fillRule?: 'nonzero' | 'evenodd';
+}
+/**
+ * Opacity applied to the composed layer output at this point in the modifier order.
+ */
+export interface CompositionLayerOpacityModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'opacity';
+    /**
+     * Opacity value from 0 to 1.
+     */
+    readonly value: number;
+}
+/**
+ * Color transformation using a 4x5 matrix applied to the composed layer output.
+ */
+export interface CompositionLayerColorMatrixModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'colorMatrix';
+    /**
+     * 4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.
+     *
+     * @minItems 20
+     * @maxItems 20
+     */
+    readonly matrix: [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+    ];
+}
+/**
+ * Gaussian blur applied to the composed layer output.
+ */
+export interface CompositionLayerGaussianBlurModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'gaussianBlur';
+    /**
+     * Gaussian blur radius.
+     */
+    readonly radius: number;
+}
+/**
+ * Adds a signed brightness bias to the rendered layer contents.
+ */
+export interface CompositionLayerBrightnessBiasModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'brightnessBias';
+    /**
+     * Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.
+     */
+    readonly value: number;
+}
+/**
+ * Applies a saturation adjustment to the rendered layer contents.
+ */
+export interface CompositionLayerSaturateModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'saturate';
+    /**
+     * Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.
+     */
+    readonly value: number;
+}
+/**
+ * Represents a platform background material effect captured as layer rendering state.
+ */
+export interface CompositionLayerBackgroundMaterialModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'backgroundMaterial';
+    /**
+     * Material kind.
+     */
+    readonly kind: 'glass';
+}
+/**
  * Mobile-specific. Schema of a MutationPayload.
  */
 export interface MobileMutationPayload {
@@ -674,4 +858,63 @@ export interface PointerInteraction {
      * Y-axis coordinate for this PointerInteraction.
      */
     y: number;
+}
+/**
+ * Mobile-specific. Incremental data carrying composition tree layer mutations.
+ */
+export interface CompositionTreeMutationData {
+    /**
+     * The source of this type of incremental data.
+     */
+    readonly source: 10;
+    root?: CompositionLayer;
+    /**
+     * Full layer definitions for newly added layers.
+     */
+    readonly adds?: CompositionLayer[];
+    /**
+     * Ids of layers to remove.
+     */
+    readonly removes?: number[];
+    /**
+     * Sparse updates for existing layers.
+     */
+    readonly updates?: CompositionLayerUpdate[];
+}
+/**
+ * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ */
+export interface CompositionLayerUpdate {
+    /**
+     * The id of the layer to update.
+     */
+    readonly id: number;
+    /**
+     * Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x?: number;
+    /**
+     * Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y?: number;
+    /**
+     * Updated width in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width?: number;
+    /**
+     * Updated height in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height?: number;
+    /**
+     * When present, replaces the full child list for this layer.
+     */
+    readonly children?: CompositionLayerChild[];
+    /**
+     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Updated composite operation for this layer.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
 }

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -873,7 +873,7 @@ export interface CompositionTreeMutationData {
      */
     readonly adds?: CompositionLayer[];
     /**
-     * Ids of layers to remove.
+     * Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.
      */
     readonly removes?: number[];
     /**

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -882,7 +882,7 @@ export interface CompositionTreeMutationData {
     readonly updates?: CompositionLayerUpdate[];
 }
 /**
- * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ * Sparse update for a composition layer. Omitted fields are unchanged.
  */
 export interface CompositionLayerUpdate {
     /**
@@ -910,7 +910,7 @@ export interface CompositionLayerUpdate {
      */
     readonly children?: CompositionLayerChild[];
     /**
-     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     * When present, replaces the full modifier list for this layer.
      */
     readonly modifiers?: CompositionLayerModifier[];
     /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -1665,7 +1665,7 @@ export interface CompositionTreeMutationData {
      */
     readonly adds?: CompositionLayer[];
     /**
-     * Ids of layers to remove.
+     * Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.
      */
     readonly removes?: number[];
     /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -1674,7 +1674,7 @@ export interface CompositionTreeMutationData {
     readonly updates?: CompositionLayerUpdate[];
 }
 /**
- * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ * Sparse update for a composition layer. Omitted fields are unchanged.
  */
 export interface CompositionLayerUpdate {
     /**
@@ -1702,7 +1702,7 @@ export interface CompositionLayerUpdate {
      */
     readonly children?: CompositionLayerChild[];
     /**
-     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     * When present, replaces the full modifier list for this layer.
      */
     readonly modifiers?: CompositionLayerModifier[];
     /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -601,6 +601,7 @@ export type MobileFullSnapshotRecord = CommonRecordSchema & {
          * The Wireframes contained by this Record.
          */
         readonly wireframes: Wireframe[];
+        readonly compositionTree?: CompositionTree;
     };
 };
 /**
@@ -798,6 +799,10 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
+ * A rendering modifier applied to the composed layer output.
+ */
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+/**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
 export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
@@ -810,7 +815,7 @@ export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
  */
-export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData;
+export type MobileIncrementalData = MobileMutationData | TouchData | ViewportResizeData | PointerInteractionData | CompositionTreeMutationData;
 /**
  * Mobile-specific. Schema of a MutationData.
  */
@@ -1414,6 +1419,185 @@ export interface WireframeClip {
     readonly right?: number;
 }
 /**
+ * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+ */
+export interface CompositionTree {
+    root: CompositionLayer;
+    /**
+     * Non-root composition layers referenced by the tree.
+     */
+    readonly layers?: CompositionLayer[];
+}
+/**
+ * A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+ */
+export interface CompositionLayer {
+    /**
+     * Stable layer identifier, persistent throughout the view lifetime.
+     */
+    readonly id: number;
+    /**
+     * The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x: number;
+    /**
+     * The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y: number;
+    /**
+     * The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width: number;
+    /**
+     * The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height: number;
+    /**
+     * Ordered back-to-front references to child wireframes or child layers.
+     */
+    readonly children: CompositionLayerChild[];
+    /**
+     * Ordered list of rendering modifiers applied to the composed layer output in array order.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Operation used when compositing the rendered group into its parent.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
+}
+/**
+ * A reference to a child wireframe or child layer in a composition layer.
+ */
+export interface CompositionLayerChild {
+    /**
+     * The type of the child reference.
+     */
+    readonly type: 'wireframe' | 'layer';
+    /**
+     * The id of the referenced wireframe or layer.
+     */
+    readonly id: number;
+}
+/**
+ * Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.
+ */
+export interface CompositionLayerClipModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'clip';
+    /**
+     * SVG path string defining the clip region, in coordinates local to the layer rectangle.
+     */
+    readonly path: string;
+    /**
+     * Path fill rule. Defaults to 'nonzero'.
+     */
+    readonly fillRule?: 'nonzero' | 'evenodd';
+}
+/**
+ * Opacity applied to the composed layer output at this point in the modifier order.
+ */
+export interface CompositionLayerOpacityModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'opacity';
+    /**
+     * Opacity value from 0 to 1.
+     */
+    readonly value: number;
+}
+/**
+ * Color transformation using a 4x5 matrix applied to the composed layer output.
+ */
+export interface CompositionLayerColorMatrixModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'colorMatrix';
+    /**
+     * 4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.
+     *
+     * @minItems 20
+     * @maxItems 20
+     */
+    readonly matrix: [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+    ];
+}
+/**
+ * Gaussian blur applied to the composed layer output.
+ */
+export interface CompositionLayerGaussianBlurModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'gaussianBlur';
+    /**
+     * Gaussian blur radius.
+     */
+    readonly radius: number;
+}
+/**
+ * Adds a signed brightness bias to the rendered layer contents.
+ */
+export interface CompositionLayerBrightnessBiasModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'brightnessBias';
+    /**
+     * Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.
+     */
+    readonly value: number;
+}
+/**
+ * Applies a saturation adjustment to the rendered layer contents.
+ */
+export interface CompositionLayerSaturateModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'saturate';
+    /**
+     * Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.
+     */
+    readonly value: number;
+}
+/**
+ * Represents a platform background material effect captured as layer rendering state.
+ */
+export interface CompositionLayerBackgroundMaterialModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'backgroundMaterial';
+    /**
+     * Material kind.
+     */
+    readonly kind: 'glass';
+}
+/**
  * Mobile-specific. Schema of a MutationPayload.
  */
 export interface MobileMutationPayload {
@@ -1466,4 +1650,63 @@ export interface CommonWireframeUpdate {
      */
     readonly height?: number;
     clip?: WireframeClip;
+}
+/**
+ * Mobile-specific. Incremental data carrying composition tree layer mutations.
+ */
+export interface CompositionTreeMutationData {
+    /**
+     * The source of this type of incremental data.
+     */
+    readonly source: 10;
+    root?: CompositionLayer;
+    /**
+     * Full layer definitions for newly added layers.
+     */
+    readonly adds?: CompositionLayer[];
+    /**
+     * Ids of layers to remove.
+     */
+    readonly removes?: number[];
+    /**
+     * Sparse updates for existing layers.
+     */
+    readonly updates?: CompositionLayerUpdate[];
+}
+/**
+ * Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.
+ */
+export interface CompositionLayerUpdate {
+    /**
+     * The id of the layer to update.
+     */
+    readonly id: number;
+    /**
+     * Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly x?: number;
+    /**
+     * Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly y?: number;
+    /**
+     * Updated width in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly width?: number;
+    /**
+     * Updated height in pixels. Uses the same coordinate space as mobile wireframes.
+     */
+    readonly height?: number;
+    /**
+     * When present, replaces the full child list for this layer.
+     */
+    readonly children?: CompositionLayerChild[];
+    /**
+     * When present, replaces the full modifier list for this layer. An empty array clears all modifiers.
+     */
+    readonly modifiers?: CompositionLayerModifier[];
+    /**
+     * Updated composite operation for this layer.
+     */
+    readonly compositeOperation?: 'sourceOver' | 'destinationIn' | 'plusDarker';
 }

--- a/samples/session-replay/mobile/record/full-snapshot-record-with-composition-tree.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record-with-composition-tree.json
@@ -1,0 +1,65 @@
+{
+  "timestamp": 1657618587157,
+  "type": 10,
+  "data": {
+    "wireframes": [
+      {
+        "id": 42,
+        "x": 20,
+        "y": 100,
+        "width": 240,
+        "height": 80,
+        "type": "shape"
+      },
+      {
+        "id": 43,
+        "x": 44,
+        "y": 124,
+        "width": 160,
+        "height": 24,
+        "type": "text",
+        "text": "Hello",
+        "textStyle": {
+          "family": "Arial",
+          "size": 16,
+          "type": "sans-serif",
+          "color": "#000000FF"
+        }
+      }
+    ],
+    "compositionTree": {
+      "root": {
+        "id": 1,
+        "x": 0,
+        "y": 0,
+        "width": 390,
+        "height": 844,
+        "children": [{ "type": "layer", "id": 2 }]
+      },
+      "layers": [
+        {
+          "id": 2,
+          "x": 20,
+          "y": 100,
+          "width": 240,
+          "height": 80,
+          "modifiers": [
+            {
+              "type": "clip",
+              "path": "M 0 24 Q 0 0 24 0 H 216 Q 240 0 240 24 V 80 H 0 Z",
+              "fillRule": "nonzero"
+            },
+            {
+              "type": "opacity",
+              "value": 0.9
+            }
+          ],
+          "children": [
+            { "type": "wireframe", "id": 42 },
+            { "type": "wireframe", "id": 43 }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/samples/session-replay/mobile/record/incremental-snapshot-record-composition-tree-mutation.json
+++ b/samples/session-replay/mobile/record/incremental-snapshot-record-composition-tree-mutation.json
@@ -1,0 +1,51 @@
+{
+  "timestamp": 1657620232337,
+  "type": 11,
+  "data": {
+    "source": 10,
+    "root": {
+      "id": 1,
+      "x": 0,
+      "y": 0,
+      "width": 390,
+      "height": 844,
+      "children": [
+        { "type": "layer", "id": 2 },
+        { "type": "layer", "id": 3 }
+      ]
+    },
+    "adds": [
+      {
+        "id": 3,
+        "x": 10,
+        "y": 200,
+        "width": 100,
+        "height": 50,
+        "children": [],
+        "modifiers": [
+          {
+            "type": "gaussianBlur",
+            "radius": 8
+          }
+        ],
+        "compositeOperation": "sourceOver"
+      }
+    ],
+    "removes": [4],
+    "updates": [
+      {
+        "id": 2,
+        "modifiers": [
+          {
+            "type": "clip",
+            "path": "M 0 16 Q 0 0 16 0 H 224 Q 240 0 240 16 V 80 H 0 Z"
+          }
+        ],
+        "children": [
+          { "type": "wireframe", "id": 42 },
+          { "type": "wireframe", "id": 43 }
+        ]
+      }
+    ]
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-background-material-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-background-material-modifier-schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-background-material-modifier-schema.json",
+  "title": "CompositionLayerBackgroundMaterialModifier",
+  "type": "object",
+  "description": "Represents a platform background material effect captured as layer rendering state.",
+  "required": ["type", "kind"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "backgroundMaterial",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["glass"],
+      "description": "Material kind.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-brightness-bias-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-brightness-bias-modifier-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-brightness-bias-modifier-schema.json",
+  "title": "CompositionLayerBrightnessBiasModifier",
+  "type": "object",
+  "description": "Adds a signed brightness bias to the rendered layer contents.",
+  "required": ["type", "value"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "brightnessBias",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "value": {
+      "type": "number",
+      "minimum": -1,
+      "maximum": 1,
+      "description": "Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-child-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-child-schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-child-schema.json",
+  "title": "CompositionLayerChild",
+  "type": "object",
+  "description": "A reference to a child wireframe or child layer in a composition layer.",
+  "required": ["type", "id"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["wireframe", "layer"],
+      "description": "The type of the child reference.",
+      "readOnly": true
+    },
+    "id": {
+      "type": "integer",
+      "description": "The id of the referenced wireframe or layer.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-clip-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-clip-modifier-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-clip-modifier-schema.json",
+  "title": "CompositionLayerClipModifier",
+  "type": "object",
+  "description": "Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.",
+  "required": ["type", "path"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "clip",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "path": {
+      "type": "string",
+      "description": "SVG path string defining the clip region, in coordinates local to the layer rectangle.",
+      "readOnly": true
+    },
+    "fillRule": {
+      "type": "string",
+      "enum": ["nonzero", "evenodd"],
+      "description": "Path fill rule. Defaults to 'nonzero'.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-color-matrix-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-color-matrix-modifier-schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-color-matrix-modifier-schema.json",
+  "title": "CompositionLayerColorMatrixModifier",
+  "type": "object",
+  "description": "Color transformation using a 4x5 matrix applied to the composed layer output.",
+  "required": ["type", "matrix"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "colorMatrix",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "matrix": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 20,
+      "maxItems": 20,
+      "description": "4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-gaussian-blur-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-gaussian-blur-modifier-schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-gaussian-blur-modifier-schema.json",
+  "title": "CompositionLayerGaussianBlurModifier",
+  "type": "object",
+  "description": "Gaussian blur applied to the composed layer output.",
+  "required": ["type", "radius"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "gaussianBlur",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "radius": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Gaussian blur radius.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-modifier-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-modifier-schema.json",
+  "title": "CompositionLayerModifier",
+  "type": "object",
+  "description": "A rendering modifier applied to the composed layer output.",
+  "oneOf": [
+    {
+      "$ref": "composition-layer-clip-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-opacity-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-color-matrix-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-gaussian-blur-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-brightness-bias-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-saturate-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-background-material-modifier-schema.json"
+    }
+  ]
+}

--- a/schemas/session-replay/mobile/composition-layer-opacity-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-opacity-modifier-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-opacity-modifier-schema.json",
+  "title": "CompositionLayerOpacityModifier",
+  "type": "object",
+  "description": "Opacity applied to the composed layer output at this point in the modifier order.",
+  "required": ["type", "value"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "opacity",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "value": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Opacity value from 0 to 1.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-saturate-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-saturate-modifier-schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-saturate-modifier-schema.json",
+  "title": "CompositionLayerSaturateModifier",
+  "type": "object",
+  "description": "Applies a saturation adjustment to the rendered layer contents.",
+  "required": ["type", "value"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "saturate",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "value": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-schema.json",
+  "title": "CompositionLayer",
+  "type": "object",
+  "description": "A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.",
+  "required": ["id", "x", "y", "width", "height", "children"],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Stable layer identifier, persistent throughout the view lifetime.",
+      "readOnly": true
+    },
+    "x": {
+      "type": "integer",
+      "description": "The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "y": {
+      "type": "integer",
+      "description": "The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "width": {
+      "type": "integer",
+      "description": "The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "height": {
+      "type": "integer",
+      "description": "The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "children": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-child-schema.json"
+      },
+      "description": "Ordered back-to-front references to child wireframes or child layers.",
+      "readOnly": true
+    },
+    "modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-modifier-schema.json"
+      },
+      "description": "Ordered list of rendering modifiers applied to the composed layer output in array order.",
+      "readOnly": true
+    },
+    "compositeOperation": {
+      "type": "string",
+      "enum": ["sourceOver", "destinationIn", "plusDarker"],
+      "description": "Operation used when compositing the rendered group into its parent.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-update-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-update-schema.json
@@ -3,7 +3,7 @@
   "$id": "session-replay/mobile/composition-layer-update-schema.json",
   "title": "CompositionLayerUpdate",
   "type": "object",
-  "description": "Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.",
+  "description": "Sparse update for a composition layer. Omitted fields are unchanged.",
   "required": ["id"],
   "properties": {
     "id": {
@@ -44,7 +44,7 @@
       "items": {
         "$ref": "composition-layer-modifier-schema.json"
       },
-      "description": "When present, replaces the full modifier list for this layer. An empty array clears all modifiers.",
+      "description": "When present, replaces the full modifier list for this layer.",
       "readOnly": true
     },
     "compositeOperation": {

--- a/schemas/session-replay/mobile/composition-layer-update-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-update-schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-update-schema.json",
+  "title": "CompositionLayerUpdate",
+  "type": "object",
+  "description": "Sparse update for a composition layer. Only id is required; omitted fields are unchanged. An empty modifiers array clears all modifiers. An empty children array clears all children.",
+  "required": ["id"],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "The id of the layer to update.",
+      "readOnly": true
+    },
+    "x": {
+      "type": "integer",
+      "description": "Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "y": {
+      "type": "integer",
+      "description": "Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "width": {
+      "type": "integer",
+      "description": "Updated width in pixels. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "height": {
+      "type": "integer",
+      "description": "Updated height in pixels. Uses the same coordinate space as mobile wireframes.",
+      "readOnly": true
+    },
+    "children": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-child-schema.json"
+      },
+      "description": "When present, replaces the full child list for this layer.",
+      "readOnly": true
+    },
+    "modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-modifier-schema.json"
+      },
+      "description": "When present, replaces the full modifier list for this layer. An empty array clears all modifiers.",
+      "readOnly": true
+    },
+    "compositeOperation": {
+      "type": "string",
+      "enum": ["sourceOver", "destinationIn", "plusDarker"],
+      "description": "Updated composite operation for this layer.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-tree-mutation-data-schema.json
+++ b/schemas/session-replay/mobile/composition-tree-mutation-data-schema.json
@@ -28,7 +28,7 @@
       "items": {
         "type": "integer"
       },
-      "description": "Ids of layers to remove.",
+      "description": "Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.",
       "readOnly": true
     },
     "updates": {

--- a/schemas/session-replay/mobile/composition-tree-mutation-data-schema.json
+++ b/schemas/session-replay/mobile/composition-tree-mutation-data-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-tree-mutation-data-schema.json",
+  "title": "CompositionTreeMutationData",
+  "type": "object",
+  "description": "Mobile-specific. Incremental data carrying composition tree layer mutations.",
+  "required": ["source"],
+  "properties": {
+    "source": {
+      "type": "integer",
+      "const": 10,
+      "description": "The source of this type of incremental data.",
+      "readOnly": true
+    },
+    "root": {
+      "$ref": "composition-layer-schema.json"
+    },
+    "adds": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-schema.json"
+      },
+      "description": "Full layer definitions for newly added layers.",
+      "readOnly": true
+    },
+    "removes": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Ids of layers to remove.",
+      "readOnly": true
+    },
+    "updates": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-update-schema.json"
+      },
+      "description": "Sparse updates for existing layers.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-tree-schema.json
+++ b/schemas/session-replay/mobile/composition-tree-schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-tree-schema.json",
+  "title": "CompositionTree",
+  "type": "object",
+  "description": "Optional composition tree describing the rendering hierarchy for a full snapshot. When present, the player uses this tree for rendering order and group operations instead of rendering the flat wireframes array.",
+  "required": ["root"],
+  "properties": {
+    "root": {
+      "$ref": "composition-layer-schema.json"
+    },
+    "layers": {
+      "type": "array",
+      "items": {
+        "$ref": "composition-layer-schema.json"
+      },
+      "description": "Non-root composition layers referenced by the tree.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-tree-schema.json
+++ b/schemas/session-replay/mobile/composition-tree-schema.json
@@ -3,7 +3,7 @@
   "$id": "session-replay/mobile/composition-tree-schema.json",
   "title": "CompositionTree",
   "type": "object",
-  "description": "Optional composition tree describing the rendering hierarchy for a full snapshot. When present, the player uses this tree for rendering order and group operations instead of rendering the flat wireframes array.",
+  "description": "Optional composition tree describing the rendering hierarchy for a full snapshot. When present, the player uses this tree for rendering order and group operations instead of rendering the wireframes as a flat array.",
   "required": ["root"],
   "properties": {
     "root": {

--- a/schemas/session-replay/mobile/full-snapshot-record-schema.json
+++ b/schemas/session-replay/mobile/full-snapshot-record-schema.json
@@ -29,6 +29,11 @@
               },
               "description": "The Wireframes contained by this Record.",
               "readOnly": true
+            },
+            "compositionTree": {
+              "$ref": "composition-tree-schema.json",
+              "description": "Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.",
+              "readOnly": true
             }
           }
         }

--- a/schemas/session-replay/mobile/incremental-data-schema.json
+++ b/schemas/session-replay/mobile/incremental-data-schema.json
@@ -16,6 +16,9 @@
     },
     {
       "$ref": "../common/pointer-interaction-data-schema.json"
+    },
+    {
+      "$ref": "composition-tree-mutation-data-schema.json"
     }
   ]
 }


### PR DESCRIPTION
Mobile Session Replay wireframes are flat, which means the player has no way to apply rendering operations that depend on hierarchy (clipping with rounded corners, group opacity, blur, and compositing). This PR adds an optional `compositionTree` to mobile full snapshots that lets SDKs describe the rendering groups the player needs.

### What's new

A composition layer groups child wireframes and child layers and carries an ordered list of rendering modifiers: `clip`, `opacity`, `colorMatrix`, `gaussianBlur`, `brightnessBias`, `saturate`, and `backgroundMaterial`. Each layer can also specify a `compositeOperation` for blending into its parent.

A new incremental data source (`source: 10`) carries layer mutations following the same model as wireframe mutations.

### Backward compatibility

`compositionTree` is optional. When it is absent, the player renders the flat `wireframes` array as before.

Internal references:
- [Composition tree schema RFC](https://datadoghq.atlassian.net/wiki/x/tIVXkQE)
- [Core Animation recording RFC](https://datadoghq.atlassian.net/wiki/x/v4AXjAE)