### PR TITLE
RUM-17895: Add `use_client_side_stats` to telemetry configuration schema

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -481,6 +481,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the beta track WebSockets feature is enabled
              */
             beta_track_web_sockets?: boolean;
+            /**
+             * Whether tracing feature's client-side-stats generation is enabled
+             */
+            use_client_side_stats?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -481,6 +481,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether the beta track WebSockets feature is enabled
              */
             beta_track_web_sockets?: boolean;
+            /**
+             * Whether tracing feature's client-side-stats generation is enabled
+             */
+            use_client_side_stats?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -540,6 +540,10 @@
                   "type": "boolean",
                   "description": "Whether the beta track WebSockets feature is enabled",
                   "readOnly": false
+                },
+                "use_client_side_stats": {
+                  "type": "boolean",
+                  "description": "Whether tracing feature's client-side-stats generation is enabled"
                 }
               }
             }


### PR DESCRIPTION
* Adds new boolean to indicate if Tracing has the generate of span stats enabled on client side
* Generate the Typescript definitions