### PR TITLE
feat: Add linear gradients to Mobile Session Replay shape wireframes

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -71,6 +71,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -80,6 +81,10 @@ export type ShapeStyle = {
      */
     readonly cornerRadius?: number;
 };
+/**
+ * A background gradient for a shape wireframe. When backgroundColor is also present, the background color is painted first and the gradient is painted over it. The gradient is clipped to the wireframe shape, the border is painted afterward, and shape opacity applies to the combined result.
+ */
+export type ShapeGradient = ShapeLinearGradient;
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
@@ -587,6 +592,49 @@ export interface WireframeClip {
      * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
      */
     readonly right?: number;
+}
+/**
+ * A linear background gradient for a shape wireframe. Colors before the first stop and after the last stop are clamped to the nearest stop color.
+ */
+export interface ShapeLinearGradient {
+    /**
+     * The type of the gradient.
+     */
+    readonly type: 'linear';
+    /**
+     * Ordered gradient color stops. Positions must be non-decreasing.
+     *
+     * @minItems 2
+     */
+    readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    startPoint: ShapeGradientPoint;
+    endPoint: ShapeGradientPoint;
+}
+/**
+ * A color and its relative position in a shape gradient.
+ */
+export interface ShapeGradientStop {
+    /**
+     * The stop color as a hexadecimal string in #RRGGBB or #RRGGBBAA format.
+     */
+    readonly color: string;
+    /**
+     * Relative stop position between 0 and 1. Stops must be ordered by non-decreasing position.
+     */
+    readonly position: number;
+}
+/**
+ * A point in the wireframe's normalized coordinate space. The top-left corner is (0, 0), the bottom-right corner is (1, 1), and values outside this range place the point outside the wireframe bounds.
+ */
+export interface ShapeGradientPoint {
+    /**
+     * Horizontal position, where 0 is the left edge and 1 is the right edge.
+     */
+    readonly x: number;
+    /**
+     * Vertical position, where 0 is the top edge and 1 is the bottom edge.
+     */
+    readonly y: number;
 }
 /**
  * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -71,7 +71,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
-    backgroundGradient?: ShapeGradient;
+    readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -607,8 +607,8 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
-    startPoint: ShapeGradientPoint;
-    endPoint: ShapeGradientPoint;
+    readonly startPoint: ShapeGradientPoint;
+    readonly endPoint: ShapeGradientPoint;
 }
 /**
  * A color and its relative position in a shape gradient.

--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -71,6 +71,9 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    /**
+     * The background gradient for this wireframe.
+     */
     readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
@@ -607,7 +610,13 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    /**
+     * The point where position 0 of the gradient is placed.
+     */
     readonly startPoint: ShapeGradientPoint;
+    /**
+     * The point where position 1 of the gradient is placed.
+     */
     readonly endPoint: ShapeGradientPoint;
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -638,6 +638,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -647,6 +648,10 @@ export type ShapeStyle = {
      */
     readonly cornerRadius?: number;
 };
+/**
+ * A background gradient for a shape wireframe. When backgroundColor is also present, the background color is painted first and the gradient is painted over it. The gradient is clipped to the wireframe shape, the border is painted afterward, and shape opacity applies to the combined result.
+ */
+export type ShapeGradient = ShapeLinearGradient;
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
@@ -1419,6 +1424,49 @@ export interface WireframeClip {
      * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
      */
     readonly right?: number;
+}
+/**
+ * A linear background gradient for a shape wireframe. Colors before the first stop and after the last stop are clamped to the nearest stop color.
+ */
+export interface ShapeLinearGradient {
+    /**
+     * The type of the gradient.
+     */
+    readonly type: 'linear';
+    /**
+     * Ordered gradient color stops. Positions must be non-decreasing.
+     *
+     * @minItems 2
+     */
+    readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    startPoint: ShapeGradientPoint;
+    endPoint: ShapeGradientPoint;
+}
+/**
+ * A color and its relative position in a shape gradient.
+ */
+export interface ShapeGradientStop {
+    /**
+     * The stop color as a hexadecimal string in #RRGGBB or #RRGGBBAA format.
+     */
+    readonly color: string;
+    /**
+     * Relative stop position between 0 and 1. Stops must be ordered by non-decreasing position.
+     */
+    readonly position: number;
+}
+/**
+ * A point in the wireframe's normalized coordinate space. The top-left corner is (0, 0), the bottom-right corner is (1, 1), and values outside this range place the point outside the wireframe bounds.
+ */
+export interface ShapeGradientPoint {
+    /**
+     * Horizontal position, where 0 is the left edge and 1 is the right edge.
+     */
+    readonly x: number;
+    /**
+     * Vertical position, where 0 is the top edge and 1 is the bottom edge.
+     */
+    readonly y: number;
 }
 /**
  * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -638,6 +638,9 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    /**
+     * The background gradient for this wireframe.
+     */
     readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
