### PR TITLE
Make view optional in the RUM common schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -94,7 +94,7 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the action starting in the foreground (focus in browser)
          */
@@ -167,6 +167,9 @@ export type RumTransitionEvent = CommonProperties & {
      * RUM event type
      */
     readonly type: 'transition';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Stream properties
      */
@@ -447,7 +450,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the error starting in the foreground (focus in browser)
          */
@@ -494,6 +497,9 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
      * RUM event type
      */
     readonly type: 'long_task';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Long Task properties
      */
@@ -624,6 +630,9 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
      * RUM event type
      */
     readonly type: 'resource';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Resource properties
      */
@@ -881,6 +890,9 @@ export type RumViewUpdateEvent = ViewContainerSchema & StreamSchema & ViewProper
      * RUM event type
      */
     readonly type: 'view_update';
+    readonly view: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 export type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent | RumVitalAppLaunchEvent;
@@ -912,6 +924,9 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
      * RUM event type
      */
     readonly type: 'vital';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Vital properties
      */
@@ -1073,7 +1088,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * UUID of the view
          */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -94,7 +94,7 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the action starting in the foreground (focus in browser)
          */
@@ -167,6 +167,9 @@ export type RumTransitionEvent = CommonProperties & {
      * RUM event type
      */
     readonly type: 'transition';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Stream properties
      */
@@ -447,7 +450,7 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
         /**
          * Is the error starting in the foreground (focus in browser)
          */
@@ -494,6 +497,9 @@ export type RumLongTaskEvent = CommonProperties & ActionChildProperties & ViewCo
      * RUM event type
      */
     readonly type: 'long_task';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Long Task properties
      */
@@ -624,6 +630,9 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
      * RUM event type
      */
     readonly type: 'resource';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Resource properties
      */
@@ -881,6 +890,9 @@ export type RumViewUpdateEvent = ViewContainerSchema & StreamSchema & ViewProper
      * RUM event type
      */
     readonly type: 'view_update';
+    readonly view: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 };
 export type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent | RumVitalAppLaunchEvent;
@@ -912,6 +924,9 @@ export type RumVitalEventCommonProperties = CommonProperties & ViewContainerSche
      * RUM event type
      */
     readonly type: 'vital';
+    readonly view: {
+        [k: string]: unknown;
+    };
     /**
      * Vital properties
      */
@@ -1073,7 +1088,7 @@ export interface CommonProperties {
     /**
      * View properties
      */
-    readonly view: {
+    readonly view?: {
         /**
          * UUID of the view
          */

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -4,7 +4,7 @@
   "title": "CommonProperties",
   "type": "object",
   "description": "Schema of common properties of RUM events",
-  "required": ["date", "application", "session", "view", "_dd"],
+  "required": ["date", "application", "session", "_dd"],
   "properties": {
     "date": {
       "type": "integer",

--- a/schemas/rum/_vital-common-schema.json
+++ b/schemas/rum/_vital-common-schema.json
@@ -12,12 +12,16 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "vital"],
+      "required": ["type", "view", "vital"],
       "properties": {
         "type": {
           "type": "string",
           "description": "RUM event type",
           "const": "vital",
+          "readOnly": true
+        },
+        "view": {
+          "type": "object",
           "readOnly": true
         },
         "vital": {

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -12,7 +12,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "action"],
+      "required": ["type", "view", "action"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "error"],
+      "required": ["type", "view", "error"],
       "properties": {
         "type": {
           "type": "string",

--- a/schemas/rum/long_task-schema.json
+++ b/schemas/rum/long_task-schema.json
@@ -16,12 +16,16 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "long_task"],
+      "required": ["type", "view", "long_task"],
       "properties": {
         "type": {
           "type": "string",
           "description": "RUM event type",
           "const": "long_task",
+          "readOnly": true
+        },
+        "view": {
+          "type": "object",
           "readOnly": true
         },
         "long_task": {

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -15,12 +15,16 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "resource"],
+      "required": ["type", "view", "resource"],
       "properties": {
         "type": {
           "type": "string",
           "description": "RUM event type",
           "const": "resource",
+          "readOnly": true
+        },
+        "view": {
+          "type": "object",
           "readOnly": true
         },
         "resource": {

--- a/schemas/rum/transition-schema.json
+++ b/schemas/rum/transition-schema.json
@@ -9,12 +9,16 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": ["type", "transition", "stream"],
+      "required": ["type", "view", "transition", "stream"],
       "properties": {
         "type": {
           "type": "string",
           "description": "RUM event type",
           "const": "transition",
+          "readOnly": true
+        },
+        "view": {
+          "type": "object",
           "readOnly": true
         },
         "stream": {

--- a/schemas/rum/view_update-schema.json
+++ b/schemas/rum/view_update-schema.json
@@ -18,12 +18,16 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": ["type"],
+      "required": ["type", "view"],
       "properties": {
         "type": {
           "type": "string",
           "description": "RUM event type",
           "const": "view_update",
+          "readOnly": true
+        },
+        "view": {
+          "type": "object",
           "readOnly": true
         }
       }


### PR DESCRIPTION
### What and why?

Timeseries events need to be emitted independently of a RUM view, but `view` was required for every RUM event via `_common-schema.json`. Since `allOf`/`$ref` composition can only add requirements, not loosen them, the only way to keep `view` optional for timeseries while preserving today's behavior everywhere else is to move the requirement out of the shared base and into each event type that still needs it.