### PR TITLE
feat: add `remote_configuration_id` field to rum view event schema

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -226,7 +226,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1956,6 +1956,10 @@ export interface ViewProperties {
              * Whether session replay recording configured to start manually
              */
             readonly start_session_replay_recording_manually?: boolean;
+            /**
+             * The id of the remote configuration applied to the SDK, if any
+             */
+            readonly remote_configuration_id?: string;
             [k: string]: unknown;
         };
         /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -234,7 +234,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -226,7 +226,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1956,6 +1956,10 @@ export interface ViewProperties {
              * Whether session replay recording configured to start manually
              */
             readonly start_session_replay_recording_manually?: boolean;
+            /**
+             * The id of the remote configuration applied to the SDK, if any
+             */
+            readonly remote_configuration_id?: string;
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -234,7 +234,9 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [
+    StyleSheetRules
+] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/schemas/rum/_view-properties-schema.json
+++ b/schemas/rum/_view-properties-schema.json
@@ -544,6 +544,11 @@
               "type": "boolean",
               "description": "Whether session replay recording configured to start manually",
               "readOnly": true
+            },
+            "remote_configuration_id": {
+              "type": "string",
+              "description": "The id of the remote configuration applied to the SDK, if any",
+              "readOnly": true
             }
           }
         },


### PR DESCRIPTION
For remote config project we need a way to identify clients who have remote config added to their init configuration