@@ -1439,7 +1442,13 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    /**
+     * The point where position 0 of the gradient is placed.
+     */
     readonly startPoint: ShapeGradientPoint;
+    /**
+     * The point where position 1 of the gradient is placed.
+     */
     readonly endPoint: ShapeGradientPoint;
 }
 /**

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -638,7 +638,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
-    backgroundGradient?: ShapeGradient;
+    readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -1439,8 +1439,8 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
-    startPoint: ShapeGradientPoint;
-    endPoint: ShapeGradientPoint;
+    readonly startPoint: ShapeGradientPoint;
+    readonly endPoint: ShapeGradientPoint;
 }
 /**
  * A color and its relative position in a shape gradient.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -71,6 +71,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -80,6 +81,10 @@ export type ShapeStyle = {
      */
     readonly cornerRadius?: number;
 };
+/**
+ * A background gradient for a shape wireframe. When backgroundColor is also present, the background color is painted first and the gradient is painted over it. The gradient is clipped to the wireframe shape, the border is painted afterward, and shape opacity applies to the combined result.
+ */
+export type ShapeGradient = ShapeLinearGradient;
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
@@ -587,6 +592,49 @@ export interface WireframeClip {
      * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
      */
     readonly right?: number;
+}
+/**
+ * A linear background gradient for a shape wireframe. Colors before the first stop and after the last stop are clamped to the nearest stop color.
+ */
+export interface ShapeLinearGradient {
+    /**
+     * The type of the gradient.
+     */
+    readonly type: 'linear';
+    /**
+     * Ordered gradient color stops. Positions must be non-decreasing.
+     *
+     * @minItems 2
+     */
+    readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    startPoint: ShapeGradientPoint;
+    endPoint: ShapeGradientPoint;
+}
+/**
+ * A color and its relative position in a shape gradient.
+ */
+export interface ShapeGradientStop {
+    /**
+     * The stop color as a hexadecimal string in #RRGGBB or #RRGGBBAA format.
+     */
+    readonly color: string;
+    /**
+     * Relative stop position between 0 and 1. Stops must be ordered by non-decreasing position.
+     */
+    readonly position: number;
+}
+/**
+ * A point in the wireframe's normalized coordinate space. The top-left corner is (0, 0), the bottom-right corner is (1, 1), and values outside this range place the point outside the wireframe bounds.
+ */
+export interface ShapeGradientPoint {
+    /**
+     * Horizontal position, where 0 is the left edge and 1 is the right edge.
+     */
+    readonly x: number;
+    /**
+     * Vertical position, where 0 is the top edge and 1 is the bottom edge.
+     */
+    readonly y: number;
 }
 /**
  * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -71,7 +71,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
-    backgroundGradient?: ShapeGradient;
+    readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -607,8 +607,8 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
-    startPoint: ShapeGradientPoint;
-    endPoint: ShapeGradientPoint;
+    readonly startPoint: ShapeGradientPoint;
+    readonly endPoint: ShapeGradientPoint;
 }
 /**
  * A color and its relative position in a shape gradient.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -71,6 +71,9 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    /**
+     * The background gradient for this wireframe.
+     */
     readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
@@ -607,7 +610,13 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    /**
+     * The point where position 0 of the gradient is placed.
+     */
     readonly startPoint: ShapeGradientPoint;
+    /**
+     * The point where position 1 of the gradient is placed.
+     */
     readonly endPoint: ShapeGradientPoint;
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -638,6 +638,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -647,6 +648,10 @@ export type ShapeStyle = {
      */
     readonly cornerRadius?: number;
 };
+/**
+ * A background gradient for a shape wireframe. When backgroundColor is also present, the background color is painted first and the gradient is painted over it. The gradient is clipped to the wireframe shape, the border is painted afterward, and shape opacity applies to the combined result.
+ */
+export type ShapeGradient = ShapeLinearGradient;
 /**
  * The border properties of this wireframe. The default value is null (no-border).
  */
