### PR TITLE
Add `beta_enable_view_updates` to telemetry configuration schema

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -226,7 +226,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -234,7 +234,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -473,6 +473,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the beta encode cookie options is enabled
              */
             beta_encode_cookie_options?: boolean;
+            /**
+             * Whether the beta partial view updates feature is enabled
+             */
+            beta_enable_view_updates?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -226,7 +226,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -234,7 +234,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -473,6 +473,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the beta encode cookie options is enabled
              */
             beta_encode_cookie_options?: boolean;
+            /**
+             * Whether the beta partial view updates feature is enabled
+             */
+            beta_enable_view_updates?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -530,6 +530,11 @@
                   "type": "boolean",
                   "description": "Whether the beta encode cookie options is enabled",
                   "readOnly": false
+                },
+                "beta_enable_view_updates": {
+                  "type": "boolean",
+                  "description": "Whether the beta partial view updates feature is enabled",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
The browser-sdk is adding a `betaEnableViewUpdates` init option for partial view updates (DataDog/browser-sdk#4833). We need this field in the telemetry configuration schema so the SDK can report whether the feature is enabled.

Added `beta_enable_view_updates` (optional boolean) to `configuration-schema.json`, same pattern as `beta_encode_cookie_options`. Generated `.d.ts` files updated accordingly.