### PR TITLE
[RUM-16925] Add debug_ids to error and long_task RUM event schemas

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -468,6 +468,15 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
          * Profiling context
          */
         profiling?: ProfilingInternalContextSchema;
+        /**
+         * Mapping of source file URLs to their debug IDs for source map deobfuscation
+         */
+        readonly debug_ids?: {
+            /**
+             * Debug ID (UUID) for the source file
+             */
+            [k: string]: string;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -584,6 +593,15 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
          * Profiling context
          */
         profiling?: ProfilingInternalContextSchema;
+        /**
+         * Mapping of source file URLs to their debug IDs for source map deobfuscation
+         */
+        readonly debug_ids?: {
+            /**
+             * Debug ID (UUID) for the source file
+             */
+            [k: string]: string;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -468,6 +468,15 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
          * Profiling context
          */
         profiling?: ProfilingInternalContextSchema;
+        /**
+         * Mapping of source file URLs to their debug IDs for source map deobfuscation
+         */
+        readonly debug_ids?: {
+            /**
+             * Debug ID (UUID) for the source file
+             */
+            [k: string]: string;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -584,6 +593,15 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
          * Profiling context
          */
         profiling?: ProfilingInternalContextSchema;
+        /**
+         * Mapping of source file URLs to their debug IDs for source map deobfuscation
+         */
+        readonly debug_ids?: {
+            /**
+             * Debug ID (UUID) for the source file
+             */
+            [k: string]: string;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -82,8 +82,8 @@
   "_dd": {
     "format_version": 2,
     "debug_ids": [
-      { "https://service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
-      { "https://shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
+      { "https://foo.com/service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
+      { "https://bar.com/shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
     ]
   }
 }

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -80,6 +80,10 @@
     "effective_type": "4g"
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "debug_ids": [
+      { "https://service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
+      { "https://shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
+    ]
   }
 }

--- a/samples/rum-events/long_animation_frame.json
+++ b/samples/rum-events/long_animation_frame.json
@@ -43,6 +43,10 @@
     "id": "ae3a5d82-cdd1-468d-9bc9-3aa9e54d853c"
   },
   "_dd": {
-    "format_version": 2
+    "format_version": 2,
+    "debug_ids": [
+      { "https://service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
+      { "https://shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
+    ]
   }
 }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -386,6 +386,20 @@
                   "type": "object",
                   "description": "Profiling context",
                   "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
+                },
+                "debug_ids": {
+                  "type": "array",
+                  "description": "Mapping of source file URLs to their debug IDs for source map deobfuscation",
+                  "items": {
+                    "type": "object",
+                    "description": "Mapping of a source file URL to its debug ID",
+                    "additionalProperties": {
+                      "type": "string",
+                      "description": "Debug ID (UUID) for the source file",
+                      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+                    }
+                  },
+                  "readOnly": true
                 }
               }
             }

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -174,6 +174,20 @@
               "type": "object",
               "description": "Profiling context",
               "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
+            },
+            "debug_ids": {
+              "type": "array",
+              "description": "Mapping of source file URLs to their debug IDs for source map deobfuscation",
+              "items": {
+                "type": "object",
+                "description": "Mapping of a source file URL to its debug ID",
+                "additionalProperties": {
+                  "type": "string",
+                  "description": "Debug ID (UUID) for the source file",
+                  "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+                }
+              },
+              "readOnly": true
             }
           },
           "readOnly": true


### PR DESCRIPTION
## Context

Part of the Micro frontend Error Un-minification RFC. When an error spans multiple MFE bundles, only frames matching the top frame's (service, version) are un-minified today. `debug_ids` maps source file URLs to per-bundle UUIDs (generated at
build time, following Sentry's debug_id approach / TC39 proposal).

## Changes

- Add `_dd.debug_ids` to `error` and `long_task` schemas
- Update generated TypeScript types and JSON samples
