### PR TITLE
Add missing MobileIncrementalSource, WireframeType, and CompositeOperation values

### DIFF
--- a/lib/cjs/src/session-replay-mobile.d.ts
+++ b/lib/cjs/src/session-replay-mobile.d.ts
@@ -35,4 +35,10 @@ export declare const IncrementalSource: {
     CompositionTreeMutation: SessionReplay.CompositionTreeMutationData['source'];
 };
 export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];
-export type CompositeOperation = SessionReplay.CompositionLayer['compositeOperation'];
+export declare const CompositeOperation: {
+    SourceOver: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'sourceOver'>;
+    DestinationIn: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'destinationIn'>;
+    DestinationOut: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'destinationOut'>;
+    PlusDarker: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'plusDarker'>;
+};
+export type CompositeOperation = (typeof CompositeOperation)[keyof typeof CompositeOperation];

--- a/lib/cjs/src/session-replay-mobile.d.ts
+++ b/lib/cjs/src/session-replay-mobile.d.ts
@@ -21,6 +21,10 @@ export type RecordType = (typeof RecordType)[keyof typeof RecordType];
 export declare const WireframeType: {
     Shape: SessionReplay.ShapeWireframe['type'];
     Text: SessionReplay.TextWireframe['type'];
+    Image: SessionReplay.ImageWireframe['type'];
+    Placeholder: SessionReplay.PlaceholderWireframe['type'];
+    Webview: SessionReplay.WebviewWireframe['type'];
+    EmbeddedContent: SessionReplay.EmbeddedContentWireframe['type'];
 };
 export type WireframeType = (typeof WireframeType)[keyof typeof WireframeType];
 export declare const IncrementalSource: {
@@ -28,5 +32,7 @@ export declare const IncrementalSource: {
     Touch: SessionReplay.TouchData['source'];
     ViewportResize: SessionReplay.ViewportResizeData['source'];
     PointerInteraction: SessionReplay.PointerInteractionData['source'];
+    CompositionTreeMutation: SessionReplay.CompositionTreeMutationData['source'];
 };
 export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];
+export type CompositeOperation = SessionReplay.CompositionLayer['compositeOperation'];

