### PR TITLE
feat: Add shadow modifier to Mobile Session Replay composition layers

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -236,7 +236,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -727,6 +727,35 @@ export interface CompositionLayerGaussianBlurModifier {
      * Gaussian blur radius.
      */
     readonly radius: number;
+}
+/**
+ * Drop shadow drawn behind the composed layer output.
+ */
+export interface CompositionLayerShadowModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'shadow';
+    /**
+     * The shadow color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. SDKs should encode the effective shadow alpha in this color and omit the shadow modifier when the effective alpha is 0.
+     */
+    readonly color: string;
+    /**
+     * Horizontal shadow offset in pixels.
+     */
+    readonly offsetX: number;
+    /**
+     * Vertical shadow offset in pixels.
+     */
+    readonly offsetY: number;
+    /**
+     * Blur radius used to create the shadow.
+     */
+    readonly radius: number;
+    /**
+     * Optional SVG path string defining the shadow outline, in coordinates local to the layer rectangle. When present, the path is interpreted using the non-zero winding rule. When omitted, the shadow follows the composed layer alpha.
+     */
+    readonly path?: string;
 }
 /**
  * Adds a signed brightness bias to the rendered layer contents.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -803,7 +803,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -1559,6 +1559,35 @@ export interface CompositionLayerGaussianBlurModifier {
      * Gaussian blur radius.
      */
     readonly radius: number;
+}
+/**
+ * Drop shadow drawn behind the composed layer output.
+ */
+export interface CompositionLayerShadowModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'shadow';
+    /**
+     * The shadow color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. SDKs should encode the effective shadow alpha in this color and omit the shadow modifier when the effective alpha is 0.
+     */
+    readonly color: string;
+    /**
+     * Horizontal shadow offset in pixels.
+     */
+    readonly offsetX: number;
+    /**
+     * Vertical shadow offset in pixels.
+     */
+    readonly offsetY: number;
+    /**
+     * Blur radius used to create the shadow.
+     */
+    readonly radius: number;
+    /**
+     * Optional SVG path string defining the shadow outline, in coordinates local to the layer rectangle. When present, the path is interpreted using the non-zero winding rule. When omitted, the shadow follows the composed layer alpha.
+     */
+    readonly path?: string;
 }
 /**
  * Adds a signed brightness bias to the rendered layer contents.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -236,7 +236,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -727,6 +727,35 @@ export interface CompositionLayerGaussianBlurModifier {
      * Gaussian blur radius.
      */
     readonly radius: number;
+}
+/**
+ * Drop shadow drawn behind the composed layer output.
+ */
+export interface CompositionLayerShadowModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'shadow';
+    /**
+     * The shadow color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. SDKs should encode the effective shadow alpha in this color and omit the shadow modifier when the effective alpha is 0.
+     */
+    readonly color: string;
+    /**
+     * Horizontal shadow offset in pixels.
+     */
+    readonly offsetX: number;
+    /**
+     * Vertical shadow offset in pixels.
+     */
+    readonly offsetY: number;
+    /**
+     * Blur radius used to create the shadow.
+     */
+    readonly radius: number;
+    /**
+     * Optional SVG path string defining the shadow outline, in coordinates local to the layer rectangle. When present, the path is interpreted using the non-zero winding rule. When omitted, the shadow follows the composed layer alpha.
+     */
+    readonly path?: string;
 }
 /**
  * Adds a signed brightness bias to the rendered layer contents.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -803,7 +803,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -1559,6 +1559,35 @@ export interface CompositionLayerGaussianBlurModifier {
      * Gaussian blur radius.
      */
     readonly radius: number;
+}
+/**
+ * Drop shadow drawn behind the composed layer output.
+ */
+export interface CompositionLayerShadowModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'shadow';
+    /**
+     * The shadow color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. SDKs should encode the effective shadow alpha in this color and omit the shadow modifier when the effective alpha is 0.
+     */
+    readonly color: string;
+    /**
+     * Horizontal shadow offset in pixels.
+     */
+    readonly offsetX: number;
+    /**
+     * Vertical shadow offset in pixels.
+     */
+    readonly offsetY: number;
+    /**
+     * Blur radius used to create the shadow.
+     */
+    readonly radius: number;
+    /**
+     * Optional SVG path string defining the shadow outline, in coordinates local to the layer rectangle. When present, the path is interpreted using the non-zero winding rule. When omitted, the shadow follows the composed layer alpha.
+     */
+    readonly path?: string;
 }
 /**
  * Adds a signed brightness bias to the rendered layer contents.

--- a/samples/session-replay/mobile/record/full-snapshot-record-with-composition-tree.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record-with-composition-tree.json
@@ -50,6 +50,14 @@
               "fillRule": "nonzero"
             },
             {
+              "type": "shadow",
+              "color": "#00000040",
+              "offsetX": 0,
+              "offsetY": 2,
+              "radius": 8,
+              "path": "M 0 24 Q 0 0 24 0 H 216 Q 240 0 240 24 V 80 H 0 Z"
+            },
+            {
               "type": "opacity",
               "value": 0.9
             }

--- a/schemas/session-replay/mobile/composition-layer-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-modifier-schema.json
@@ -18,6 +18,9 @@
       "$ref": "composition-layer-gaussian-blur-modifier-schema.json"
     },
     {
+      "$ref": "composition-layer-shadow-modifier-schema.json"
+    },
+    {
       "$ref": "composition-layer-brightness-bias-modifier-schema.json"
     },
     {

--- a/schemas/session-replay/mobile/composition-layer-shadow-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-shadow-modifier-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-shadow-modifier-schema.json",
+  "title": "CompositionLayerShadowModifier",
+  "type": "object",
+  "description": "Drop shadow drawn behind the composed layer output.",
+  "required": ["type", "color", "offsetX", "offsetY", "radius"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "shadow",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "color": {
+      "type": "string",
+      "pattern": "^#[A-Fa-f0-9]{6}([A-Fa-f0-9]{2})?$",
+      "description": "The shadow color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. SDKs should encode the effective shadow alpha in this color and omit the shadow modifier when the effective alpha is 0.",
+      "readOnly": true
+    },
+    "offsetX": {
+      "type": "number",
+      "description": "Horizontal shadow offset in pixels.",
+      "readOnly": true
+    },
+    "offsetY": {
+      "type": "number",
+      "description": "Vertical shadow offset in pixels.",
+      "readOnly": true
+    },
+    "radius": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Blur radius used to create the shadow.",
+      "readOnly": true
+    },
+    "path": {
+      "type": "string",
+      "description": "Optional SVG path string defining the shadow outline, in coordinates local to the layer rectangle. When present, the path is interpreted using the non-zero winding rule. When omitted, the shadow follows the composed layer alpha.",
+      "readOnly": true
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `shadow` modifier to Mobile Session Replay composition layers.

It follows the composition tree model introduced in #390 and the RFC for Mobile Session Replay capture fidelity. The modifier lets SDKs describe a shadow with `color`, `offsetX`, `offsetY`, `radius`, and an optional `path`.

The shadow color carries the effective alpha. SDKs should skip the modifier when the effective alpha is `0`.

### Backward compatibility

This is additive. Existing records are unchanged, and players can ignore the new modifier until support is added.

### Internal references

- [Mobile Session Replay schema changes for capture fidelity](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/6733399476/RFC+Mobile+Session+Replay+schema+changes+for+capture+fidelity)