### PR TITLE
feat: Add Session Replay experimental features to RUM configuration

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -1359,6 +1359,10 @@ export interface CommonProperties {
              * The percentage of sessions with traced resources
              */
             readonly trace_sample_rate?: number;
+            /**
+             * Session Replay experimental features enabled in the SDK configuration
+             */
+            readonly session_replay_experimental_features?: string[];
             [k: string]: unknown;
         };
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -1359,6 +1359,10 @@ export interface CommonProperties {
              * The percentage of sessions with traced resources
              */
             readonly trace_sample_rate?: number;
+            /**
+             * Session Replay experimental features enabled in the SDK configuration
+             */
+            readonly session_replay_experimental_features?: string[];
             [k: string]: unknown;
         };
         /**

--- a/samples/rum-events/view.json
+++ b/samples/rum-events/view.json
@@ -110,6 +110,7 @@
     "configuration": {
       "session_sample_rate": 12.45,
       "session_replay_sample_rate": 100,
+      "session_replay_experimental_features": ["layer_tree_recording"],
       "start_session_replay_recording_manually": true
     },
     "profiling": {

--- a/schemas/rum/_common-schema.json
+++ b/schemas/rum/_common-schema.json
@@ -469,6 +469,14 @@
               "minimum": 0,
               "maximum": 100,
               "readOnly": true
+            },
+            "session_replay_experimental_features": {
+              "type": "array",
+              "description": "Session Replay experimental features enabled in the SDK configuration",
+              "items": {
+                "type": "string"
+              },
+              "readOnly": true
             }
           }
         },


### PR DESCRIPTION
This PR adds `session_replay_experimental_features` to the RUM `_dd.configuration` schema.

It lets SDKs report which Session Replay experimental features were enabled in the SDK configuration when the event was created. Values are feature identifiers, for example `swiftui` or `layer_tree_recording`.

The RUM view sample and generated TypeScript declarations were updated accordingly.

### Backward compatibility

This is additive. Existing events are unchanged, and consumers can ignore the new optional field until support is added.

### Internal references

- [PANA-8501](https://datadoghq.atlassian.net/browse/PANA-8501)

[PANA-8501]: https://datadoghq.atlassian.net/browse/PANA-8501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