### PR TITLE
Update timeseries CPU and memory schemas to object-v2 flattened format

### DIFF
--- a/schemas/rum/timeseries-cpu-schema.json
+++ b/schemas/rum/timeseries-cpu-schema.json
@@ -111,7 +111,7 @@
         "schema": {
           "type": "string",
           "description": "Wire-shape discriminator for the data field",
-          "enum": ["object", "delta-scalar"],
+          "const": "object-v2",
           "readOnly": true
         },
         "start": {
@@ -125,33 +125,36 @@
           "readOnly": true
         },
         "data": {
-          "type": "array",
-          "description": "Array of CPU data points",
-          "items": {
-            "type": "object",
-            "description": "A single CPU data point",
-            "required": ["timestamp", "data_point"],
-            "properties": {
-              "timestamp": {
+          "type": "object",
+          "description": "Flattened CPU data points",
+          "required": ["timestamps", "values"],
+          "properties": {
+            "timestamps": {
+              "type": "array",
+              "description": "Sample timestamps in nanoseconds from epoch",
+              "items": {
                 "type": "integer",
-                "description": "Sample timestamp in nanoseconds from epoch",
                 "readOnly": true
               },
-              "data_point": {
-                "type": "object",
-                "description": "CPU measurements for this sample",
-                "required": ["cpu_usage"],
-                "properties": {
-                  "cpu_usage": {
-                    "type": "number",
-                    "description": "CPU usage as a percentage (0.0 to 100.0)",
-                    "readOnly": true
-                  }
-                },
-                "readOnly": true
-              }
+              "readOnly": true
             },
-            "readOnly": true
+            "values": {
+              "type": "object",
+              "description": "CPU measurements, aligned index-for-index with timestamps",
+              "required": ["cpu_usage"],
+              "properties": {
+                "cpu_usage": {
+                  "type": "array",
+                  "description": "CPU usage as a percentage (0.0 to 100.0)",
+                  "items": {
+                    "type": "number",
+                    "readOnly": true
+                  },
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            }
           },
           "readOnly": true
         }

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -111,7 +111,7 @@
         "schema": {
           "type": "string",
           "description": "Wire-shape discriminator for the data field",
-          "enum": ["object", "delta-object"],
+          "const": "object-v2",
           "readOnly": true
         },
         "start": {
@@ -125,38 +125,45 @@
           "readOnly": true
         },
         "data": {
-          "type": "array",
-          "description": "Array of memory data points",
-          "items": {
-            "type": "object",
-            "description": "A single memory data point",
-            "required": ["timestamp", "data_point"],
-            "properties": {
-              "timestamp": {
+          "type": "object",
+          "description": "Flattened memory data points",
+          "required": ["timestamps", "values"],
+          "properties": {
+            "timestamps": {
+              "type": "array",
+              "description": "Sample timestamps in nanoseconds from epoch",
+              "items": {
                 "type": "integer",
-                "description": "Sample timestamp in nanoseconds from epoch",
                 "readOnly": true
               },
-              "data_point": {
-                "type": "object",
-                "description": "Memory measurements for this sample",
-                "required": ["memory_footprint", "memory_percent"],
-                "properties": {
-                  "memory_footprint": {
+              "readOnly": true
+            },
+            "values": {
+              "type": "object",
+              "description": "Memory measurements, aligned index-for-index with timestamps",
+              "required": ["memory_footprint", "memory_percent"],
+              "properties": {
+                "memory_footprint": {
+                  "type": "array",
+                  "description": "Physical memory footprint of the process in kilobytes",
+                  "items": {
                     "type": "number",
-                    "description": "Physical memory footprint of the process in bytes",
                     "readOnly": true
                   },
-                  "memory_percent": {
-                    "type": "number",
-                    "description": "Memory footprint as a percentage of total device RAM",
-                    "readOnly": true
-                  }
+                  "readOnly": true
                 },
-                "readOnly": true
-              }
-            },
-            "readOnly": true
+                "memory_percent": {
+                  "type": "array",
+                  "description": "Memory footprint as a percentage of total device RAM",
+                  "items": {
+                    "type": "number",
+                    "readOnly": true
+                  },
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            }
           },
           "readOnly": true
         }


### PR DESCRIPTION
### What and why?

- `timeseries.schema` is now a const `"object-v2"` (removes `object`/`delta-scalar`/`delta-object` enum)
- `timeseries.data` flattened from array of `{timestamp, data_point}` to `{ timestamps: [], values: {...} }`
- `memory_footprint` unit changed from bytes to KB (still float)

### Review checklist
- [ ] Schema changes reviewed for shape correctness
- [ ] No breaking change to `id`/`start`/`end`/`name` fields