@@ -1419,6 +1424,49 @@ export interface WireframeClip {
      * The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
      */
     readonly right?: number;
+}
+/**
+ * A linear background gradient for a shape wireframe. Colors before the first stop and after the last stop are clamped to the nearest stop color.
+ */
+export interface ShapeLinearGradient {
+    /**
+     * The type of the gradient.
+     */
+    readonly type: 'linear';
+    /**
+     * Ordered gradient color stops. Positions must be non-decreasing.
+     *
+     * @minItems 2
+     */
+    readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    startPoint: ShapeGradientPoint;
+    endPoint: ShapeGradientPoint;
+}
+/**
+ * A color and its relative position in a shape gradient.
+ */
+export interface ShapeGradientStop {
+    /**
+     * The stop color as a hexadecimal string in #RRGGBB or #RRGGBBAA format.
+     */
+    readonly color: string;
+    /**
+     * Relative stop position between 0 and 1. Stops must be ordered by non-decreasing position.
+     */
+    readonly position: number;
+}
+/**
+ * A point in the wireframe's normalized coordinate space. The top-left corner is (0, 0), the bottom-right corner is (1, 1), and values outside this range place the point outside the wireframe bounds.
+ */
+export interface ShapeGradientPoint {
+    /**
+     * Horizontal position, where 0 is the left edge and 1 is the right edge.
+     */
+    readonly x: number;
+    /**
+     * Vertical position, where 0 is the top edge and 1 is the bottom edge.
+     */
+    readonly y: number;
 }
 /**
  * Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -638,6 +638,9 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
+    /**
+     * The background gradient for this wireframe.
+     */
     readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
@@ -1439,7 +1442,13 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
+    /**
+     * The point where position 0 of the gradient is placed.
+     */
     readonly startPoint: ShapeGradientPoint;
+    /**
+     * The point where position 1 of the gradient is placed.
+     */
     readonly endPoint: ShapeGradientPoint;
 }
 /**

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -638,7 +638,7 @@ export type ShapeStyle = {
      * The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
      */
     readonly backgroundColor?: string;
-    backgroundGradient?: ShapeGradient;
+    readonly backgroundGradient?: ShapeGradient;
     /**
      * The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
      */
