### PR TITLE
RUM-17207 Add local_cache_hit field to resource event schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -779,6 +779,10 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
+         * Mobile-only: indicates the resource was served from the device's local cache. Only ever sent as `true`; absence means not a local cache hit.
+         */
+        readonly local_cache_hit?: boolean;
+        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -779,7 +779,7 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
-         * Mobile-only: indicates the resource was served from the device's local cache. Only ever sent as `true`; absence means not a local cache hit.
+         * Whether the resource was served from the device's local cache
          */
         readonly local_cache_hit?: boolean;
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -779,6 +779,10 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
+         * Mobile-only: indicates the resource was served from the device's local cache. Only ever sent as `true`; absence means not a local cache hit.
+         */
+        readonly local_cache_hit?: boolean;
+        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -779,7 +779,7 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
-         * Mobile-only: indicates the resource was served from the device's local cache. Only ever sent as `true`; absence means not a local cache hit.
+         * Whether the resource was served from the device's local cache
          */
         readonly local_cache_hit?: boolean;
         /**

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -244,6 +244,11 @@
               "enum": ["cache", "navigational-prefetch", "other"],
               "readOnly": true
             },
+            "local_cache_hit": {
+              "type": "boolean",
+              "description": "Mobile-only: indicates the resource was served from the device's local cache. Only ever sent as `true`; absence means not a local cache hit.",
+              "readOnly": true
+            },
             "provider": {
               "type": "object",
               "description": "The provider for this resource",

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -246,7 +246,7 @@
             },
             "local_cache_hit": {
               "type": "boolean",
-              "description": "Mobile-only: indicates the resource was served from the device's local cache. Only ever sent as `true`; absence means not a local cache hit.",
+              "description": "Whether the resource was served from the device's local cache",
               "readOnly": true
             },
             "provider": {


### PR DESCRIPTION
### What and why?

Adds an optional, read-only `local_cache_hit` boolean field to the Resource so mobile SDKs can report when a resource was served from the device's local cache. The RUM backend has accepted `resource.local_cache_hit == true` as an input signal since 15/06 (to set `cache_reason = local_cache`), but no SDK can send it yet since the field doesn't exist in the schema.