### PR TITLE
[RUM-17395] Add debug_id support to browser profiler trace resources

### DIFF
--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -140,6 +140,10 @@ export interface BrowserProfilerTrace {
      */
     readonly resources: string[];
     /**
+     * Mapping of profiler resources to their debug IDs for source map deobfuscation.
+     */
+    readonly debugIds?: RumProfilerDebugIdEntry[];
+    /**
      * An array of profiler frames.
      */
     readonly frames: ProfilerFrame[];
@@ -174,6 +178,20 @@ export interface BrowserProfilerTrace {
      * List of detected navigation entries.
      */
     readonly views: RumViewEntry[];
+    [k: string]: unknown;
+}
+/**
+ * Association between a profiler resource and its debug ID.
+ */
+export interface RumProfilerDebugIdEntry {
+    /**
+     * Index in the trace.resources array.
+     */
+    readonly resourceId: number;
+    /**
+     * Debug ID (UUID) for the resource, used for source map deobfuscation.
+     */
+    readonly debugId: string;
     [k: string]: unknown;
 }
 /**

--- a/lib/cjs/generated/browserProfiling.d.ts
+++ b/lib/cjs/generated/browserProfiling.d.ts
@@ -142,7 +142,7 @@ export interface BrowserProfilerTrace {
     /**
      * Mapping of profiler resources to their debug IDs for source map deobfuscation.
      */
-    readonly debugIds?: RumProfilerDebugIdEntry[];
+    readonly debugIds?: ResourceDebugId[];
     /**
      * An array of profiler frames.
      */
@@ -183,7 +183,7 @@ export interface BrowserProfilerTrace {
 /**
  * Association between a profiler resource and its debug ID.
  */
-export interface RumProfilerDebugIdEntry {
+export interface ResourceDebugId {
     /**
      * Index in the trace.resources array.
      */

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -140,6 +140,10 @@ export interface BrowserProfilerTrace {
      */
     readonly resources: string[];
     /**
+     * Mapping of profiler resources to their debug IDs for source map deobfuscation.
+     */
+    readonly debugIds?: RumProfilerDebugIdEntry[];
+    /**
      * An array of profiler frames.
      */
     readonly frames: ProfilerFrame[];
@@ -174,6 +178,20 @@ export interface BrowserProfilerTrace {
      * List of detected navigation entries.
      */
     readonly views: RumViewEntry[];
+    [k: string]: unknown;
+}
+/**
+ * Association between a profiler resource and its debug ID.
+ */
+export interface RumProfilerDebugIdEntry {
+    /**
+     * Index in the trace.resources array.
+     */
+    readonly resourceId: number;
+    /**
+     * Debug ID (UUID) for the resource, used for source map deobfuscation.
+     */
+    readonly debugId: string;
     [k: string]: unknown;
 }
 /**

--- a/lib/esm/generated/browserProfiling.d.ts
+++ b/lib/esm/generated/browserProfiling.d.ts
@@ -142,7 +142,7 @@ export interface BrowserProfilerTrace {
     /**
      * Mapping of profiler resources to their debug IDs for source map deobfuscation.
      */
-    readonly debugIds?: RumProfilerDebugIdEntry[];
+    readonly debugIds?: ResourceDebugId[];
     /**
      * An array of profiler frames.
      */
@@ -183,7 +183,7 @@ export interface BrowserProfilerTrace {
 /**
  * Association between a profiler resource and its debug ID.
  */
-export interface RumProfilerDebugIdEntry {
+export interface ResourceDebugId {
     /**
      * Index in the trace.resources array.
      */

--- a/samples/profiling/browser/profiler-trace/profiler-trace.json
+++ b/samples/profiling/browser/profiler-trace/profiler-trace.json
@@ -1,5 +1,11 @@
 {
   "resources": ["https://localhost:58682/assets/index-CiZoFVPd.js"],
+  "debugIds": [
+    {
+      "resourceId": 0,
+      "debugId": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21"
+    }
+  ],
   "frames": [
     {
       "name": "R2",

--- a/schemas/profiling/browser/profiler-trace-schema.json
+++ b/schemas/profiling/browser/profiler-trace-schema.json
@@ -181,8 +181,8 @@
         }
       }
     },
-    "DebugIdEntry": {
-      "title": "RumProfilerDebugIdEntry",
+    "ResourceDebugId": {
+      "title": "ResourceDebugId",
       "type": "object",
       "description": "Association between a profiler resource and its debug ID.",
       "required": ["resourceId", "debugId"],
@@ -234,7 +234,7 @@
     "debugIds": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/DebugIdEntry"
+        "$ref": "#/definitions/ResourceDebugId"
       },
       "description": "Mapping of profiler resources to their debug IDs for source map deobfuscation.",
       "readOnly": true

--- a/schemas/profiling/browser/profiler-trace-schema.json
+++ b/schemas/profiling/browser/profiler-trace-schema.json
@@ -181,6 +181,25 @@
         }
       }
     },
+    "DebugIdEntry": {
+      "title": "RumProfilerDebugIdEntry",
+      "type": "object",
+      "description": "Association between a profiler resource and its debug ID.",
+      "required": ["resourceId", "debugId"],
+      "properties": {
+        "resourceId": {
+          "type": "integer",
+          "description": "Index in the trace.resources array.",
+          "readOnly": true
+        },
+        "debugId": {
+          "type": "string",
+          "description": "Debug ID (UUID) for the resource, used for source map deobfuscation.",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        }
+      }
+    },
     "ViewEntry": {
       "title": "RumViewEntry",
       "type": "object",
@@ -210,6 +229,14 @@
         "type": "string"
       },
       "description": "An array of profiler resources.",
+      "readOnly": true
+    },
+    "debugIds": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DebugIdEntry"
+      },
+      "description": "Mapping of profiler resources to their debug IDs for source map deobfuscation.",
       "readOnly": true
     },
     "frames": {


### PR DESCRIPTION
## Summary
Adds an optional `debugIds` array to the browser profiler trace schema (wall-time.json), mapping `resourceId` → `debugId` (UUID), so profiler stack frames can be un-minified across micro frontends 

## Test plan
- [x] `yarn build` regenerates types successfully
- [x] `yarn validate` passes for all samples