### PR TITLE
[RUM-16925] Switch debug_ids to recommended URL/Debug-ID array format

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -226,9 +226,7 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [
-    StyleSheetRules
-] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -471,12 +471,17 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
         /**
          * Mapping of source file URLs to their debug IDs for source map deobfuscation
          */
-        readonly debug_ids?: {
+        debug_ids?: {
+            /**
+             * URL of the source file
+             */
+            url: string;
             /**
              * Debug ID (UUID) for the source file
              */
-            [k: string]: string;
-        };
+            id: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -596,12 +601,17 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
         /**
          * Mapping of source file URLs to their debug IDs for source map deobfuscation
          */
-        readonly debug_ids?: {
+        debug_ids?: {
+            /**
+             * URL of the source file
+             */
+            url: string;
             /**
              * Debug ID (UUID) for the source file
              */
-            [k: string]: string;
-        };
+            id: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -234,9 +234,7 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [
-    StyleSheetRules
-] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -226,9 +226,7 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [
-    StyleSheetRules
-] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -471,12 +471,17 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
         /**
          * Mapping of source file URLs to their debug IDs for source map deobfuscation
          */
-        readonly debug_ids?: {
+        debug_ids?: {
+            /**
+             * URL of the source file
+             */
+            url: string;
             /**
              * Debug ID (UUID) for the source file
              */
-            [k: string]: string;
-        };
+            id: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;
@@ -596,12 +601,17 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
         /**
          * Mapping of source file URLs to their debug IDs for source map deobfuscation
          */
-        readonly debug_ids?: {
+        debug_ids?: {
+            /**
+             * URL of the source file
+             */
+            url: string;
             /**
              * Debug ID (UUID) for the source file
              */
-            [k: string]: string;
-        };
+            id: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -234,9 +234,7 @@ export type AddStyleSheetChange = StyleSheetSnapshot;
  *
  * @minItems 1
  */
-export type StyleSheetSnapshot = [
-    StyleSheetRules
-] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
+export type StyleSheetSnapshot = [StyleSheetRules] | [StyleSheetRules, StyleSheetMediaList] | [StyleSheetRules, StyleSheetMediaList, boolean];
 /**
  * Schema representing a CSS stylesheet's rules, encoded either as a single string or as an array containing a separate string for each rule.
  */

--- a/samples/rum-events/error.json
+++ b/samples/rum-events/error.json
@@ -81,9 +81,9 @@
   },
   "_dd": {
     "format_version": 2,
-    "debug_ids": {
-      "https://foo.com/service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21",
-      "https://bar.com/shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28"
-    }
+    "debug_ids": [
+      { "url": "https://foo.com/service-a.js", "id": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
+      { "url": "https://bar.com/shell-app.js", "id": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
+    ]
   }
 }

--- a/samples/rum-events/long_animation_frame.json
+++ b/samples/rum-events/long_animation_frame.json
@@ -44,9 +44,9 @@
   },
   "_dd": {
     "format_version": 2,
-    "debug_ids": {
-      "https://service-a.js": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21",
-      "https://shell-app.js": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28"
-    }
+    "debug_ids": [
+      { "url": "https://service-a.js", "id": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" },
+      { "url": "https://shell-app.js", "id": "1d93a8f4-2c75-4b8e-a641-9e5f3d7c0b28" }
+    ]
   }
 }

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -388,14 +388,24 @@
                   "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
                 },
                 "debug_ids": {
-                  "type": "object",
+                  "type": "array",
                   "description": "Mapping of source file URLs to their debug IDs for source map deobfuscation",
-                  "additionalProperties": {
-                    "type": "string",
-                    "description": "Debug ID (UUID) for the source file",
-                    "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
-                  },
-                  "readOnly": true
+                  "items": {
+                    "type": "object",
+                    "description": "Association between a source file URL and its debug ID",
+                    "required": ["url", "id"],
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "description": "URL of the source file"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Debug ID (UUID) for the source file",
+                        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -176,14 +176,24 @@
               "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
             },
             "debug_ids": {
-              "type": "object",
+              "type": "array",
               "description": "Mapping of source file URLs to their debug IDs for source map deobfuscation",
-              "additionalProperties": {
-                "type": "string",
-                "description": "Debug ID (UUID) for the source file",
-                "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
-              },
-              "readOnly": true
+              "items": {
+                "type": "object",
+                "description": "Association between a source file URL and its debug ID",
+                "required": ["url", "id"],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "URL of the source file"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "Debug ID (UUID) for the source file",
+                    "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+                  }
+                }
+              }
             }
           },
           "readOnly": true


### PR DESCRIPTION
## What

Change `_dd.debug_ids` in the RUM **error** and **long_task** schemas from a flat object mapping URLs → IDs into an **array of `{ url, id }` objects**, per the updated recommendation in the [Debug _id data format RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/6863128158/Debug+_id+data+format).

## Why

The event platform breaks down keys containing dots into nested objects, so frame URLs can't safely be used as object keys. The RFC now recommends the URL-to-Debug-ID array as the canonical format.
