### PR TITLE
fix(ci): correct e2e command and rename build to typecheck job

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -33,5 +33,5 @@ jobs:
         run: eval $command_${{matrix.test_type}}
         env:
           command_unit: 'yarn test:unit'
-          command_e2e: 'yarn test:e2e --workers 10'
+          command_e2e: 'yarn test:e2e:init && yarn test:e2e --workers 10'
           command_typecheck: 'yarn typecheck'

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -33,5 +33,5 @@ jobs:
         run: eval $command_${{matrix.test_type}}
         env:
           command_unit: 'yarn test:unit'
-          command_e2e: 'yarn test:e2e:ci --workers 10'
-          command_build: 'yarn typecheck'
+          command_e2e: 'yarn test:e2e --workers 10'
+          command_typecheck: 'yarn typecheck'


### PR DESCRIPTION
## Summary

- Fix the e2e CI command: use `yarn test:e2e` instead of `yarn test:e2e:ci` (the `:ci` variant does not exist)
- Rename the `build` matrix entry to `typecheck` to accurately reflect what the job does (`yarn typecheck`)

## Test plan

- [ ] Verify the GitHub Actions workflow runs the correct commands for each matrix entry