### PR TITLE
[RUM-16925] Fix debug_ids format to URL-to-Debug-ID mapping object

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -476,7 +476,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
              * Debug ID (UUID) for the source file
              */
             [k: string]: string;
-        }[];
+        };
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -601,7 +601,7 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
              * Debug ID (UUID) for the source file
              */
             [k: string]: string;
-        }[];
+        };
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -476,7 +476,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
              * Debug ID (UUID) for the source file
              */
             [k: string]: string;
-        }[];
+        };
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -601,7 +601,7 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
              * Debug ID (UUID) for the source file
              */
             [k: string]: string;
-        }[];
+        };
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -81,9 +81,9 @@
   },
   "_dd": {
     "format_version": 2,
-    "debug_ids": [
-      { "https://foo.com/service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
-      { "https://bar.com/shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
-    ]
+    "debug_ids": {
+      "https://foo.com/service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21",
+      "https://bar.com/shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28"
+    }
   }
 }

--- a/samples/rum-events/long_animation_frame.json
+++ b/samples/rum-events/long_animation_frame.json
@@ -44,9 +44,9 @@
   },
   "_dd": {
     "format_version": 2,
-    "debug_ids": [
-      { "https://service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
-      { "https://shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
-    ]
+    "debug_ids": {
+      "https://service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21",
+      "https://shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28"
+    }
   }
 }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -388,16 +388,12 @@
                   "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
                 },
                 "debug_ids": {
-                  "type": "array",
+                  "type": "object",
                   "description": "Mapping of source file URLs to their debug IDs for source map deobfuscation",
-                  "items": {
-                    "type": "object",
-                    "description": "Mapping of a source file URL to its debug ID",
-                    "additionalProperties": {
-                      "type": "string",
-                      "description": "Debug ID (UUID) for the source file",
-                      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
-                    }
+                  "additionalProperties": {
+                    "type": "string",
+                    "description": "Debug ID (UUID) for the source file",
+                    "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
                   },
                   "readOnly": true
                 }

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -176,16 +176,12 @@
               "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
             },
             "debug_ids": {
-              "type": "array",
+              "type": "object",
               "description": "Mapping of source file URLs to their debug IDs for source map deobfuscation",
-              "items": {
-                "type": "object",
-                "description": "Mapping of a source file URL to its debug ID",
-                "additionalProperties": {
-                  "type": "string",
-                  "description": "Debug ID (UUID) for the source file",
-                  "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
-                }
+              "additionalProperties": {
+                "type": "string",
+                "description": "Debug ID (UUID) for the source file",
+                "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
               },
               "readOnly": true
             }


### PR DESCRIPTION
## Summary

- Changes `debug_ids` from an array of single-key objects to a flat object mapping source file URLs directly to their debug IDs
- Applies to both `error` and `long_task` event schemas
- Follows the [recommended URL-to-Debug-ID mapping format](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/6863128158/Debug+_id+data+format)

**Before:**
```json
"debug_ids": [
  { "https://service-a.js": "5f4b4d0a-..." },
  { "https://shell-app.js": "1d93a8f4-..." }
]
```

**After:**
```json
"debug_ids": {
  "https://service-a.js": "5f4b4d0a-...",
  "https://shell-app.js": "1d93a8f4-..."
}
```

## Test plan

- [ ] Verify generated TypeScript types reflect `{ [k: string]: string }` (not array)
- [ ] Update Browser SDK to send the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)