### PR TITLE
Juan.naranjo/flutter embedded view schema

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -51,15 +51,23 @@ export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe | EmbeddedContentWireframe;
+export type Wireframe = EmbeddedContentWireframe | ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
- * Schema of all properties of a ShapeWireframe.
+ * Schema of all properties of an EmbeddedContentWireframe.
  */
-export type ShapeWireframe = CommonShapeWireframe & {
+export type EmbeddedContentWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
-    readonly type: 'shape';
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
     /**
      * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
@@ -109,6 +117,19 @@ export type ShapeBorder = {
      * The width of the border in pixels.
      */
     readonly width: number;
+};
+/**
+ * Schema of all properties of a ShapeWireframe.
+ */
+export type ShapeWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextWireframe.
@@ -251,27 +272,6 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
- * Schema of all properties of an EmbeddedContentWireframe.
- */
-export type EmbeddedContentWireframe = CommonShapeWireframe & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
-     */
-    readonly isVisible?: boolean;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
-};
-/**
  * A rendering modifier applied to the composed layer output.
  */
 export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
@@ -301,7 +301,31 @@ export type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate | EmbeddedContentWireframeUpdate;
+export type WireframeUpdateMutation = EmbeddedContentWireframeUpdate | TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+/**
+ * Schema of all properties of an EmbeddedContentWireframeUpdate.
+ */
+export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
+};
+/**
+ * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
+ */
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+    shapeStyle?: ShapeStyle;
+    border?: ShapeBorder;
+};
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -316,13 +340,6 @@ export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     text?: string;
     textStyle?: TextStyle;
     textPosition?: TextPosition;
-};
-/**
- * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
- */
-export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
-    shapeStyle?: ShapeStyle;
-    border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
@@ -385,23 +402,6 @@ export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     readonly slotId: string;
     /**
      * Whether this webview is visible or not.
-     */
-    readonly isVisible?: boolean;
-};
-/**
- * Schema of all properties of an EmbeddedContentWireframeUpdate.
- */
-export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
      */
     readonly isVisible?: boolean;
 };

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -609,15 +609,23 @@ export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe | EmbeddedContentWireframe;
+export type Wireframe = EmbeddedContentWireframe | ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
- * Schema of all properties of a ShapeWireframe.
+ * Schema of all properties of an EmbeddedContentWireframe.
  */
-export type ShapeWireframe = CommonShapeWireframe & {
+export type EmbeddedContentWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
-    readonly type: 'shape';
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
     /**
      * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
@@ -667,6 +675,19 @@ export type ShapeBorder = {
      * The width of the border in pixels.
      */
     readonly width: number;
+};
+/**
+ * Schema of all properties of a ShapeWireframe.
+ */
+export type ShapeWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextWireframe.
@@ -809,27 +830,6 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
- * Schema of all properties of an EmbeddedContentWireframe.
- */
-export type EmbeddedContentWireframe = CommonShapeWireframe & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
-     */
-    readonly isVisible?: boolean;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
-};
-/**
  * A rendering modifier applied to the composed layer output.
  */
 export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
@@ -859,7 +859,31 @@ export type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate | EmbeddedContentWireframeUpdate;
+export type WireframeUpdateMutation = EmbeddedContentWireframeUpdate | TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+/**
+ * Schema of all properties of an EmbeddedContentWireframeUpdate.
+ */
+export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
+};
+/**
+ * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
+ */
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+    shapeStyle?: ShapeStyle;
+    border?: ShapeBorder;
+};
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -874,13 +898,6 @@ export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     text?: string;
     textStyle?: TextStyle;
     textPosition?: TextPosition;
-};
-/**
- * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
- */
-export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
-    shapeStyle?: ShapeStyle;
-    border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
@@ -943,23 +960,6 @@ export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     readonly slotId: string;
     /**
      * Whether this webview is visible or not.
-     */
-    readonly isVisible?: boolean;
-};
-/**
- * Schema of all properties of an EmbeddedContentWireframeUpdate.
- */
-export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
      */
     readonly isVisible?: boolean;
 };

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -51,15 +51,23 @@ export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe | EmbeddedContentWireframe;
+export type Wireframe = EmbeddedContentWireframe | ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
- * Schema of all properties of a ShapeWireframe.
+ * Schema of all properties of an EmbeddedContentWireframe.
  */
