### PR TITLE
[PANA-8578] Add support for session replay string namespaces

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -84,9 +84,9 @@ export type SnapshotFormatChange = 1;
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]] | [11, ...AddNamespacedStringsChange[]];
 /**
- * Browser-specific. Schema representing the addition of a string to the string table.
+ * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string namespace.
  */
 export type AddStringChange = string;
 /**
@@ -98,7 +98,13 @@ export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | A
  *
  * @minItems 2
  */
-export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [
+    InsertionPoint,
+    '#cdata-section' | {
+        namespace: 1;
+        string: '#cdata-section';
+    } | StringReference
+];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
@@ -130,33 +136,88 @@ export type StringReference = number;
  */
 export type AddDocTypeNodeChange = [
     InsertionPoint,
-    '#doctype' | StringReference,
+    '#doctype' | {
+        namespace: 1;
+        string: '#doctype';
+    } | StringReference,
     StringOrStringReference,
     StringOrStringReference,
     StringOrStringReference
 ];
 /**
- * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
+ * Browser-specific. Schema representing a string, either expressed as a literal, as a literal with an associated string namespace, or as an index into the string table.
  */
-export type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = StringLiteral | NamespacedStringLiteral | StringReference;
+/**
+ * Browser-specific. Schema representing a string, expressed as a literal.
+ */
+export type StringLiteral = string;
+/**
+ * Browser-specific. Schema representing a string namespace.
+ */
+export type StringNamespaceId = StringNamespaceDefault | StringNamespaceNodeName | StringNamespaceAttributeName | StringNamespaceAttributeValue | StringNamespaceTextContent | StringNamespaceFormInput | StringNamespaceCSS | StringNamespaceURL;
+/**
+ * The default string namespace, used for uncategorized strings. Strings added by an AddStringChange are added to this string namespace.
+ */
+export type StringNamespaceDefault = 0;
+/**
+ * A string namespace containing DOM node names (e.g. 'div', '#text').
+ */
+export type StringNamespaceNodeName = 1;
+/**
+ * A string namespace containing DOM attribute names.
+ */
+export type StringNamespaceAttributeName = 2;
+/**
+ * A string namespace containing DOM attribute values.
+ */
+export type StringNamespaceAttributeValue = 3;
+/**
+ * A string namespace containing DOM text content.
+ */
+export type StringNamespaceTextContent = 4;
+/**
+ * A string namespace containing DOM form input values.
+ */
+export type StringNamespaceFormInput = 5;
+/**
+ * A string namespace containing CSS inline styles and stylesheets.
+ */
+export type StringNamespaceCSS = 6;
+/**
+ * A string namespace containing URLs.
+ */
+export type StringNamespaceURL = 7;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [
+    InsertionPoint,
+    '#document' | {
+        namespace: 1;
+        string: '#document';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [
+    InsertionPoint,
+    '#document-fragment' | {
+        namespace: 1;
+        string: '#document-fragment';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, StringOrStringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
@@ -168,13 +229,26 @@ export type AttributeAssignment = [StringOrStringReference, StringOrStringRefere
  *
  * @minItems 2
  */
-export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [
+    InsertionPoint,
+    '#shadow-root' | {
+        namespace: 1;
+        string: '#shadow-root';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [
+    InsertionPoint,
+    '#text' | {
+        namespace: 1;
+        string: '#text';
+    } | StringReference,
+    StringOrStringReference
+];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
@@ -303,6 +377,12 @@ export type VisualViewportHeight = number;
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
 export type VisualViewportScale = number;
+/**
+ * Browser-specific. Schema representing the addition of a sequence of strings to the string table, annotated as belonging to a particular string namespace.
+ *
+ * @minItems 1
+ */
+export type AddNamespacedStringsChange = [StringNamespaceId, ...StringLiteral[]];
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -763,6 +843,13 @@ export interface CDataNode {
      */
     readonly type: 4;
     textContent: '';
+}
+/**
+ * Browser-specific. Schema representing a string literal with an associated string namespace.
+ */
+export interface NamespacedStringLiteral {
+    namespace: StringNamespaceId;
+    string: StringLiteral;
 }
 /**
  * Schema of an AddedNodeMutation.

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -92,9 +92,9 @@ export type SnapshotFormatChange = 1;
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]] | [11, ...AddNamespacedStringsChange[]];
 /**
- * Browser-specific. Schema representing the addition of a string to the string table.
+ * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string namespace.
  */
 export type AddStringChange = string;
 /**
@@ -106,7 +106,13 @@ export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | A
  *
  * @minItems 2
  */
-export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [
+    InsertionPoint,
+    '#cdata-section' | {
+        namespace: 1;
+        string: '#cdata-section';
+    } | StringReference
+];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
@@ -138,33 +144,88 @@ export type StringReference = number;
  */
 export type AddDocTypeNodeChange = [
     InsertionPoint,
-    '#doctype' | StringReference,
+    '#doctype' | {
+        namespace: 1;
+        string: '#doctype';
+    } | StringReference,
     StringOrStringReference,
     StringOrStringReference,
     StringOrStringReference
 ];
 /**
- * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
+ * Browser-specific. Schema representing a string, either expressed as a literal, as a literal with an associated string namespace, or as an index into the string table.
  */
-export type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = StringLiteral | NamespacedStringLiteral | StringReference;
+/**
+ * Browser-specific. Schema representing a string, expressed as a literal.
+ */
+export type StringLiteral = string;
+/**
+ * Browser-specific. Schema representing a string namespace.
+ */
+export type StringNamespaceId = StringNamespaceDefault | StringNamespaceNodeName | StringNamespaceAttributeName | StringNamespaceAttributeValue | StringNamespaceTextContent | StringNamespaceFormInput | StringNamespaceCSS | StringNamespaceURL;
+/**
+ * The default string namespace, used for uncategorized strings. Strings added by an AddStringChange are added to this string namespace.
+ */
+export type StringNamespaceDefault = 0;
+/**
+ * A string namespace containing DOM node names (e.g. 'div', '#text').
+ */
+export type StringNamespaceNodeName = 1;
+/**
+ * A string namespace containing DOM attribute names.
+ */
+export type StringNamespaceAttributeName = 2;
+/**
+ * A string namespace containing DOM attribute values.
+ */
+export type StringNamespaceAttributeValue = 3;
+/**
+ * A string namespace containing DOM text content.
+ */
+export type StringNamespaceTextContent = 4;
+/**
+ * A string namespace containing DOM form input values.
+ */
+export type StringNamespaceFormInput = 5;
+/**
+ * A string namespace containing CSS inline styles and stylesheets.
+ */
+export type StringNamespaceCSS = 6;
+/**
+ * A string namespace containing URLs.
+ */
+export type StringNamespaceURL = 7;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [
+    InsertionPoint,
+    '#document' | {
+        namespace: 1;
+        string: '#document';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [
+    InsertionPoint,
+    '#document-fragment' | {
+        namespace: 1;
+        string: '#document-fragment';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, StringOrStringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
@@ -176,13 +237,26 @@ export type AttributeAssignment = [StringOrStringReference, StringOrStringRefere
  *
  * @minItems 2
  */
-export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [
+    InsertionPoint,
+    '#shadow-root' | {
+        namespace: 1;
+        string: '#shadow-root';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [
+    InsertionPoint,
+    '#text' | {
+        namespace: 1;
+        string: '#text';
+    } | StringReference,
+    StringOrStringReference
+];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
@@ -311,6 +385,12 @@ export type VisualViewportHeight = number;
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
 export type VisualViewportScale = number;
+/**
+ * Browser-specific. Schema representing the addition of a sequence of strings to the string table, annotated as belonging to a particular string namespace.
+ *
+ * @minItems 1
+ */
+export type AddNamespacedStringsChange = [StringNamespaceId, ...StringLiteral[]];
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -1232,6 +1312,13 @@ export interface CDataNode {
      */
     readonly type: 4;
     textContent: '';
+}
+/**
+ * Browser-specific. Schema representing a string literal with an associated string namespace.
+ */
+export interface NamespacedStringLiteral {
+    namespace: StringNamespaceId;
+    string: StringLiteral;
 }
 /**
  * Schema of an AddedNodeMutation.

--- a/lib/cjs/src/session-replay-browser.d.ts
+++ b/lib/cjs/src/session-replay-browser.d.ts
@@ -70,8 +70,20 @@ export declare const ChangeType: {
     AttachedStyleSheets: ChangeTypeId<8, SessionReplay.AttachedStyleSheetsChange>;
     MediaPlaybackState: ChangeTypeId<9, SessionReplay.MediaPlaybackStateChange>;
     VisualViewport: ChangeTypeId<10, SessionReplay.VisualViewportChange>;
+    AddNamespacedStrings: ChangeTypeId<11, SessionReplay.AddNamespacedStringsChange>;
 };
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType];
+export declare const StringNamespace: {
+    Default: SessionReplay.StringNamespaceDefault;
+    NodeName: SessionReplay.StringNamespaceNodeName;
+    AttributeName: SessionReplay.StringNamespaceAttributeName;
+    AttributeValue: SessionReplay.StringNamespaceAttributeValue;
+    TextContent: SessionReplay.StringNamespaceTextContent;
+    FormInput: SessionReplay.StringNamespaceFormInput;
+    CSS: SessionReplay.StringNamespaceCSS;
+    URL: SessionReplay.StringNamespaceURL;
+};
+export type StringNamespace = (typeof StringNamespace)[keyof typeof StringNamespace];
 export declare const PlaybackState: {
     Playing: SessionReplay.PlaybackStatePlaying;
     Paused: SessionReplay.PlaybackStatePaused;

--- a/lib/cjs/src/session-replay-browser.js
+++ b/lib/cjs/src/session-replay-browser.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.SnapshotFormat = exports.PlaybackState = exports.ChangeType = exports.MediaInteractionType = exports.MouseInteractionType = exports.IncrementalSource = exports.NodeType = exports.RecordType = exports.BrowserSource = void 0;
+exports.SnapshotFormat = exports.PlaybackState = exports.StringNamespace = exports.ChangeType = exports.MediaInteractionType = exports.MouseInteractionType = exports.IncrementalSource = exports.NodeType = exports.RecordType = exports.BrowserSource = void 0;
 __exportStar(require("../generated/browserSessionReplay"), exports);
 /**
  * For backward compatibility reasons, `undefined` should be accepted as a possible value for Browser segments, too.
@@ -80,6 +80,17 @@ exports.ChangeType = {
     AttachedStyleSheets: 8,
     MediaPlaybackState: 9,
     VisualViewport: 10,
+    AddNamespacedStrings: 11,
+};
+exports.StringNamespace = {
+    Default: 0,
+    NodeName: 1,
+    AttributeName: 2,
+    AttributeValue: 3,
+    TextContent: 4,
+    FormInput: 5,
+    CSS: 6,
+    URL: 7,
 };
 exports.PlaybackState = {
     Playing: 0,

--- a/lib/cjs/src/session-replay.d.ts
+++ b/lib/cjs/src/session-replay.d.ts
@@ -1,7 +1,7 @@
 import type { IncrementalSource as BrowserIncrementalSource, RecordType as BrowserRecordType } from './session-replay-browser';
 import type { IncrementalSource as MobileIncrementalSource, RecordType as MobileRecordType } from './session-replay-mobile';
 export * from '../generated/sessionReplay';
-export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
+export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, StringNamespace, } from './session-replay-browser';
 export { CompositeOperation, IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export declare const RecordType: {
     BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot;

--- a/lib/cjs/src/session-replay.js
+++ b/lib/cjs/src/session-replay.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PointerType = exports.PointerEventType = exports.RecordType = exports.WireframeType = exports.MobileSource = exports.MobileIncrementalSource = exports.CompositeOperation = exports.SnapshotFormat = exports.PlaybackState = exports.MediaInteractionType = exports.MouseInteractionType = exports.BrowserIncrementalSource = exports.NodeType = exports.BrowserChangeType = exports.BrowserSource = void 0;
+exports.PointerType = exports.PointerEventType = exports.RecordType = exports.WireframeType = exports.MobileSource = exports.MobileIncrementalSource = exports.CompositeOperation = exports.StringNamespace = exports.SnapshotFormat = exports.PlaybackState = exports.MediaInteractionType = exports.MouseInteractionType = exports.BrowserIncrementalSource = exports.NodeType = exports.BrowserChangeType = exports.BrowserSource = void 0;
 __exportStar(require("../generated/sessionReplay"), exports);
 var session_replay_browser_1 = require("./session-replay-browser");
 Object.defineProperty(exports, "BrowserSource", { enumerable: true, get: function () { return session_replay_browser_1.BrowserSource; } });
@@ -25,6 +25,7 @@ Object.defineProperty(exports, "MouseInteractionType", { enumerable: true, get: 
 Object.defineProperty(exports, "MediaInteractionType", { enumerable: true, get: function () { return session_replay_browser_1.MediaInteractionType; } });
 Object.defineProperty(exports, "PlaybackState", { enumerable: true, get: function () { return session_replay_browser_1.PlaybackState; } });
 Object.defineProperty(exports, "SnapshotFormat", { enumerable: true, get: function () { return session_replay_browser_1.SnapshotFormat; } });
+Object.defineProperty(exports, "StringNamespace", { enumerable: true, get: function () { return session_replay_browser_1.StringNamespace; } });
 var session_replay_mobile_1 = require("./session-replay-mobile");
 Object.defineProperty(exports, "CompositeOperation", { enumerable: true, get: function () { return session_replay_mobile_1.CompositeOperation; } });
 Object.defineProperty(exports, "MobileIncrementalSource", { enumerable: true, get: function () { return session_replay_mobile_1.IncrementalSource; } });

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -84,9 +84,9 @@ export type SnapshotFormatChange = 1;
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]] | [11, ...AddNamespacedStringsChange[]];
 /**
- * Browser-specific. Schema representing the addition of a string to the string table.
+ * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string namespace.
  */
 export type AddStringChange = string;
 /**
@@ -98,7 +98,13 @@ export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | A
  *
  * @minItems 2
  */
-export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [
+    InsertionPoint,
+    '#cdata-section' | {
+        namespace: 1;
+        string: '#cdata-section';
+    } | StringReference
+];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
@@ -130,33 +136,88 @@ export type StringReference = number;
  */
 export type AddDocTypeNodeChange = [
     InsertionPoint,
-    '#doctype' | StringReference,
+    '#doctype' | {
+        namespace: 1;
+        string: '#doctype';
+    } | StringReference,
     StringOrStringReference,
     StringOrStringReference,
     StringOrStringReference
 ];
 /**
- * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
+ * Browser-specific. Schema representing a string, either expressed as a literal, as a literal with an associated string namespace, or as an index into the string table.
  */
-export type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = StringLiteral | NamespacedStringLiteral | StringReference;
+/**
+ * Browser-specific. Schema representing a string, expressed as a literal.
+ */
+export type StringLiteral = string;
+/**
+ * Browser-specific. Schema representing a string namespace.
+ */
+export type StringNamespaceId = StringNamespaceDefault | StringNamespaceNodeName | StringNamespaceAttributeName | StringNamespaceAttributeValue | StringNamespaceTextContent | StringNamespaceFormInput | StringNamespaceCSS | StringNamespaceURL;
+/**
+ * The default string namespace, used for uncategorized strings. Strings added by an AddStringChange are added to this string namespace.
+ */
+export type StringNamespaceDefault = 0;
+/**
+ * A string namespace containing DOM node names (e.g. 'div', '#text').
+ */
+export type StringNamespaceNodeName = 1;
+/**
+ * A string namespace containing DOM attribute names.
+ */
+export type StringNamespaceAttributeName = 2;
+/**
+ * A string namespace containing DOM attribute values.
+ */
+export type StringNamespaceAttributeValue = 3;
+/**
+ * A string namespace containing DOM text content.
+ */
+export type StringNamespaceTextContent = 4;
+/**
+ * A string namespace containing DOM form input values.
+ */
+export type StringNamespaceFormInput = 5;
+/**
+ * A string namespace containing CSS inline styles and stylesheets.
+ */
+export type StringNamespaceCSS = 6;
+/**
+ * A string namespace containing URLs.
+ */
+export type StringNamespaceURL = 7;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [
+    InsertionPoint,
+    '#document' | {
+        namespace: 1;
+        string: '#document';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [
+    InsertionPoint,
+    '#document-fragment' | {
+        namespace: 1;
+        string: '#document-fragment';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, StringOrStringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
@@ -168,13 +229,26 @@ export type AttributeAssignment = [StringOrStringReference, StringOrStringRefere
  *
  * @minItems 2
  */
-export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [
+    InsertionPoint,
+    '#shadow-root' | {
+        namespace: 1;
+        string: '#shadow-root';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [
+    InsertionPoint,
+    '#text' | {
+        namespace: 1;
+        string: '#text';
+    } | StringReference,
+    StringOrStringReference
+];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
@@ -303,6 +377,12 @@ export type VisualViewportHeight = number;
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
 export type VisualViewportScale = number;
+/**
+ * Browser-specific. Schema representing the addition of a sequence of strings to the string table, annotated as belonging to a particular string namespace.
+ *
+ * @minItems 1
+ */
+export type AddNamespacedStringsChange = [StringNamespaceId, ...StringLiteral[]];
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -763,6 +843,13 @@ export interface CDataNode {
      */
     readonly type: 4;
     textContent: '';
+}
+/**
+ * Browser-specific. Schema representing a string literal with an associated string namespace.
+ */
+export interface NamespacedStringLiteral {
+    namespace: StringNamespaceId;
+    string: StringLiteral;
 }
 /**
  * Schema of an AddedNodeMutation.

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -92,9 +92,9 @@ export type SnapshotFormatChange = 1;
 /**
  * Browser-specific. Schema representing an individual change within a BrowserChangeData collection.
  */
-export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]];
+export type Change = [0, ...AddStringChange[]] | [1, ...AddNodeChange[]] | [2, ...RemoveNodeChange[]] | [3, ...AttributeChange[]] | [4, ...TextChange[]] | [5, ...SizeChange[]] | [6, ...ScrollPositionChange[]] | [7, ...AddStyleSheetChange[]] | [8, ...AttachedStyleSheetsChange[]] | [9, ...MediaPlaybackStateChange[]] | [10, ...VisualViewportChange[]] | [11, ...AddNamespacedStringsChange[]];
 /**
- * Browser-specific. Schema representing the addition of a string to the string table.
+ * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string namespace.
  */
 export type AddStringChange = string;
 /**
@@ -106,7 +106,13 @@ export type AddNodeChange = AddCDataSectionNodeChange | AddDocTypeNodeChange | A
  *
  * @minItems 2
  */
-export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference];
+export type AddCDataSectionNodeChange = [
+    InsertionPoint,
+    '#cdata-section' | {
+        namespace: 1;
+        string: '#cdata-section';
+    } | StringReference
+];
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
@@ -138,33 +144,88 @@ export type StringReference = number;
  */
 export type AddDocTypeNodeChange = [
     InsertionPoint,
-    '#doctype' | StringReference,
+    '#doctype' | {
+        namespace: 1;
+        string: '#doctype';
+    } | StringReference,
     StringOrStringReference,
     StringOrStringReference,
     StringOrStringReference
 ];
 /**
- * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
+ * Browser-specific. Schema representing a string, either expressed as a literal, as a literal with an associated string namespace, or as an index into the string table.
  */
-export type StringOrStringReference = string | StringReference;
+export type StringOrStringReference = StringLiteral | NamespacedStringLiteral | StringReference;
+/**
+ * Browser-specific. Schema representing a string, expressed as a literal.
+ */
+export type StringLiteral = string;
+/**
+ * Browser-specific. Schema representing a string namespace.
+ */
+export type StringNamespaceId = StringNamespaceDefault | StringNamespaceNodeName | StringNamespaceAttributeName | StringNamespaceAttributeValue | StringNamespaceTextContent | StringNamespaceFormInput | StringNamespaceCSS | StringNamespaceURL;
+/**
+ * The default string namespace, used for uncategorized strings. Strings added by an AddStringChange are added to this string namespace.
+ */
+export type StringNamespaceDefault = 0;
+/**
+ * A string namespace containing DOM node names (e.g. 'div', '#text').
+ */
+export type StringNamespaceNodeName = 1;
+/**
+ * A string namespace containing DOM attribute names.
+ */
+export type StringNamespaceAttributeName = 2;
+/**
+ * A string namespace containing DOM attribute values.
+ */
+export type StringNamespaceAttributeValue = 3;
+/**
+ * A string namespace containing DOM text content.
+ */
+export type StringNamespaceTextContent = 4;
+/**
+ * A string namespace containing DOM form input values.
+ */
+export type StringNamespaceFormInput = 5;
+/**
+ * A string namespace containing CSS inline styles and stylesheets.
+ */
+export type StringNamespaceCSS = 6;
+/**
+ * A string namespace containing URLs.
+ */
+export type StringNamespaceURL = 7;
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference];
+export type AddDocumentNodeChange = [
+    InsertionPoint,
+    '#document' | {
+        namespace: 1;
+        string: '#document';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference];
+export type AddDocumentFragmentNodeChange = [
+    InsertionPoint,
+    '#document-fragment' | {
+        namespace: 1;
+        string: '#document-fragment';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]];
+export type AddElementNodeChange = [InsertionPoint, StringOrStringReference, ...AttributeAssignment[]];
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
@@ -176,13 +237,26 @@ export type AttributeAssignment = [StringOrStringReference, StringOrStringRefere
  *
  * @minItems 2
  */
-export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference];
+export type AddShadowRootNodeChange = [
+    InsertionPoint,
+    '#shadow-root' | {
+        namespace: 1;
+        string: '#shadow-root';
+    } | StringReference
+];
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference];
+export type AddTextNodeChange = [
+    InsertionPoint,
+    '#text' | {
+        namespace: 1;
+        string: '#text';
+    } | StringReference,
+    StringOrStringReference
+];
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
@@ -311,6 +385,12 @@ export type VisualViewportHeight = number;
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
 export type VisualViewportScale = number;
+/**
+ * Browser-specific. Schema representing the addition of a sequence of strings to the string table, annotated as belonging to a particular string namespace.
+ *
+ * @minItems 1
+ */
+export type AddNamespacedStringsChange = [StringNamespaceId, ...StringLiteral[]];
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -1232,6 +1312,13 @@ export interface CDataNode {
      */
     readonly type: 4;
     textContent: '';
+}
+/**
+ * Browser-specific. Schema representing a string literal with an associated string namespace.
+ */
+export interface NamespacedStringLiteral {
+    namespace: StringNamespaceId;
+    string: StringLiteral;
 }
 /**
  * Schema of an AddedNodeMutation.

--- a/lib/esm/src/session-replay-browser.d.ts
+++ b/lib/esm/src/session-replay-browser.d.ts
@@ -70,8 +70,20 @@ export declare const ChangeType: {
     AttachedStyleSheets: ChangeTypeId<8, SessionReplay.AttachedStyleSheetsChange>;
     MediaPlaybackState: ChangeTypeId<9, SessionReplay.MediaPlaybackStateChange>;
     VisualViewport: ChangeTypeId<10, SessionReplay.VisualViewportChange>;
+    AddNamespacedStrings: ChangeTypeId<11, SessionReplay.AddNamespacedStringsChange>;
 };
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType];
+export declare const StringNamespace: {
+    Default: SessionReplay.StringNamespaceDefault;
+    NodeName: SessionReplay.StringNamespaceNodeName;
+    AttributeName: SessionReplay.StringNamespaceAttributeName;
+    AttributeValue: SessionReplay.StringNamespaceAttributeValue;
+    TextContent: SessionReplay.StringNamespaceTextContent;
+    FormInput: SessionReplay.StringNamespaceFormInput;
+    CSS: SessionReplay.StringNamespaceCSS;
+    URL: SessionReplay.StringNamespaceURL;
+};
+export type StringNamespace = (typeof StringNamespace)[keyof typeof StringNamespace];
 export declare const PlaybackState: {
     Playing: SessionReplay.PlaybackStatePlaying;
     Paused: SessionReplay.PlaybackStatePaused;

--- a/lib/esm/src/session-replay-browser.js
+++ b/lib/esm/src/session-replay-browser.js
@@ -63,6 +63,17 @@ export var ChangeType = {
     AttachedStyleSheets: 8,
     MediaPlaybackState: 9,
     VisualViewport: 10,
+    AddNamespacedStrings: 11,
+};
+export var StringNamespace = {
+    Default: 0,
+    NodeName: 1,
+    AttributeName: 2,
+    AttributeValue: 3,
+    TextContent: 4,
+    FormInput: 5,
+    CSS: 6,
+    URL: 7,
 };
 export var PlaybackState = {
     Playing: 0,

--- a/lib/esm/src/session-replay.d.ts
+++ b/lib/esm/src/session-replay.d.ts
@@ -1,7 +1,7 @@
 import type { IncrementalSource as BrowserIncrementalSource, RecordType as BrowserRecordType } from './session-replay-browser';
 import type { IncrementalSource as MobileIncrementalSource, RecordType as MobileRecordType } from './session-replay-mobile';
 export * from '../generated/sessionReplay';
-export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
+export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, StringNamespace, } from './session-replay-browser';
 export { CompositeOperation, IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export declare const RecordType: {
     BrowserFullSnapshot: typeof BrowserRecordType.FullSnapshot;

--- a/lib/esm/src/session-replay.js
+++ b/lib/esm/src/session-replay.js
@@ -1,5 +1,5 @@
 export * from '../generated/sessionReplay';
-export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, } from './session-replay-browser';
+export { BrowserSource, ChangeType as BrowserChangeType, NodeType, IncrementalSource as BrowserIncrementalSource, MouseInteractionType, MediaInteractionType, PlaybackState, SnapshotFormat, StringNamespace, } from './session-replay-browser';
 export { CompositeOperation, IncrementalSource as MobileIncrementalSource, MobileSource, WireframeType, } from './session-replay-mobile';
 export var RecordType = {
     BrowserFullSnapshot: 2,

--- a/lib/src/session-replay-browser.ts
+++ b/lib/src/session-replay-browser.ts
@@ -115,6 +115,7 @@ export const ChangeType: {
   AttachedStyleSheets: ChangeTypeId<8, SessionReplay.AttachedStyleSheetsChange>
   MediaPlaybackState: ChangeTypeId<9, SessionReplay.MediaPlaybackStateChange>
   VisualViewport: ChangeTypeId<10, SessionReplay.VisualViewportChange>
+  AddNamespacedStrings: ChangeTypeId<11, SessionReplay.AddNamespacedStringsChange>
 } = {
   AddString: 0,
   AddNode: 1,
@@ -127,9 +128,32 @@ export const ChangeType: {
   AttachedStyleSheets: 8,
   MediaPlaybackState: 9,
   VisualViewport: 10,
+  AddNamespacedStrings: 11,
 } as const
 
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType]
+
+export const StringNamespace: {
+  Default: SessionReplay.StringNamespaceDefault
+  NodeName: SessionReplay.StringNamespaceNodeName
+  AttributeName: SessionReplay.StringNamespaceAttributeName
+  AttributeValue: SessionReplay.StringNamespaceAttributeValue
+  TextContent: SessionReplay.StringNamespaceTextContent
+  FormInput: SessionReplay.StringNamespaceFormInput
+  CSS: SessionReplay.StringNamespaceCSS
+  URL: SessionReplay.StringNamespaceURL
+} = {
+  Default: 0,
+  NodeName: 1,
+  AttributeName: 2,
+  AttributeValue: 3,
+  TextContent: 4,
+  FormInput: 5,
+  CSS: 6,
+  URL: 7,
+} as const
+
+export type StringNamespace = (typeof StringNamespace)[keyof typeof StringNamespace]
 
 export const PlaybackState: {
   Playing: SessionReplay.PlaybackStatePlaying

--- a/lib/src/session-replay.ts
+++ b/lib/src/session-replay.ts
@@ -18,6 +18,7 @@ export {
   MediaInteractionType,
   PlaybackState,
   SnapshotFormat,
+  StringNamespace,
 } from './session-replay-browser'
 export {
   CompositeOperation,

--- a/samples/session-replay/browser/record/change-record.json
+++ b/samples/session-replay/browser/record/change-record.json
@@ -57,6 +57,18 @@
       [1, 16],
       [1, 9]
     ],
+    [
+      1,
+      [null, { "namespace": 1, "string": "#document" }],
+      [1, { "namespace": 1, "string": "#doctype" }, "html", "", ""],
+      [0, { "namespace": 1, "string": "html" }],
+      [1, { "namespace": 1, "string": "body" }, ["style", "background-color: green"]],
+      [1, { "namespace": 1, "string": "span" }],
+      [1, { "namespace": 1, "string": "#text" }, "Hello"],
+      [0, { "namespace": 1, "string": "#cdata-section" }],
+      [6, { "namespace": 1, "string": "#document-fragment" }],
+      [1, { "namespace": 1, "string": "#shadow-root" }]
+    ],
     [2, 8, 9],
     [3, [3, ["id", "app"], ["class"]], [4, ["id", "heading"]]],
     [0, "id", "app", "class", "heading"],
@@ -64,6 +76,7 @@
     [4, [6, "Goodbye"], [7, " for today"]],
     [0, "Goodbye", " for today"],
     [4, [6, 0], [7, 1]],
+    [4, [6, { "namespace": 4, "string": "Goodbye" }]],
     [5, [4, 100, 200], [8, 95, 20]],
     [6, [0, 0, 50], [7, 15, 20]],
     [7, ["div { color: blue }"]],
@@ -79,6 +92,8 @@
     [8, [11, 0, 1]],
     [9, [15, 0]],
     [9, [15, 1]],
-    [10, [30, 30, 15, 15, 1024, 768, 2]]
+    [10, [30, 30, 15, 15, 1024, 768, 2]],
+    [11, [1, "div", "span"], [6, "div { color: blue }"], [5, "Hello"]],
+    [11, [7, "https://example.com/app.css"]]
   ]
 }

--- a/samples/session-replay/browser/record/full-snapshot-change-record.json
+++ b/samples/session-replay/browser/record/full-snapshot-change-record.json
@@ -58,6 +58,18 @@
       [1, 16],
       [1, 9]
     ],
+    [
+      1,
+      [null, { "namespace": 1, "string": "#document" }],
+      [1, { "namespace": 1, "string": "#doctype" }, "html", "", ""],
+      [0, { "namespace": 1, "string": "html" }],
+      [1, { "namespace": 1, "string": "body" }, ["style", "background-color: green"]],
+      [1, { "namespace": 1, "string": "span" }],
+      [1, { "namespace": 1, "string": "#text" }, "Hello"],
+      [0, { "namespace": 1, "string": "#cdata-section" }],
+      [6, { "namespace": 1, "string": "#document-fragment" }],
+      [1, { "namespace": 1, "string": "#shadow-root" }]
+    ],
     [2, 8, 9],
     [3, [3, ["id", "app"], ["class"]], [4, ["id", "heading"]]],
     [0, "id", "app", "class", "heading"],
@@ -65,6 +77,7 @@
     [4, [6, "Goodbye"], [7, " for today"]],
     [0, "Goodbye", " for today"],
     [4, [6, 0], [7, 1]],
+    [4, [6, { "namespace": 4, "string": "Goodbye" }]],
     [5, [4, 100, 200], [8, 95, 20]],
     [6, [0, 0, 50], [7, 15, 20]],
     [7, ["div { color: blue }"]],
@@ -80,6 +93,8 @@
     [8, [11, 0, 1]],
     [9, [15, 0]],
     [9, [15, 1]],
-    [10, [30, 30, 15, 15, 1024, 768, 2]]
+    [10, [30, 30, 15, 15, 1024, 768, 2]],
+    [11, [1, "div", "span"], [6, "div { color: blue }"], [5, "Hello"]],
+    [11, [7, "https://example.com/app.css"]]
   ]
 }

--- a/schemas/session-replay/browser/changes/add-namespaced-strings-change-schema.json
+++ b/schemas/session-replay/browser/changes/add-namespaced-strings-change-schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/browser/changes/add-namespaced-strings-change-schema.json",
+  "title": "AddNamespacedStringsChange",
+  "description": "Browser-specific. Schema representing the addition of a sequence of strings to the string table, annotated as belonging to a particular string namespace.",
+  "type": "array",
+  "minItems": 1,
+  "items": [{ "$ref": "string-references/string-namespace-schema.json" }],
+  "additionalItems": { "$ref": "string-references/string-literal-schema.json" }
+}

--- a/schemas/session-replay/browser/changes/add-node-change-schema.json
+++ b/schemas/session-replay/browser/changes/add-node-change-schema.json
@@ -12,7 +12,14 @@
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
         {
-          "oneOf": [{ "const": "#cdata-section" }, { "$ref": "string-references/string-reference-schema.json" }]
+          "oneOf": [
+            { "const": "#cdata-section" },
+            {
+              "description": "The node name expressed as a literal string in the NodeName string namespace.",
+              "const": { "namespace": 1, "string": "#cdata-section" }
+            },
+            { "$ref": "string-references/string-reference-schema.json" }
+          ]
         }
       ],
       "additionalItems": false
@@ -25,7 +32,14 @@
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
         {
-          "oneOf": [{ "const": "#doctype" }, { "$ref": "string-references/string-reference-schema.json" }]
+          "oneOf": [
+            { "const": "#doctype" },
+            {
+              "description": "The node name expressed as a literal string in the NodeName string namespace.",
+              "const": { "namespace": 1, "string": "#doctype" }
+            },
+            { "$ref": "string-references/string-reference-schema.json" }
+          ]
         },
         { "$ref": "string-references/string-or-string-reference-schema.json" },
         { "$ref": "string-references/string-or-string-reference-schema.json" },
@@ -41,7 +55,14 @@
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
         {
-          "oneOf": [{ "const": "#document" }, { "$ref": "string-references/string-reference-schema.json" }]
+          "oneOf": [
+            { "const": "#document" },
+            {
+              "description": "The node name expressed as a literal string in the NodeName string namespace.",
+              "const": { "namespace": 1, "string": "#document" }
+            },
+            { "$ref": "string-references/string-reference-schema.json" }
+          ]
         }
       ],
       "additionalItems": false
@@ -54,7 +75,14 @@
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
         {
-          "oneOf": [{ "const": "#document-fragment" }, { "$ref": "string-references/string-reference-schema.json" }]
+          "oneOf": [
+            { "const": "#document-fragment" },
+            {
+              "description": "The node name expressed as a literal string in the NodeName string namespace.",
+              "const": { "namespace": 1, "string": "#document-fragment" }
+            },
+            { "$ref": "string-references/string-reference-schema.json" }
+          ]
         }
       ],
       "additionalItems": false
@@ -66,15 +94,7 @@
       "minItems": 2,
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
-        {
-          "oneOf": [
-            {
-              "type": "string",
-              "description": "The element's node name expressed as a literal string."
-            },
-            { "$ref": "string-references/string-reference-schema.json" }
-          ]
-        }
+        { "$ref": "string-references/string-or-string-reference-schema.json" }
       ],
       "additionalItems": { "$ref": "attributes/attribute-assignment-schema.json" }
     },
@@ -86,7 +106,14 @@
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
         {
-          "oneOf": [{ "const": "#shadow-root" }, { "$ref": "string-references/string-reference-schema.json" }]
+          "oneOf": [
+            { "const": "#shadow-root" },
+            {
+              "description": "The node name expressed as a literal string in the NodeName string namespace.",
+              "const": { "namespace": 1, "string": "#shadow-root" }
+            },
+            { "$ref": "string-references/string-reference-schema.json" }
+          ]
         }
       ],
       "additionalItems": false
@@ -99,7 +126,14 @@
       "items": [
         { "$ref": "node-references/insertion-point-schema.json" },
         {
-          "oneOf": [{ "const": "#text" }, { "$ref": "string-references/string-reference-schema.json" }]
+          "oneOf": [
+            { "const": "#text" },
+            {
+              "description": "The node name expressed as a literal string in the NodeName string namespace.",
+              "const": { "namespace": 1, "string": "#text" }
+            },
+            { "$ref": "string-references/string-reference-schema.json" }
+          ]
         },
         { "$ref": "string-references/string-or-string-reference-schema.json" }
       ],

--- a/schemas/session-replay/browser/changes/add-string-change-schema.json
+++ b/schemas/session-replay/browser/changes/add-string-change-schema.json
@@ -2,6 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "session-replay/browser/changes/add-string-change-schema.json",
   "title": "AddStringChange",
-  "description": "Browser-specific. Schema representing the addition of a string to the string table.",
+  "description": "Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string namespace.",
   "type": "string"
 }

--- a/schemas/session-replay/browser/changes/change-schema.json
+++ b/schemas/session-replay/browser/changes/change-schema.json
@@ -80,6 +80,13 @@
       "items": [{ "const": 10 }],
       "additionalItems": { "$ref": "visual-viewport-change-schema.json" },
       "description": "Changes to the visual viewport."
+    },
+    {
+      "type": "array",
+      "minItems": 1,
+      "items": [{ "const": 11 }],
+      "additionalItems": { "$ref": "add-namespaced-strings-change-schema.json" },
+      "description": "Newly added namespaced strings."
     }
   ]
 }

--- a/schemas/session-replay/browser/changes/string-references/namespaced-string-literal-schema.json
+++ b/schemas/session-replay/browser/changes/string-references/namespaced-string-literal-schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/browser/changes/string-references/namespaced-string-literal-schema.json",
+  "title": "NamespacedStringLiteral",
+  "description": "Browser-specific. Schema representing a string literal with an associated string namespace.",
+  "type": "object",
+  "required": ["namespace", "string"],
+  "properties": {
+    "namespace": { "$ref": "string-namespace-schema.json" },
+    "string": { "$ref": "string-literal-schema.json" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/session-replay/browser/changes/string-references/string-literal-schema.json
+++ b/schemas/session-replay/browser/changes/string-references/string-literal-schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/browser/changes/string-references/string-literal-schema.json",
+  "title": "StringLiteral",
+  "description": "Browser-specific. Schema representing a string, expressed as a literal.",
+  "type": "string"
+}

--- a/schemas/session-replay/browser/changes/string-references/string-namespace-schema.json
+++ b/schemas/session-replay/browser/changes/string-references/string-namespace-schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/browser/changes/string-references/string-namespace-schema.json",
+  "title": "StringNamespaceId",
+  "description": "Browser-specific. Schema representing a string namespace.",
+  "oneOf": [
+    {
+      "title": "StringNamespaceDefault",
+      "description": "The default string namespace, used for uncategorized strings. Strings added by an AddStringChange are added to this string namespace.",
+      "const": 0
+    },
+    {
+      "title": "StringNamespaceNodeName",
+      "description": "A string namespace containing DOM node names (e.g. 'div', '#text').",
+      "const": 1
+    },
+    {
+      "title": "StringNamespaceAttributeName",
+      "description": "A string namespace containing DOM attribute names.",
+      "const": 2
+    },
+    {
+      "title": "StringNamespaceAttributeValue",
+      "description": "A string namespace containing DOM attribute values.",
+      "const": 3
+    },
+    {
+      "title": "StringNamespaceTextContent",
+      "description": "A string namespace containing DOM text content.",
+      "const": 4
+    },
+    {
+      "title": "StringNamespaceFormInput",
+      "description": "A string namespace containing DOM form input values.",
+      "const": 5
+    },
+    {
+      "title": "StringNamespaceCSS",
+      "description": "A string namespace containing CSS inline styles and stylesheets.",
+      "const": 6
+    },
+    {
+      "title": "StringNamespaceURL",
+      "description": "A string namespace containing URLs.",
+      "const": 7
+    }
+  ]
+}

--- a/schemas/session-replay/browser/changes/string-references/string-or-string-reference-schema.json
+++ b/schemas/session-replay/browser/changes/string-references/string-or-string-reference-schema.json
@@ -2,12 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "session-replay/browser/changes/string-references/string-or-string-reference-schema.json",
   "title": "StringOrStringReference",
-  "description": "Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.",
+  "description": "Browser-specific. Schema representing a string, either expressed as a literal, as a literal with an associated string namespace, or as an index into the string table.",
   "oneOf": [
-    {
-      "type": "string",
-      "description": "A literal string."
-    },
+    { "$ref": "string-literal-schema.json" },
+    { "$ref": "namespaced-string-literal-schema.json" },
     { "$ref": "string-reference-schema.json" }
   ]
 }


### PR DESCRIPTION
Today the browser Session Replay "Change" format keeps every recorded string in one undifferentiated string table. This PR extends the data format to annotate each string with a **namespace** which identifies its origin. The motivation for this change is to make it easier to transform session replay recordings downstream; in particular, annotating the strings in this way makes it easier to perform additional privacy masking after the fact.

There is an enumerated set of namespaces:
* 0: the default namespace, for uncategorized strings. In recordings generated by browser SDKs which are string namespace aware, this namespace will be almost empty; it primarily exists to map the namespace concept onto older recordings which don't explicitly annotate strings with a particular namespace.
* 1: DOM node names. (e.g. `div`, `#text`)
* 2: DOM attribute names.
* 3: DOM attribute values.
* 4: DOM text content.
* 5: DOM form input.
* 6: CSS.
* 7: URLs.

It's worth noting that identical strings may be added to the string table more than once if they exist in different namespaces. This is what enables us to, for example, mask all text content and form input after the fact, without risk of breaking structural elements of the page like attribute names.

Some of these categories conceptually overlap (for example, CSS and URLs may appear as DOM attribute values). The general rule is that most specific wins, but the details are likely to evolve over time as the use cases for these string namespaces change.

A new change opcode, `AddNamespacedStringsChange` (11), adds strings to the string table while annotating them with a namespace, and one change can cover several namespaces at once:

```ts
// Adds "div" and "span" as node names, then a stylesheet's text as CSS
[11, [1, "div", "span"], [6, "div { color: blue }"]]
```

The existing `AddStringChange` (0) is reinterpreted such that it now annotates strings with the `default` namespace.

Alongside these changes, `StringOrStringReference` gains a third variant, `NamespacedStringLiteral` which pairs a string with its namespace inline:
```ts
(`{"namespace": StringNamespace.TextContent, "string": "Goodbye"}`)
```

Real recordings will never contain a `NamespacedStringLiteral`; the SDK's encoder transforms every string into a string reference. However, it's still helpful for the format to support a more explicit representation; it can both serve as as an intermediate representation within the encoding pipeline, and as a debug representation when presenting a recording in human-readable form.

[PANA-8578]: https://datadoghq.atlassian.net/browse/PANA-8578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