### PR TITLE
Preserve Android snapshot argument ordering

### DIFF
--- a/lib/cjs/generated/mobileSessionReplay.d.ts
+++ b/lib/cjs/generated/mobileSessionReplay.d.ts
@@ -26,7 +26,7 @@ export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotR
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -38,11 +38,6 @@ export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
         readonly wireframes: Wireframe[];
         readonly compositionTree?: CompositionTree;
     };
-};
-/**
- * Schema of common properties for a Record event type that is supported by slots.
- */
-export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -278,12 +273,16 @@ export type CompositionLayerModifier = CompositionLayerClipModifier | Compositio
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export type MobileIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 11;
     data: MobileIncrementalData;
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
@@ -478,6 +477,15 @@ export type MetaRecord = SlotSupportedCommonRecordSchema & {
          */
         href?: string;
     };
+};
+/**
+ * Schema of common properties for a Record event type that is supported by slots.
+ */
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Schema of a Record type which contains focus information.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -593,7 +593,7 @@ export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotR
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -605,6 +605,10 @@ export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
         readonly wireframes: Wireframe[];
         readonly compositionTree?: CompositionTree;
     };
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Schema of a Wireframe type.
@@ -836,12 +840,16 @@ export type CompositionLayerModifier = CompositionLayerClipModifier | Compositio
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export type MobileIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 11;
     data: MobileIncrementalData;
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.

--- a/lib/esm/generated/mobileSessionReplay.d.ts
+++ b/lib/esm/generated/mobileSessionReplay.d.ts
@@ -26,7 +26,7 @@ export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotR
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -38,11 +38,6 @@ export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
         readonly wireframes: Wireframe[];
         readonly compositionTree?: CompositionTree;
     };
-};
-/**
- * Schema of common properties for a Record event type that is supported by slots.
- */
-export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
     /**
      * Unique ID of the slot that generated this record.
      */
@@ -278,12 +273,16 @@ export type CompositionLayerModifier = CompositionLayerClipModifier | Compositio
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export type MobileIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 11;
     data: MobileIncrementalData;
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.
@@ -478,6 +477,15 @@ export type MetaRecord = SlotSupportedCommonRecordSchema & {
          */
         href?: string;
     };
+};
+/**
+ * Schema of common properties for a Record event type that is supported by slots.
+ */
+export type SlotSupportedCommonRecordSchema = CommonRecordSchema & {
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Schema of a Record type which contains focus information.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -593,7 +593,7 @@ export type MobileRecord = MobileFullSnapshotRecord | MobileIncrementalSnapshotR
 /**
  * Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileFullSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
@@ -605,6 +605,10 @@ export type MobileFullSnapshotRecord = SlotSupportedCommonRecordSchema & {
         readonly wireframes: Wireframe[];
         readonly compositionTree?: CompositionTree;
     };
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Schema of a Wireframe type.
@@ -836,12 +840,16 @@ export type CompositionLayerModifier = CompositionLayerClipModifier | Compositio
 /**
  * Mobile-specific. Schema of a Record type which contains mutations of a screen.
  */
-export type MobileIncrementalSnapshotRecord = SlotSupportedCommonRecordSchema & {
+export type MobileIncrementalSnapshotRecord = CommonRecordSchema & {
     /**
      * The type of this Record.
      */
     readonly type: 11;
     data: MobileIncrementalData;
+    /**
+     * Unique ID of the slot that generated this record.
+     */
+    readonly slotId?: string;
 };
 /**
  * Mobile-specific. Schema of a Session Replay IncrementalData type.

--- a/schemas/session-replay/mobile/full-snapshot-record-schema.json
+++ b/schemas/session-replay/mobile/full-snapshot-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.",
   "allOf": [
     {
-      "$ref": "../common/_slot-supported-common-record-schema.json"
+      "$ref": "../common/_common-record-schema.json"
     },
     {
       "required": ["type", "data"],
@@ -36,6 +36,11 @@
               "readOnly": true
             }
           }
+        },
+        "slotId": {
+          "type": "string",
+          "description": "Unique ID of the slot that generated this record.",
+          "readOnly": true
         }
       }
     }

--- a/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
+++ b/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Mobile-specific. Schema of a Record type which contains mutations of a screen.",
   "allOf": [
     {
-      "$ref": "../common/_slot-supported-common-record-schema.json"
+      "$ref": "../common/_common-record-schema.json"
     },
     {
       "required": ["type", "data"],
@@ -19,6 +19,11 @@
         },
         "data": {
           "$ref": "incremental-data-schema.json"
+        },
+        "slotId": {
+          "type": "string",
+          "description": "Unique ID of the slot that generated this record.",
+          "readOnly": true
         }
       }
     }


### PR DESCRIPTION
Moves slotId to the end of the mobile full and incremental snapshot schemas, preserving the existing positional argument order in generated Android models. 

The addition of slotId changed the positional constructor order of the generated Android full and incremental snapshot models from (timestamp, data) to (timestamp, slotId, data), breaking existing positional call sites. This change keeps slotId at the record level but declares it after data, preserving the existing argument order while adding slotId as the final optional parameter.