-export type ShapeWireframe = CommonShapeWireframe & {
+export type EmbeddedContentWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
-    readonly type: 'shape';
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
     /**
      * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
@@ -109,6 +117,19 @@ export type ShapeBorder = {
      * The width of the border in pixels.
      */
     readonly width: number;
+};
+/**
+ * Schema of all properties of a ShapeWireframe.
+ */
+export type ShapeWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextWireframe.
@@ -251,27 +272,6 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
- * Schema of all properties of an EmbeddedContentWireframe.
- */
-export type EmbeddedContentWireframe = CommonShapeWireframe & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
-     */
-    readonly isVisible?: boolean;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
-};
-/**
  * A rendering modifier applied to the composed layer output.
  */
 export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
@@ -301,7 +301,31 @@ export type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate | EmbeddedContentWireframeUpdate;
+export type WireframeUpdateMutation = EmbeddedContentWireframeUpdate | TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+/**
+ * Schema of all properties of an EmbeddedContentWireframeUpdate.
+ */
+export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
+};
+/**
+ * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
+ */
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+    shapeStyle?: ShapeStyle;
+    border?: ShapeBorder;
+};
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -316,13 +340,6 @@ export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     text?: string;
     textStyle?: TextStyle;
     textPosition?: TextPosition;
-};
-/**
- * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
- */
-export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
-    shapeStyle?: ShapeStyle;
-    border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
@@ -385,23 +402,6 @@ export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     readonly slotId: string;
     /**
      * Whether this webview is visible or not.
-     */
-    readonly isVisible?: boolean;
-};
-/**
- * Schema of all properties of an EmbeddedContentWireframeUpdate.
- */
-export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
      */
     readonly isVisible?: boolean;
 };

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -609,15 +609,23 @@ export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
 /**
  * Schema of a Wireframe type.
  */
-export type Wireframe = ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe | EmbeddedContentWireframe;
+export type Wireframe = EmbeddedContentWireframe | ShapeWireframe | TextWireframe | ImageWireframe | PlaceholderWireframe | WebviewWireframe;
 /**
- * Schema of all properties of a ShapeWireframe.
+ * Schema of all properties of an EmbeddedContentWireframe.
  */
-export type ShapeWireframe = CommonShapeWireframe & {
+export type EmbeddedContentWireframe = CommonShapeWireframe & {
     /**
      * The type of the wireframe.
      */
-    readonly type: 'shape';
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
     /**
      * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
      */
@@ -667,6 +675,19 @@ export type ShapeBorder = {
      * The width of the border in pixels.
      */
     readonly width: number;
+};
+/**
+ * Schema of all properties of a ShapeWireframe.
+ */
+export type ShapeWireframe = CommonShapeWireframe & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'shape';
+    /**
+     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
+     */
+    readonly permanentId?: string;
 };
 /**
  * Schema of all properties of a TextWireframe.
@@ -809,27 +830,6 @@ export type WebviewWireframe = CommonShapeWireframe & {
     readonly permanentId?: string;
 };
 /**
- * Schema of all properties of an EmbeddedContentWireframe.
- */
-export type EmbeddedContentWireframe = CommonShapeWireframe & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
-     */
-    readonly isVisible?: boolean;
-    /**
-     * A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
-     */
-    readonly permanentId?: string;
-};
-/**
  * A rendering modifier applied to the composed layer output.
  */
 export type CompositionLayerModifier = CompositionLayerClipModifier | CompositionLayerOpacityModifier | CompositionLayerColorMatrixModifier | CompositionLayerGaussianBlurModifier | CompositionLayerShadowModifier | CompositionLayerBrightnessBiasModifier | CompositionLayerSaturateModifier | CompositionLayerBackgroundMaterialModifier | CompositionLayerMaskImageModifier;
