### PR TITLE
Merge Timeseries schema

### DIFF
--- a/schemas/rum-events-mobile-schema.json
+++ b/schemas/rum-events-mobile-schema.json
@@ -39,6 +39,17 @@
     },
     {
       "$ref": "telemetry-events-schema.json"
+    },
+    {
+      "title": "RumTimeseriesEvent",
+      "oneOf": [
+        {
+          "$ref": "rum/timeseries-memory-schema.json"
+        },
+        {
+          "$ref": "rum/timeseries-cpu-schema.json"
+        }
+      ]
     }
   ]
 }

--- a/schemas/rum/timeseries-cpu-schema.json
+++ b/schemas/rum/timeseries-cpu-schema.json
@@ -105,6 +105,7 @@
         "name": {
           "type": "string",
           "description": "Name identifying the timeseries metric",
+          "const": "cpu",
           "readOnly": true
         },
         "schema": {

--- a/schemas/rum/timeseries-cpu-schema.json
+++ b/schemas/rum/timeseries-cpu-schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/timeseries-cpu-schema.json",
+  "title": "RumTimeseriesCpuEvent",
+  "type": "object",
+  "description": "Schema for a CPU timeseries event.",
+  "required": ["_dd", "application", "date", "session", "source", "timeseries", "type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "RUM event type",
+      "const": "timeseries",
+      "readOnly": true
+    },
+    "_dd": {
+      "type": "object",
+      "description": "Internal properties",
+      "required": ["format_version"],
+      "properties": {
+        "format_version": {
+          "type": "integer",
+          "const": 2,
+          "description": "Version of the RUM event format",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "application": {
+      "type": "object",
+      "description": "Application properties",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the application",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "session": {
+      "type": "object",
+      "description": "Session properties",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the session",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the session",
+          "enum": ["user", "synthetics", "ci_test"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "source": {
+      "type": "string",
+      "description": "The source of this event",
+      "enum": [
+        "android",
+        "ios",
+        "browser",
+        "flutter",
+        "react-native",
+        "roku",
+        "unity",
+        "kotlin-multiplatform",
+        "electron",
+        "rum-cpp"
+      ],
+      "readOnly": true
+    },
+    "date": {
+      "type": "integer",
+      "description": "Start of the event in ms from epoch",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "service": {
+      "type": "string",
+      "description": "The service name for this application"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version for this application"
+    },
+    "timeseries": {
+      "type": "object",
+      "description": "CPU timeseries properties",
+      "required": ["id", "name", "start", "end", "data"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the timeseries batch",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name identifying the timeseries metric",
+          "readOnly": true
+        },
+        "start": {
+          "type": "integer",
+          "description": "Timestamp of the first sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "end": {
+          "type": "integer",
+          "description": "Timestamp of the last sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "data": {
+          "type": "array",
+          "description": "Array of CPU data points",
+          "items": {
+            "type": "object",
+            "description": "A single CPU data point",
+            "required": ["timestamp", "data_point"],
+            "properties": {
+              "timestamp": {
+                "type": "integer",
+                "description": "Sample timestamp in nanoseconds from epoch",
+                "readOnly": true
+              },
+              "data_point": {
+                "type": "object",
+                "description": "CPU measurements for this sample",
+                "required": ["cpu_usage"],
+                "properties": {
+                  "cpu_usage": {
+                    "type": "number",
+                    "description": "CPU usage as a percentage (0.0 to 100.0)",
+                    "readOnly": true
+                  }
+                },
+                "readOnly": true
+              }
+            },
+            "readOnly": true
+          },
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/timeseries-cpu-schema.json
+++ b/schemas/rum/timeseries-cpu-schema.json
@@ -94,7 +94,7 @@
     "timeseries": {
       "type": "object",
       "description": "CPU timeseries properties",
-      "required": ["id", "name", "start", "end", "data"],
+      "required": ["id", "name", "schema", "start", "end", "data"],
       "properties": {
         "id": {
           "type": "string",
@@ -105,6 +105,12 @@
         "name": {
           "type": "string",
           "description": "Name identifying the timeseries metric",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Wire-shape discriminator for the data field",
+          "enum": ["object", "delta-scalar"],
           "readOnly": true
         },
         "start": {

--- a/schemas/rum/timeseries-cpu-schema.json
+++ b/schemas/rum/timeseries-cpu-schema.json
@@ -4,151 +4,80 @@
   "title": "RumTimeseriesCpuEvent",
   "type": "object",
   "description": "Schema for a CPU timeseries event.",
-  "required": ["_dd", "application", "date", "session", "source", "timeseries", "type"],
-  "properties": {
-    "type": {
-      "type": "string",
-      "description": "RUM event type",
-      "const": "timeseries",
-      "readOnly": true
+  "allOf": [
+    {
+      "$ref": "_common-schema.json"
     },
-    "_dd": {
-      "type": "object",
-      "description": "Internal properties",
-      "required": ["format_version"],
+    {
+      "required": ["type", "timeseries"],
       "properties": {
-        "format_version": {
-          "type": "integer",
-          "const": 2,
-          "description": "Version of the RUM event format",
-          "readOnly": true
-        }
-      },
-      "readOnly": true
-    },
-    "application": {
-      "type": "object",
-      "description": "Application properties",
-      "required": ["id"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "UUID of the application",
-          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-          "readOnly": true
-        }
-      },
-      "readOnly": true
-    },
-    "session": {
-      "type": "object",
-      "description": "Session properties",
-      "required": ["id", "type"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "UUID of the session",
-          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-          "readOnly": true
-        },
         "type": {
           "type": "string",
-          "description": "Type of the session",
-          "enum": ["user", "synthetics", "ci_test"],
-          "readOnly": true
-        }
-      },
-      "readOnly": true
-    },
-    "source": {
-      "type": "string",
-      "description": "The source of this event",
-      "enum": [
-        "android",
-        "ios",
-        "browser",
-        "flutter",
-        "react-native",
-        "roku",
-        "unity",
-        "kotlin-multiplatform",
-        "electron",
-        "rum-cpp"
-      ],
-      "readOnly": true
-    },
-    "date": {
-      "type": "integer",
-      "description": "Start of the event in ms from epoch",
-      "minimum": 0,
-      "readOnly": true
-    },
-    "service": {
-      "type": "string",
-      "description": "The service name for this application"
-    },
-    "version": {
-      "type": "string",
-      "description": "The version for this application"
-    },
-    "timeseries": {
-      "type": "object",
-      "description": "CPU timeseries properties",
-      "required": ["id", "name", "schema", "start", "end", "data"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "UUID of the timeseries batch",
-          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "description": "RUM event type",
+          "const": "timeseries",
           "readOnly": true
         },
-        "name": {
-          "type": "string",
-          "description": "Name identifying the timeseries metric",
-          "const": "cpu",
-          "readOnly": true
-        },
-        "schema": {
-          "type": "string",
-          "description": "Wire-shape discriminator for the data field",
-          "const": "object-v2",
-          "readOnly": true
-        },
-        "start": {
-          "type": "integer",
-          "description": "Timestamp of the first sample in nanoseconds from epoch",
-          "readOnly": true
-        },
-        "end": {
-          "type": "integer",
-          "description": "Timestamp of the last sample in nanoseconds from epoch",
-          "readOnly": true
-        },
-        "data": {
+        "timeseries": {
           "type": "object",
-          "description": "Flattened CPU data points",
-          "required": ["timestamps", "values"],
+          "description": "CPU timeseries properties",
+          "required": ["id", "name", "schema", "start", "end", "data"],
           "properties": {
-            "timestamps": {
-              "type": "array",
-              "description": "Sample timestamps in nanoseconds from epoch",
-              "items": {
-                "type": "integer",
-                "readOnly": true
-              },
+            "id": {
+              "type": "string",
+              "description": "UUID of the timeseries batch",
+              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
               "readOnly": true
             },
-            "values": {
+            "name": {
+              "type": "string",
+              "description": "Name identifying the timeseries metric",
+              "const": "cpu",
+              "readOnly": true
+            },
+            "schema": {
+              "type": "string",
+              "description": "Wire-shape discriminator for the data field",
+              "const": "object-v2",
+              "readOnly": true
+            },
+            "start": {
+              "type": "integer",
+              "description": "Timestamp of the first sample in nanoseconds from epoch",
+              "readOnly": true
+            },
+            "end": {
+              "type": "integer",
+              "description": "Timestamp of the last sample in nanoseconds from epoch",
+              "readOnly": true
+            },
+            "data": {
               "type": "object",
-              "description": "CPU measurements, aligned index-for-index with timestamps",
-              "required": ["cpu_usage"],
+              "description": "Flattened CPU data points",
+              "required": ["timestamps", "values"],
               "properties": {
-                "cpu_usage": {
+                "timestamps": {
                   "type": "array",
-                  "description": "CPU usage as a percentage (0.0 to 100.0)",
+                  "description": "Sample timestamps in nanoseconds from epoch",
                   "items": {
-                    "type": "number",
+                    "type": "integer",
                     "readOnly": true
+                  },
+                  "readOnly": true
+                },
+                "values": {
+                  "type": "object",
+                  "description": "CPU measurements, aligned index-for-index with timestamps",
+                  "required": ["cpu_usage"],
+                  "properties": {
+                    "cpu_usage": {
+                      "type": "array",
+                      "description": "CPU usage as a percentage (0.0 to 100.0)",
+                      "items": {
+                        "type": "number",
+                        "readOnly": true
+                      },
+                      "readOnly": true
+                    }
                   },
                   "readOnly": true
                 }
@@ -158,8 +87,7 @@
           },
           "readOnly": true
         }
-      },
-      "readOnly": true
+      }
     }
-  }
+  ]
 }

--- a/schemas/rum/timeseries-cpu-schema.json
+++ b/schemas/rum/timeseries-cpu-schema.json
@@ -111,7 +111,7 @@
         "schema": {
           "type": "string",
           "description": "Wire-shape discriminator for the data field",
-          "enum": ["object", "delta-scalar"],
+          "const": "object-v2",
           "readOnly": true
         },
         "start": {
@@ -125,33 +125,36 @@
           "readOnly": true
         },
         "data": {
-          "type": "array",
-          "description": "Array of CPU data points",
-          "items": {
-            "type": "object",
-            "description": "A single CPU data point",
-            "required": ["timestamp", "data_point"],
-            "properties": {
-              "timestamp": {
+          "type": "object",
+          "description": "Flattened CPU data points",
+          "required": ["timestamps", "values"],
+          "properties": {
+            "timestamps": {
+              "type": "array",
+              "description": "Sample timestamps in nanoseconds from epoch",
+              "items": {
                 "type": "integer",
-                "description": "Sample timestamp in nanoseconds from epoch",
                 "readOnly": true
               },
-              "data_point": {
-                "type": "object",
-                "description": "CPU measurements for this sample",
-                "required": ["cpu_usage"],
-                "properties": {
-                  "cpu_usage": {
-                    "type": "number",
-                    "description": "CPU usage as a percentage (0.0 to 100.0)",
-                    "readOnly": true
-                  }
-                },
-                "readOnly": true
-              }
+              "readOnly": true
             },
-            "readOnly": true
+            "values": {
+              "type": "object",
+              "description": "CPU measurements, aligned index-for-index with timestamps",
+              "required": ["cpu_usage"],
+              "properties": {
+                "cpu_usage": {
+                  "type": "array",
+                  "description": "CPU usage as a percentage (0.0 to 100.0)",
+                  "items": {
+                    "type": "number",
+                    "readOnly": true
+                  },
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            }
           },
           "readOnly": true
         }

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -105,6 +105,7 @@
         "name": {
           "type": "string",
           "description": "Name identifying the timeseries metric",
+          "const": "memory",
           "readOnly": true
         },
         "schema": {

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -94,7 +94,7 @@
     "timeseries": {
       "type": "object",
       "description": "Memory timeseries properties",
-      "required": ["id", "name", "start", "end", "data"],
+      "required": ["id", "name", "schema", "start", "end", "data"],
       "properties": {
         "id": {
           "type": "string",
@@ -105,6 +105,12 @@
         "name": {
           "type": "string",
           "description": "Name identifying the timeseries metric",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Wire-shape discriminator for the data field",
+          "enum": ["object", "delta-object"],
           "readOnly": true
         },
         "start": {

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/timeseries-memory-schema.json",
+  "title": "RumTimeseriesMemoryEvent",
+  "type": "object",
+  "description": "Schema for a memory timeseries event.",
+  "required": ["_dd", "application", "date", "session", "source", "timeseries", "type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "RUM event type",
+      "const": "timeseries",
+      "readOnly": true
+    },
+    "_dd": {
+      "type": "object",
+      "description": "Internal properties",
+      "required": ["format_version"],
+      "properties": {
+        "format_version": {
+          "type": "integer",
+          "const": 2,
+          "description": "Version of the RUM event format",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "application": {
+      "type": "object",
+      "description": "Application properties",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the application",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "session": {
+      "type": "object",
+      "description": "Session properties",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the session",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the session",
+          "enum": ["user", "synthetics", "ci_test"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "source": {
+      "type": "string",
+      "description": "The source of this event",
+      "enum": [
+        "android",
+        "ios",
+        "browser",
+        "flutter",
+        "react-native",
+        "roku",
+        "unity",
+        "kotlin-multiplatform",
+        "electron",
+        "rum-cpp"
+      ],
+      "readOnly": true
+    },
+    "date": {
+      "type": "integer",
+      "description": "Start of the event in ms from epoch",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "service": {
+      "type": "string",
+      "description": "The service name for this application"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version for this application"
+    },
+    "timeseries": {
+      "type": "object",
+      "description": "Memory timeseries properties",
+      "required": ["id", "name", "start", "end", "data"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the timeseries batch",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name identifying the timeseries metric",
+          "readOnly": true
+        },
+        "start": {
+          "type": "integer",
+          "description": "Timestamp of the first sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "end": {
+          "type": "integer",
+          "description": "Timestamp of the last sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "data": {
+          "type": "array",
+          "description": "Array of memory data points",
+          "items": {
+            "type": "object",
+            "description": "A single memory data point",
+            "required": ["timestamp", "data_point"],
+            "properties": {
+              "timestamp": {
+                "type": "integer",
+                "description": "Sample timestamp in nanoseconds from epoch",
+                "readOnly": true
+              },
+              "data_point": {
+                "type": "object",
+                "description": "Memory measurements for this sample",
+                "required": ["memory_max", "memory_percent"],
+                "properties": {
+                  "memory_max": {
+                    "type": "number",
+                    "description": "Physical memory footprint of the process in bytes",
+                    "readOnly": true
+                  },
+                  "memory_percent": {
+                    "type": "number",
+                    "description": "Memory footprint as a percentage of total device RAM",
+                    "readOnly": true
+                  }
+                },
+                "readOnly": true
+              }
+            },
+            "readOnly": true
+          },
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -140,9 +140,9 @@
               "data_point": {
                 "type": "object",
                 "description": "Memory measurements for this sample",
-                "required": ["memory_max", "memory_percent"],
+                "required": ["memory_footprint", "memory_percent"],
                 "properties": {
-                  "memory_max": {
+                  "memory_footprint": {
                     "type": "number",
                     "description": "Physical memory footprint of the process in bytes",
                     "readOnly": true

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -111,7 +111,7 @@
         "schema": {
           "type": "string",
           "description": "Wire-shape discriminator for the data field",
-          "enum": ["object", "delta-object"],
+          "const": "object-v2",
           "readOnly": true
         },
         "start": {
@@ -125,38 +125,45 @@
           "readOnly": true
         },
         "data": {
-          "type": "array",
-          "description": "Array of memory data points",
-          "items": {
-            "type": "object",
-            "description": "A single memory data point",
-            "required": ["timestamp", "data_point"],
-            "properties": {
-              "timestamp": {
+          "type": "object",
+          "description": "Flattened memory data points",
+          "required": ["timestamps", "values"],
+          "properties": {
+            "timestamps": {
+              "type": "array",
+              "description": "Sample timestamps in nanoseconds from epoch",
+              "items": {
                 "type": "integer",
-                "description": "Sample timestamp in nanoseconds from epoch",
                 "readOnly": true
               },
-              "data_point": {
-                "type": "object",
-                "description": "Memory measurements for this sample",
-                "required": ["memory_footprint", "memory_percent"],
-                "properties": {
-                  "memory_footprint": {
+              "readOnly": true
+            },
+            "values": {
+              "type": "object",
+              "description": "Memory measurements, aligned index-for-index with timestamps",
+              "required": ["memory_footprint", "memory_percent"],
+              "properties": {
+                "memory_footprint": {
+                  "type": "array",
+                  "description": "Physical memory footprint of the process in kilobytes",
+                  "items": {
                     "type": "number",
-                    "description": "Physical memory footprint of the process in bytes",
                     "readOnly": true
                   },
-                  "memory_percent": {
-                    "type": "number",
-                    "description": "Memory footprint as a percentage of total device RAM",
-                    "readOnly": true
-                  }
+                  "readOnly": true
                 },
-                "readOnly": true
-              }
-            },
-            "readOnly": true
+                "memory_percent": {
+                  "type": "array",
+                  "description": "Memory footprint as a percentage of total device RAM",
+                  "items": {
+                    "type": "number",
+                    "readOnly": true
+                  },
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            }
           },
           "readOnly": true
         }

--- a/schemas/rum/timeseries-memory-schema.json
+++ b/schemas/rum/timeseries-memory-schema.json
@@ -4,160 +4,89 @@
   "title": "RumTimeseriesMemoryEvent",
   "type": "object",
   "description": "Schema for a memory timeseries event.",
-  "required": ["_dd", "application", "date", "session", "source", "timeseries", "type"],
-  "properties": {
-    "type": {
-      "type": "string",
-      "description": "RUM event type",
-      "const": "timeseries",
-      "readOnly": true
+  "allOf": [
+    {
+      "$ref": "_common-schema.json"
     },
-    "_dd": {
-      "type": "object",
-      "description": "Internal properties",
-      "required": ["format_version"],
+    {
+      "required": ["type", "timeseries"],
       "properties": {
-        "format_version": {
-          "type": "integer",
-          "const": 2,
-          "description": "Version of the RUM event format",
-          "readOnly": true
-        }
-      },
-      "readOnly": true
-    },
-    "application": {
-      "type": "object",
-      "description": "Application properties",
-      "required": ["id"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "UUID of the application",
-          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-          "readOnly": true
-        }
-      },
-      "readOnly": true
-    },
-    "session": {
-      "type": "object",
-      "description": "Session properties",
-      "required": ["id", "type"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "UUID of the session",
-          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-          "readOnly": true
-        },
         "type": {
           "type": "string",
-          "description": "Type of the session",
-          "enum": ["user", "synthetics", "ci_test"],
-          "readOnly": true
-        }
-      },
-      "readOnly": true
-    },
-    "source": {
-      "type": "string",
-      "description": "The source of this event",
-      "enum": [
-        "android",
-        "ios",
-        "browser",
-        "flutter",
-        "react-native",
-        "roku",
-        "unity",
-        "kotlin-multiplatform",
-        "electron",
-        "rum-cpp"
-      ],
-      "readOnly": true
-    },
-    "date": {
-      "type": "integer",
-      "description": "Start of the event in ms from epoch",
-      "minimum": 0,
-      "readOnly": true
-    },
-    "service": {
-      "type": "string",
-      "description": "The service name for this application"
-    },
-    "version": {
-      "type": "string",
-      "description": "The version for this application"
-    },
-    "timeseries": {
-      "type": "object",
-      "description": "Memory timeseries properties",
-      "required": ["id", "name", "schema", "start", "end", "data"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "UUID of the timeseries batch",
-          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "description": "RUM event type",
+          "const": "timeseries",
           "readOnly": true
         },
-        "name": {
-          "type": "string",
-          "description": "Name identifying the timeseries metric",
-          "const": "memory",
-          "readOnly": true
-        },
-        "schema": {
-          "type": "string",
-          "description": "Wire-shape discriminator for the data field",
-          "const": "object-v2",
-          "readOnly": true
-        },
-        "start": {
-          "type": "integer",
-          "description": "Timestamp of the first sample in nanoseconds from epoch",
-          "readOnly": true
-        },
-        "end": {
-          "type": "integer",
-          "description": "Timestamp of the last sample in nanoseconds from epoch",
-          "readOnly": true
-        },
-        "data": {
+        "timeseries": {
           "type": "object",
-          "description": "Flattened memory data points",
-          "required": ["timestamps", "values"],
+          "description": "Memory timeseries properties",
+          "required": ["id", "name", "schema", "start", "end", "data"],
           "properties": {
-            "timestamps": {
-              "type": "array",
-              "description": "Sample timestamps in nanoseconds from epoch",
-              "items": {
-                "type": "integer",
-                "readOnly": true
-              },
+            "id": {
+              "type": "string",
+              "description": "UUID of the timeseries batch",
+              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
               "readOnly": true
             },
-            "values": {
+            "name": {
+              "type": "string",
+              "description": "Name identifying the timeseries metric",
+              "const": "memory",
+              "readOnly": true
+            },
+            "schema": {
+              "type": "string",
+              "description": "Wire-shape discriminator for the data field",
+              "const": "object-v2",
+              "readOnly": true
+            },
+            "start": {
+              "type": "integer",
+              "description": "Timestamp of the first sample in nanoseconds from epoch",
+              "readOnly": true
+            },
+            "end": {
+              "type": "integer",
+              "description": "Timestamp of the last sample in nanoseconds from epoch",
+              "readOnly": true
+            },
+            "data": {
               "type": "object",
-              "description": "Memory measurements, aligned index-for-index with timestamps",
-              "required": ["memory_footprint", "memory_percent"],
+              "description": "Flattened memory data points",
+              "required": ["timestamps", "values"],
               "properties": {
-                "memory_footprint": {
+                "timestamps": {
                   "type": "array",
-                  "description": "Physical memory footprint of the process in kilobytes",
+                  "description": "Sample timestamps in nanoseconds from epoch",
                   "items": {
-                    "type": "number",
+                    "type": "integer",
                     "readOnly": true
                   },
                   "readOnly": true
                 },
-                "memory_percent": {
-                  "type": "array",
-                  "description": "Memory footprint as a percentage of total device RAM",
-                  "items": {
-                    "type": "number",
-                    "readOnly": true
+                "values": {
+                  "type": "object",
+                  "description": "Memory measurements, aligned index-for-index with timestamps",
+                  "required": ["memory_footprint", "memory_percent"],
+                  "properties": {
+                    "memory_footprint": {
+                      "type": "array",
+                      "description": "Physical memory footprint of the process in kilobytes",
+                      "items": {
+                        "type": "number",
+                        "readOnly": true
+                      },
+                      "readOnly": true
+                    },
+                    "memory_percent": {
+                      "type": "array",
+                      "description": "Memory footprint as a percentage of total device RAM",
+                      "items": {
+                        "type": "number",
+                        "readOnly": true
+                      },
+                      "readOnly": true
+                    }
                   },
                   "readOnly": true
                 }
@@ -167,8 +96,7 @@
           },
           "readOnly": true
         }
-      },
-      "readOnly": true
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
### What and why ?
Adds a new timeseries RUM event type to the schema, with two concrete event schemas: `timeseries-cpu-schema.json` and `timeseries-memory-schema.json`, registered in `rum-events-mobile-schema.json`.

This backs the new experimental mobile RUM Timeseries feature: periodic CPU and memory samples collected during a session, batched and flushed as their own event type.
