### PR TITLE
feat: Add mask image modifier to Mobile Session Replay composition layers

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -236,7 +236,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -795,6 +795,19 @@ export interface CompositionLayerBackgroundMaterialModifier {
      * Material kind.
      */
     readonly kind: 'glass';
+}
+/**
+ * Image mask applied to the composed layer output at this point in the modifier order. The referenced image is mapped to the layer bounds and interpreted as an alpha mask: transparent pixels hide content, opaque pixels keep content, and partial alpha multiplies content alpha. RGB channels are ignored.
+ */
+export interface CompositionLayerMaskImageModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'maskImage';
+    /**
+     * Unique identifier of the image resource used as a bounds-aligned alpha mask.
+     */
+    readonly resourceId: string;
 }
 /**
  * Mobile-specific. Schema of a MutationPayload.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -803,7 +803,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -1627,6 +1627,19 @@ export interface CompositionLayerBackgroundMaterialModifier {
      * Material kind.
      */
     readonly kind: 'glass';
+}
+/**
+ * Image mask applied to the composed layer output at this point in the modifier order. The referenced image is mapped to the layer bounds and interpreted as an alpha mask: transparent pixels hide content, opaque pixels keep content, and partial alpha multiplies content alpha. RGB channels are ignored.
+ */
+export interface CompositionLayerMaskImageModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'maskImage';
+    /**
+     * Unique identifier of the image resource used as a bounds-aligned alpha mask.
+     */
+    readonly resourceId: string;
 }
 /**
  * Mobile-specific. Schema of a MutationPayload.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -236,7 +236,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -795,6 +795,19 @@ export interface CompositionLayerBackgroundMaterialModifier {
      * Material kind.
      */
     readonly kind: 'glass';
+}
+/**
+ * Image mask applied to the composed layer output at this point in the modifier order. The referenced image is mapped to the layer bounds and interpreted as an alpha mask: transparent pixels hide content, opaque pixels keep content, and partial alpha multiplies content alpha. RGB channels are ignored.
+ */
+export interface CompositionLayerMaskImageModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'maskImage';
+    /**
+     * Unique identifier of the image resource used as a bounds-aligned alpha mask.
+     */
+    readonly resourceId: string;
 }
 /**
  * Mobile-specific. Schema of a MutationPayload.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -803,7 +803,7 @@ export type WebviewWireframe = CommonShapeWireframe & {
 /**
  * A rendering modifier applied to the composed layer output.
  */
-export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier;
+export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -1627,6 +1627,19 @@ export interface CompositionLayerBackgroundMaterialModifier {
      * Material kind.
      */
     readonly kind: 'glass';
+}
+/**
+ * Image mask applied to the composed layer output at this point in the modifier order. The referenced image is mapped to the layer bounds and interpreted as an alpha mask: transparent pixels hide content, opaque pixels keep content, and partial alpha multiplies content alpha. RGB channels are ignored.
+ */
+export interface CompositionLayerMaskImageModifier {
+    /**
+     * The type of the modifier.
+     */
+    readonly type: 'maskImage';
+    /**
+     * Unique identifier of the image resource used as a bounds-aligned alpha mask.
+     */
+    readonly resourceId: string;
 }
 /**
  * Mobile-specific. Schema of a MutationPayload.

--- a/samples/session-replay/mobile/record/full-snapshot-record-with-composition-tree.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record-with-composition-tree.json
@@ -60,6 +60,10 @@
             {
               "type": "opacity",
               "value": 0.9
+            },
+            {
+              "type": "maskImage",
+              "resourceId": "maskResourceIdMock"
             }
           ],
           "children": [

--- a/schemas/session-replay/mobile/composition-layer-mask-image-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-mask-image-modifier-schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/composition-layer-mask-image-modifier-schema.json",
+  "title": "CompositionLayerMaskImageModifier",
+  "type": "object",
+  "description": "Image mask applied to the composed layer output at this point in the modifier order. The referenced image is mapped to the layer bounds and interpreted as an alpha mask: transparent pixels hide content, opaque pixels keep content, and partial alpha multiplies content alpha. RGB channels are ignored.",
+  "required": ["type", "resourceId"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "maskImage",
+      "description": "The type of the modifier.",
+      "readOnly": true
+    },
+    "resourceId": {
+      "type": "string",
+      "description": "Unique identifier of the image resource used as a bounds-aligned alpha mask.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/composition-layer-modifier-schema.json
+++ b/schemas/session-replay/mobile/composition-layer-modifier-schema.json
@@ -28,6 +28,9 @@
     },
     {
       "$ref": "composition-layer-background-material-modifier-schema.json"
+    },
+    {
+      "$ref": "composition-layer-mask-image-modifier-schema.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a `maskImage` modifier to Mobile Session Replay composition layers.

It follows the composition tree model introduced in #390 and the modifier pattern used by #401. The modifier lets SDKs reference a bounds-aligned image resource through `resourceId` and apply it at the chosen point in modifier order.

The referenced image is interpreted as an alpha mask: transparent pixels hide content, opaque pixels keep content, and partial alpha multiplies content alpha. RGB channels are ignored.

SDKs should generate mask images aligned with the composition layer bounds. No mask geometry is added in this first version.

### Backward compatibility

This is additive. Existing records are unchanged, and players can ignore the new modifier until support is added.

### Internal references

- [Mobile Session Replay schema changes for capture fidelity](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/6733399476/RFC+Mobile+Session+Replay+schema+changes+for+capture+fidelity)