--- a/lib/cjs/src/session-replay-mobile.js
+++ b/lib/cjs/src/session-replay-mobile.js
@@ -35,10 +35,15 @@ exports.RecordType = {
 exports.WireframeType = {
     Shape: 'shape',
     Text: 'text',
+    Image: 'image',
+    Placeholder: 'placeholder',
+    Webview: 'webview',
+    EmbeddedContent: 'embedded_content',
 };
 exports.IncrementalSource = {
     Mutation: 0,
     Touch: 2,
     ViewportResize: 4,
     PointerInteraction: 9,
+    CompositionTreeMutation: 10,
 };

--- a/lib/cjs/src/session-replay-mobile.js
+++ b/lib/cjs/src/session-replay-mobile.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IncrementalSource = exports.WireframeType = exports.RecordType = exports.MobileSource = void 0;
+exports.CompositeOperation = exports.IncrementalSource = exports.WireframeType = exports.RecordType = exports.MobileSource = void 0;
 __exportStar(require("../generated/mobileSessionReplay"), exports);
 exports.MobileSource = {
     Android: 'android',
@@ -46,4 +46,10 @@ exports.IncrementalSource = {
     ViewportResize: 4,
     PointerInteraction: 9,
     CompositionTreeMutation: 10,
+};
+exports.CompositeOperation = {
+    SourceOver: 'sourceOver',
+    DestinationIn: 'destinationIn',
+    DestinationOut: 'destinationOut',
+    PlusDarker: 'plusDarker',
 };

--- a/lib/cjs/src/session-replay.d.ts
+++ b/lib/cjs/src/session-replay.d.ts
@@ -2,7 +2,7 @@ import type { IncrementalSource as BrowserIncrementalSource, RecordType as Brows
 import type { IncrementalSource as MobileIncrementalSource, RecordType as MobileRecordType } from './session-replay-mobile';
 export * from '../generated/sessionReplay';
 export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
-export { IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType } from './session-replay-mobile';
+export { CompositeOperation, IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export declare const RecordType: {
     BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot;
     BrowserIncrementalSnapshot: typeof BrowserRecordType.IncrementalSnapshot;

--- a/lib/cjs/src/session-replay.js
+++ b/lib/cjs/src/session-replay.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PointerType = exports.PointerEventType = exports.RecordType = exports.WireframeType = exports.MobileSource = exports.MobileIncrementalSource = exports.SnapshotFormat = exports.PlaybackState = exports.MediaInteractionType = exports.MouseInteractionType = exports.BrowserIncrementalSource = exports.NodeType = exports.BrowserChangeType = exports.BrowserSource = void 0;
+exports.PointerType = exports.PointerEventType = exports.RecordType = exports.WireframeType = exports.MobileSource = exports.MobileIncrementalSource = exports.CompositeOperation = exports.SnapshotFormat = exports.PlaybackState = exports.MediaInteractionType = exports.MouseInteractionType = exports.BrowserIncrementalSource = exports.NodeType = exports.BrowserChangeType = exports.BrowserSource = void 0;
 __exportStar(require("../generated/sessionReplay"), exports);
 var session_replay_browser_1 = require("./session-replay-browser");
 Object.defineProperty(exports, "BrowserSource", { enumerable: true, get: function () { return session_replay_browser_1.BrowserSource; } });
@@ -26,6 +26,7 @@ Object.defineProperty(exports, "MediaInteractionType", { enumerable: true, get: 
 Object.defineProperty(exports, "PlaybackState", { enumerable: true, get: function () { return session_replay_browser_1.PlaybackState; } });
 Object.defineProperty(exports, "SnapshotFormat", { enumerable: true, get: function () { return session_replay_browser_1.SnapshotFormat; } });
 var session_replay_mobile_1 = require("./session-replay-mobile");
+Object.defineProperty(exports, "CompositeOperation", { enumerable: true, get: function () { return session_replay_mobile_1.CompositeOperation; } });
 Object.defineProperty(exports, "MobileIncrementalSource", { enumerable: true, get: function () { return session_replay_mobile_1.IncrementalSource; } });
 Object.defineProperty(exports, "MobileSource", { enumerable: true, get: function () { return session_replay_mobile_1.MobileSource; } });
 Object.defineProperty(exports, "WireframeType", { enumerable: true, get: function () { return session_replay_mobile_1.WireframeType; } });

--- a/lib/esm/src/session-replay-mobile.d.ts
+++ b/lib/esm/src/session-replay-mobile.d.ts
@@ -35,4 +35,10 @@ export declare const IncrementalSource: {
     CompositionTreeMutation: SessionReplay.CompositionTreeMutationData['source'];
 };
 export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];
-export type CompositeOperation = SessionReplay.CompositionLayer['compositeOperation'];
+export declare const CompositeOperation: {
+    SourceOver: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'sourceOver'>;
+    DestinationIn: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'destinationIn'>;
+    DestinationOut: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'destinationOut'>;
+    PlusDarker: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'plusDarker'>;
+};
+export type CompositeOperation = (typeof CompositeOperation)[keyof typeof CompositeOperation];

--- a/lib/esm/src/session-replay-mobile.d.ts
+++ b/lib/esm/src/session-replay-mobile.d.ts
@@ -21,6 +21,10 @@ export type RecordType = (typeof RecordType)[keyof typeof RecordType];
 export declare const WireframeType: {
     Shape: SessionReplay.ShapeWireframe['type'];
     Text: SessionReplay.TextWireframe['type'];
+    Image: SessionReplay.ImageWireframe['type'];
+    Placeholder: SessionReplay.PlaceholderWireframe['type'];
+    Webview: SessionReplay.WebviewWireframe['type'];
+    EmbeddedContent: SessionReplay.EmbeddedContentWireframe['type'];
 };
 export type WireframeType = (typeof WireframeType)[keyof typeof WireframeType];
 export declare const IncrementalSource: {
@@ -28,5 +32,7 @@ export declare const IncrementalSource: {
     Touch: SessionReplay.TouchData['source'];
     ViewportResize: SessionReplay.ViewportResizeData['source'];
     PointerInteraction: SessionReplay.PointerInteractionData['source'];
+    CompositionTreeMutation: SessionReplay.CompositionTreeMutationData['source'];
 };
 export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource];
+export type CompositeOperation = SessionReplay.CompositionLayer['compositeOperation'];

--- a/lib/esm/src/session-replay-mobile.js
+++ b/lib/esm/src/session-replay-mobile.js
@@ -18,10 +18,15 @@ export var RecordType = {
 export var WireframeType = {
     Shape: 'shape',
     Text: 'text',
+    Image: 'image',
+    Placeholder: 'placeholder',
+    Webview: 'webview',
+    EmbeddedContent: 'embedded_content',
 };
 export var IncrementalSource = {
     Mutation: 0,
     Touch: 2,
     ViewportResize: 4,
     PointerInteraction: 9,
+    CompositionTreeMutation: 10,
 };

--- a/lib/esm/src/session-replay-mobile.js
+++ b/lib/esm/src/session-replay-mobile.js
@@ -30,3 +30,9 @@ export var IncrementalSource = {
     PointerInteraction: 9,
     CompositionTreeMutation: 10,
 };
+export var CompositeOperation = {
+    SourceOver: 'sourceOver',
+    DestinationIn: 'destinationIn',
+    DestinationOut: 'destinationOut',
+    PlusDarker: 'plusDarker',
+};

--- a/lib/esm/src/session-replay.d.ts
+++ b/lib/esm/src/session-replay.d.ts
@@ -2,7 +2,7 @@ import type { IncrementalSource as BrowserIncrementalSource, RecordType as Brows
 import type { IncrementalSource as MobileIncrementalSource, RecordType as MobileRecordType } from './session-replay-mobile';
 export * from '../generated/sessionReplay';
 export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
-export { IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType } from './session-replay-mobile';
+export { CompositeOperation, IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export declare const RecordType: {
     BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot;
     BrowserIncrementalSnapshot: typeof BrowserRecordType.IncrementalSnapshot;

--- a/lib/esm/src/session-replay.js
+++ b/lib/esm/src/session-replay.js
@@ -1,6 +1,6 @@
 export * from '../generated/sessionReplay';
 export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
-export { IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType } from './session-replay-mobile';
+export { IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export var RecordType = {
     BrowserFullSnapshot: 2,
     BrowserIncrementalSnapshot: 3,

--- a/lib/esm/src/session-replay.js
+++ b/lib/esm/src/session-replay.js
@@ -1,6 +1,6 @@
 export * from '../generated/sessionReplay';
 export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
-export { IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
+export { CompositeOperation, IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export var RecordType = {
     BrowserFullSnapshot: 2,
     BrowserIncrementalSnapshot: 3,

--- a/lib/src/session-replay-mobile.ts
+++ b/lib/src/session-replay-mobile.ts
@@ -65,4 +65,16 @@ export const IncrementalSource: {
 
 export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource]
 
-export type CompositeOperation = SessionReplay.CompositionLayer['compositeOperation']
+export const CompositeOperation: {
+  SourceOver: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'sourceOver'>
+  DestinationIn: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'destinationIn'>
+  DestinationOut: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'destinationOut'>
+  PlusDarker: Extract<SessionReplay.CompositionLayer['compositeOperation'], 'plusDarker'>
+} = {
+  SourceOver: 'sourceOver',
+  DestinationIn: 'destinationIn',
+  DestinationOut: 'destinationOut',
+  PlusDarker: 'plusDarker',
+} as const
+
+export type CompositeOperation = (typeof CompositeOperation)[keyof typeof CompositeOperation]

--- a/lib/src/session-replay-mobile.ts
+++ b/lib/src/session-replay-mobile.ts
@@ -34,9 +34,17 @@ export type RecordType = (typeof RecordType)[keyof typeof RecordType]
 export const WireframeType: {
   Shape: SessionReplay.ShapeWireframe['type']
   Text: SessionReplay.TextWireframe['type']
+  Image: SessionReplay.ImageWireframe['type']
+  Placeholder: SessionReplay.PlaceholderWireframe['type']
+  Webview: SessionReplay.WebviewWireframe['type']
+  EmbeddedContent: SessionReplay.EmbeddedContentWireframe['type']
 } = {
   Shape: 'shape',
   Text: 'text',
+  Image: 'image',
+  Placeholder: 'placeholder',
+  Webview: 'webview',
+  EmbeddedContent: 'embedded_content',
 } as const
 
 export type WireframeType = (typeof WireframeType)[keyof typeof WireframeType]
@@ -46,11 +54,15 @@ export const IncrementalSource: {
   Touch: SessionReplay.TouchData['source']
   ViewportResize: SessionReplay.ViewportResizeData['source']
   PointerInteraction: SessionReplay.PointerInteractionData['source']
+  CompositionTreeMutation: SessionReplay.CompositionTreeMutationData['source']
 } = {
   Mutation: 0,
   Touch: 2,
   ViewportResize: 4,
   PointerInteraction: 9,
+  CompositionTreeMutation: 10,
 } as const
 
 export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource]
+
+export type CompositeOperation = SessionReplay.CompositionLayer['compositeOperation']

--- a/lib/src/session-replay.ts
+++ b/lib/src/session-replay.ts
@@ -19,7 +19,12 @@ export {
   PlaybackState,
   SnapshotFormat,
 } from './session-replay-browser'
-export { IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType } from './session-replay-mobile'
+export {
+  CompositeOperation,
+  IncrementalSource as MobileIncrementalSource,
+  MobileSource,
+  WireframeType,
+} from './session-replay-mobile'
 
 export const RecordType: {
   BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot


### PR DESCRIPTION
Several of the recent mobile session replay schema additions added new constants that weren't included in the helper TypeScript types this package exports. This makes it harder to actually use these new schema additions in TypeScript projects. Let's fix that.

Note that `WireframeType` has clearly not received much love since it was originally introduced. 😓 It should be up to date now, though.