### PR TITLE
Add salesforce LWC telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -507,7 +507,7 @@ export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | St
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource | SourceCodeContext;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource | SourceCodeContext | SalesforceLwc;
 /**
  * Schema of mobile specific features usage
  */
@@ -928,6 +928,13 @@ export interface SourceCodeContext {
      * DD_SOURCE_CODE_CONTEXT global for microfrontends
      */
     feature: 'source-code-context';
+    [k: string]: unknown;
+}
+export interface SalesforceLwc {
+    /**
+     * Salesforce LWC integration
+     */
+    feature: 'salesforce-lwc';
     [k: string]: unknown;
 }
 export interface TrackWebView {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -507,7 +507,7 @@ export type TelemetryCommonFeaturesUsage = SetTrackingConsent | StopSession | St
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource | SourceCodeContext;
+export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartDurationVital | StopDurationVital | AddDurationVital | StartAction | StopAction | StartResource | StopResource | SourceCodeContext | SalesforceLwc;
 /**
  * Schema of mobile specific features usage
  */
@@ -928,6 +928,13 @@ export interface SourceCodeContext {
      * DD_SOURCE_CODE_CONTEXT global for microfrontends
      */
     feature: 'source-code-context';
+    [k: string]: unknown;
+}
+export interface SalesforceLwc {
+    /**
+     * Salesforce LWC integration
+     */
+    feature: 'salesforce-lwc';
     [k: string]: unknown;
 }
 export interface TrackWebView {

--- a/schemas/telemetry/usage/browser-features-schema.json
+++ b/schemas/telemetry/usage/browser-features-schema.json
@@ -107,6 +107,17 @@
           "const": "source-code-context"
         }
       }
+    },
+    {
+      "required": ["feature"],
+      "title": "SalesforceLwc",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "Salesforce LWC integration",
+          "const": "salesforce-lwc"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds salesforce-lwc to browser SDK telemetry.

So we can do `addTelemetryUsage({ feature: salesforce-lwc })`