@@ -859,7 +859,31 @@ export type MobileMutationData = {
 /**
  * Schema of a WireframeUpdateMutation type.
  */
-export type WireframeUpdateMutation = TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate | EmbeddedContentWireframeUpdate;
+export type WireframeUpdateMutation = EmbeddedContentWireframeUpdate | TextWireframeUpdate | ShapeWireframeUpdate | ImageWireframeUpdate | PlaceholderWireframeUpdate | WebviewWireframeUpdate;
+/**
+ * Schema of all properties of an EmbeddedContentWireframeUpdate.
+ */
+export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
+    /**
+     * The type of the wireframe.
+     */
+    readonly type: 'embedded_content';
+    /**
+     * Unique Id of the slot containing this embedded content.
+     */
+    readonly slotId: string;
+    /**
+     * Whether this embedded content is visible or not.
+     */
+    readonly isVisible?: boolean;
+};
+/**
+ * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
+ */
+export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
+    shapeStyle?: ShapeStyle;
+    border?: ShapeBorder;
+};
 /**
  * Schema of all properties of a TextWireframeUpdate.
  */
@@ -874,13 +898,6 @@ export type TextWireframeUpdate = CommonShapeWireframeUpdate & {
     text?: string;
     textStyle?: TextStyle;
     textPosition?: TextPosition;
-};
-/**
- * Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.
- */
-export type CommonShapeWireframeUpdate = CommonWireframeUpdate & {
-    shapeStyle?: ShapeStyle;
-    border?: ShapeBorder;
 };
 /**
  * Schema of a ShapeWireframeUpdate.
@@ -943,23 +960,6 @@ export type WebviewWireframeUpdate = CommonShapeWireframeUpdate & {
     readonly slotId: string;
     /**
      * Whether this webview is visible or not.
-     */
-    readonly isVisible?: boolean;
-};
-/**
- * Schema of all properties of an EmbeddedContentWireframeUpdate.
- */
-export type EmbeddedContentWireframeUpdate = CommonShapeWireframeUpdate & {
-    /**
-     * The type of the wireframe.
-     */
-    readonly type: 'embedded_content';
-    /**
-     * Unique Id of the slot containing this embedded content.
-     */
-    readonly slotId: string;
-    /**
-     * Whether this embedded content is visible or not.
      */
     readonly isVisible?: boolean;
 };

--- a/schemas/session-replay/mobile/wireframe-schema.json
+++ b/schemas/session-replay/mobile/wireframe-schema.json
@@ -6,6 +6,9 @@
   "description": "Schema of a Wireframe type.",
   "oneOf": [
     {
+      "$ref": "embedded-content-wireframe-schema.json"
+    },
+    {
       "$ref": "shape-wireframe-schema.json"
     },
     {
@@ -19,9 +22,6 @@
     },
     {
       "$ref": "webview-wireframe-schema.json"
-    },
-    {
-      "$ref": "embedded-content-wireframe-schema.json"
     }
   ]
 }

--- a/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
+++ b/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
@@ -6,6 +6,9 @@
   "description": "Schema of a WireframeUpdateMutation type.",
   "oneOf": [
     {
+      "$ref": "embedded-content-wireframe-update-schema.json"
+    },
+    {
       "$ref": "text-wireframe-update-schema.json"
     },
     {
@@ -19,9 +22,6 @@
     },
     {
       "$ref": "webview-wireframe-update-schema.json"
-    },
-    {
-      "$ref": "embedded-content-wireframe-update-schema.json"
     }
   ]
 }


### PR DESCRIPTION
**What and why?**

Reorders the oneOf entries for embedded-content-wireframe(-update)-schema.json in wireframe-schema.json and wireframe-update-mutation-schema.json, moving them to the front of the list instead of the end.

Generated Swift/Kotlin decoders try each oneOf case in declaration order and keep the first one that successfully decodes. SRShapeWireframe's required fields are a strict subset of SREmbeddedContentWireframe's, so with embedded-content listed last, an embedded-content payload was being matched and decoded as a generic shape wireframe first — silently dropping its required slotId and corrupting the type field. This broke any round-trip decode of an embedded-content wireframe (e.g. Flutter add-to-app placeholders), even though encoding was always correct.

**How?**

Moved the embedded-content-wireframe-schema.json ref to the first position in wireframe-schema.json's oneOf array, and embedded-content-wireframe-update-schema.json to the first position in wireframe-update-mutation-schema.json's oneOf array, so they're tried before the generic shape/text/image/placeholder/webview cases that would otherwise shadow them. No schema field changes — ordering only.