### PR TITLE
Add `beta_track_web_sockets` to telemetry configuration schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -477,6 +477,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the beta partial view updates feature is enabled
              */
             beta_enable_view_updates?: boolean;
+            /**
+             * Whether the beta track WebSockets feature is enabled
+             */
+            beta_track_web_sockets?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -477,6 +477,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the beta partial view updates feature is enabled
              */
             beta_enable_view_updates?: boolean;
+            /**
+             * Whether the beta track WebSockets feature is enabled
+             */
+            beta_track_web_sockets?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -535,6 +535,11 @@
                   "type": "boolean",
                   "description": "Whether the beta partial view updates feature is enabled",
                   "readOnly": false
+                },
+                "beta_track_web_sockets": {
+                  "type": "boolean",
+                  "description": "Whether the beta track WebSockets feature is enabled",
+                  "readOnly": false
                 }
               }
             }


### PR DESCRIPTION
## Summary
- Add `beta_track_web_sockets` boolean field to the telemetry configuration schema
- Regenerate the corresponding CJS/ESM TypeScript declarations

## Test plan
- [ ] CI schema validation passes