### PR TITLE
[RUM-17847] Add remote_configuration to telemetry configuration schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -458,6 +458,36 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_remote_configuration_proxy?: boolean;
             /**
+             * Metadata of the remote configuration currently applied for this session
+             */
+            remote_configuration?: {
+                /**
+                 * Identifier of the remote configuration bundle this metadata belongs to
+                 */
+                config_id?: string;
+                /**
+                 * CDN version identifier of the applied configuration
+                 */
+                version_id?: string;
+                /**
+                 * CDN publish timestamp of the applied configuration, in ms from epoch
+                 */
+                last_modified?: number;
+                /**
+                 * Timestamp at which the device fetched and cached this configuration version, in ms from epoch
+                 */
+                last_synced?: number;
+                /**
+                 * Timestamp at which this configuration version was first observed as applied by the device, in ms from epoch. Stamped once and reused on every subsequent session that runs on the same version
+                 */
+                first_applied?: number;
+                /**
+                 * Identifier of the sync that produced this configuration version, used to deduplicate repeat sessions from the same device without a persistent identifier
+                 */
+                sync_id?: string;
+                [k: string]: unknown;
+            };
+            /**
              * The percentage of sessions with Profiling enabled
              */
             profiling_sample_rate?: number;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -458,6 +458,36 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              */
             use_remote_configuration_proxy?: boolean;
             /**
+             * Metadata of the remote configuration currently applied for this session
+             */
+            remote_configuration?: {
+                /**
+                 * Identifier of the remote configuration bundle this metadata belongs to
+                 */
+                config_id?: string;
+                /**
+                 * CDN version identifier of the applied configuration
+                 */
+                version_id?: string;
+                /**
+                 * CDN publish timestamp of the applied configuration, in ms from epoch
+                 */
+                last_modified?: number;
+                /**
+                 * Timestamp at which the device fetched and cached this configuration version, in ms from epoch
+                 */
+                last_synced?: number;
+                /**
+                 * Timestamp at which this configuration version was first observed as applied by the device, in ms from epoch. Stamped once and reused on every subsequent session that runs on the same version
+                 */
+                first_applied?: number;
+                /**
+                 * Identifier of the sync that produced this configuration version, used to deduplicate repeat sessions from the same device without a persistent identifier
+                 */
+                sync_id?: string;
+                [k: string]: unknown;
+            };
+            /**
              * The percentage of sessions with Profiling enabled
              */
             profiling_sample_rate?: number;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -508,6 +508,43 @@
                   "description": "Whether a proxy is used for remote configuration",
                   "readOnly": false
                 },
+                "remote_configuration": {
+                  "type": "object",
+                  "description": "Metadata of the remote configuration currently applied for this session",
+                  "readOnly": false,
+                  "properties": {
+                    "config_id": {
+                      "type": "string",
+                      "description": "Identifier of the remote configuration bundle this metadata belongs to",
+                      "readOnly": false
+                    },
+                    "version_id": {
+                      "type": "string",
+                      "description": "CDN version identifier of the applied configuration",
+                      "readOnly": false
+                    },
+                    "last_modified": {
+                      "type": "integer",
+                      "description": "CDN publish timestamp of the applied configuration, in ms from epoch",
+                      "readOnly": false
+                    },
+                    "last_synced": {
+                      "type": "integer",
+                      "description": "Timestamp at which the device fetched and cached this configuration version, in ms from epoch",
+                      "readOnly": false
+                    },
+                    "first_applied": {
+                      "type": "integer",
+                      "description": "Timestamp at which this configuration version was first observed as applied by the device, in ms from epoch. Stamped once and reused on every subsequent session that runs on the same version",
+                      "readOnly": false
+                    },
+                    "sync_id": {
+                      "type": "string",
+                      "description": "Identifier of the sync that produced this configuration version, used to deduplicate repeat sessions from the same device without a persistent identifier",
+                      "readOnly": false
+                    }
+                  }
+                },
                 "profiling_sample_rate": {
                   "type": "number",
                   "description": "The percentage of sessions with Profiling enabled",


### PR DESCRIPTION
## What and why?

Adds a `remote_configuration` object to the telemetry configuration event schema, describing the remote configuration currently applied for a session: `config_id`, `version_id`, `last_modified`, `last_synced`, `first_applied`, and `sync_id`.

[RFC - Remote Configuration Telemetry](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/7037813899/RFC+-+Remote+Configuration+Telemetry)