### PR TITLE
fix: Change `rum-cpp` source to `cpp`

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1065,7 +1065,7 @@ export interface CommonProperties {
     /**
      * The source of this event
      */
-    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
+    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'cpp' | 'maui';
     /**
      * View properties
      */
@@ -1391,7 +1391,7 @@ export interface ViewContainerSchema {
         /**
          * Source of the parent view
          */
-        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'cpp' | 'maui';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -545,7 +545,7 @@ export interface CommonTelemetryProperties {
     /**
      * The source of this event
      */
-    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
+    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'cpp' | 'maui';
     /**
      * The version of the SDK generating the telemetry event
      */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1065,7 +1065,7 @@ export interface CommonProperties {
     /**
      * The source of this event
      */
-    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
+    readonly source?: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'cpp' | 'maui';
     /**
      * View properties
      */
@@ -1391,7 +1391,7 @@ export interface ViewContainerSchema {
         /**
          * Source of the parent view
          */
-        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
+        readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'roku' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'cpp' | 'maui';
         [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -545,7 +545,7 @@ export interface CommonTelemetryProperties {
     /**
      * The source of this event
      */
-    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'rum-cpp' | 'maui';
+    readonly source: 'android' | 'ios' | 'browser' | 'flutter' | 'react-native' | 'unity' | 'kotlin-multiplatform' | 'electron' | 'cpp' | 'maui';
     /**
      * The version of the SDK generating the telemetry event
      */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -92,7 +92,7 @@
         "unity",
         "kotlin-multiplatform",
         "electron",
-        "rum-cpp",
+        "cpp",
         "maui"
       ],
       "readOnly": true

--- a/schemas/rum/_view-container-schema.json
+++ b/schemas/rum/_view-container-schema.json
@@ -37,7 +37,7 @@
             "unity",
             "kotlin-multiplatform",
             "electron",
-            "rum-cpp",
+            "cpp",
             "maui"
           ],
           "readOnly": true

--- a/schemas/telemetry/_common-schema.json
+++ b/schemas/telemetry/_common-schema.json
@@ -46,7 +46,7 @@
         "unity",
         "kotlin-multiplatform",
         "electron",
-        "rum-cpp",
+        "cpp",
         "maui"
       ],
       "readOnly": true


### PR DESCRIPTION
While this would normally be a breaking change, since no clients are using the `cpp` source we should be okay to make the change without a major version bump, or keeping the now deprecated `rum-cpp` naming in the schema.

refs: RUM-17831