@@ -1439,8 +1439,8 @@ export interface ShapeLinearGradient {
      * @minItems 2
      */
     readonly stops: [ShapeGradientStop, ShapeGradientStop, ...ShapeGradientStop[]];
-    startPoint: ShapeGradientPoint;
-    endPoint: ShapeGradientPoint;
+    readonly startPoint: ShapeGradientPoint;
+    readonly endPoint: ShapeGradientPoint;
 }
 /**
  * A color and its relative position in a shape gradient.

--- a/samples/session-replay/mobile/record/full-snapshot-record.json
+++ b/samples/session-replay/mobile/record/full-snapshot-record.json
@@ -45,6 +45,38 @@
         "height": 30,
         "type": "image",
         "isEmpty": true
+      },
+      {
+        "id": 5,
+        "x": 20,
+        "y": 30,
+        "width": 100,
+        "height": 50,
+        "type": "shape",
+        "shapeStyle": {
+          "backgroundGradient": {
+            "type": "linear",
+            "stops": [
+              {
+                "color": "#FF0000FF",
+                "position": 0
+              },
+              {
+                "color": "#0000FFFF",
+                "position": 1
+              }
+            ],
+            "startPoint": {
+              "x": 0,
+              "y": 0.5
+            },
+            "endPoint": {
+              "x": 1,
+              "y": 0.5
+            }
+          },
+          "cornerRadius": 8
+        }
       }
     ]
   }

--- a/schemas/session-replay/mobile/shape-gradient-point-schema.json
+++ b/schemas/session-replay/mobile/shape-gradient-point-schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/shape-gradient-point-schema.json",
+  "title": "ShapeGradientPoint",
+  "type": "object",
+  "description": "A point in the wireframe's normalized coordinate space. The top-left corner is (0, 0), the bottom-right corner is (1, 1), and values outside this range place the point outside the wireframe bounds.",
+  "required": ["x", "y"],
+  "properties": {
+    "x": {
+      "type": "number",
+      "description": "Horizontal position, where 0 is the left edge and 1 is the right edge.",
+      "readOnly": true
+    },
+    "y": {
+      "type": "number",
+      "description": "Vertical position, where 0 is the top edge and 1 is the bottom edge.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/shape-gradient-schema.json
+++ b/schemas/session-replay/mobile/shape-gradient-schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/shape-gradient-schema.json",
+  "title": "ShapeGradient",
+  "description": "A background gradient for a shape wireframe. When backgroundColor is also present, the background color is painted first and the gradient is painted over it. The gradient is clipped to the wireframe shape, the border is painted afterward, and shape opacity applies to the combined result.",
+  "oneOf": [
+    {
+      "$ref": "shape-linear-gradient-schema.json"
+    }
+  ]
+}

--- a/schemas/session-replay/mobile/shape-gradient-stop-schema.json
+++ b/schemas/session-replay/mobile/shape-gradient-stop-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/shape-gradient-stop-schema.json",
+  "title": "ShapeGradientStop",
+  "type": "object",
+  "description": "A color and its relative position in a shape gradient.",
+  "required": ["color", "position"],
+  "properties": {
+    "color": {
+      "type": "string",
+      "pattern": "^#[A-Fa-f0-9]{6}([A-Fa-f0-9]{2})?$",
+      "description": "The stop color as a hexadecimal string in #RRGGBB or #RRGGBBAA format.",
+      "readOnly": true
+    },
+    "position": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Relative stop position between 0 and 1. Stops must be ordered by non-decreasing position.",
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/session-replay/mobile/shape-linear-gradient-schema.json
+++ b/schemas/session-replay/mobile/shape-linear-gradient-schema.json
@@ -22,6 +22,7 @@
       "readOnly": true
     },
     "startPoint": {
+      "description": "The point where position 0 of the gradient is placed.",
       "readOnly": true,
       "allOf": [
         {
@@ -30,6 +31,7 @@
       ]
     },
     "endPoint": {
+      "description": "The point where position 1 of the gradient is placed.",
       "readOnly": true,
       "allOf": [
         {

--- a/schemas/session-replay/mobile/shape-linear-gradient-schema.json
+++ b/schemas/session-replay/mobile/shape-linear-gradient-schema.json
@@ -22,10 +22,20 @@
       "readOnly": true
     },
     "startPoint": {
-      "$ref": "shape-gradient-point-schema.json"
+      "readOnly": true,
+      "allOf": [
+        {
+          "$ref": "shape-gradient-point-schema.json"
+        }
+      ]
     },
     "endPoint": {
-      "$ref": "shape-gradient-point-schema.json"
+      "readOnly": true,
+      "allOf": [
+        {
+          "$ref": "shape-gradient-point-schema.json"
+        }
+      ]
     }
   }
 }

--- a/schemas/session-replay/mobile/shape-linear-gradient-schema.json
+++ b/schemas/session-replay/mobile/shape-linear-gradient-schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/shape-linear-gradient-schema.json",
+  "title": "ShapeLinearGradient",
+  "type": "object",
+  "description": "A linear background gradient for a shape wireframe. Colors before the first stop and after the last stop are clamped to the nearest stop color.",
+  "required": ["type", "stops", "startPoint", "endPoint"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "linear",
+      "description": "The type of the gradient.",
+      "readOnly": true
+    },
+    "stops": {
+      "type": "array",
+      "items": {
+        "$ref": "shape-gradient-stop-schema.json"
+      },
+      "minItems": 2,
+      "description": "Ordered gradient color stops. Positions must be non-decreasing.",
+      "readOnly": true
+    },
+    "startPoint": {
+      "$ref": "shape-gradient-point-schema.json"
+    },
+    "endPoint": {
+      "$ref": "shape-gradient-point-schema.json"
+    }
+  }
+}

--- a/schemas/session-replay/mobile/shape-style-schema.json
+++ b/schemas/session-replay/mobile/shape-style-schema.json
@@ -13,6 +13,9 @@
           "description": "The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.",
           "readOnly": true
         },
+        "backgroundGradient": {
+          "$ref": "shape-gradient-schema.json"
+        },
         "opacity": {
           "type": "number",
           "description": "The opacity of this wireframe. Takes values from 0 to 1, default value is 1.",

--- a/schemas/session-replay/mobile/shape-style-schema.json
+++ b/schemas/session-replay/mobile/shape-style-schema.json
@@ -14,6 +14,7 @@
           "readOnly": true
         },
         "backgroundGradient": {
+          "description": "The background gradient for this wireframe.",
           "readOnly": true,
           "allOf": [
             {

--- a/schemas/session-replay/mobile/shape-style-schema.json
+++ b/schemas/session-replay/mobile/shape-style-schema.json
@@ -14,7 +14,12 @@
           "readOnly": true
         },
         "backgroundGradient": {
-          "$ref": "shape-gradient-schema.json"
+          "readOnly": true,
+          "allOf": [
+            {
+              "$ref": "shape-gradient-schema.json"
+            }
+          ]
         },
         "opacity": {
           "type": "number",


### PR DESCRIPTION
This PR adds an optional `backgroundGradient` to Mobile Session Replay shape wireframes.

The first version supports linear gradients with ordered color stops and normalized start and end points. Points can fall outside the wireframe bounds, colors clamp to the nearest stop, and an existing `backgroundColor` is painted first.

`ShapeGradient` starts as a union with one `ShapeLinearGradient` case, so more gradient types can be added later without changing linear payloads.

### Backward compatibility

This is additive: existing records are unchanged, and players can ignore the new gradient until support is added.