### PR TITLE
✨ add trace sampling rules telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -515,6 +515,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether tracing feature's client-side-stats generation is enabled
              */
             use_client_side_stats?: boolean;
+            /**
+             * Whether trace sampling rules are configured
+             */
+            use_trace_sampling_rules?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -515,6 +515,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
              * Whether tracing feature's client-side-stats generation is enabled
              */
             use_client_side_stats?: boolean;
+            /**
+             * Whether trace sampling rules are configured
+             */
+            use_trace_sampling_rules?: boolean;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/schemas/telemetry/configuration-schema.json
+++ b/schemas/telemetry/configuration-schema.json
@@ -581,6 +581,10 @@
                 "use_client_side_stats": {
                   "type": "boolean",
                   "description": "Whether tracing feature's client-side-stats generation is enabled"
+                },
+                "use_trace_sampling_rules": {
+                  "type": "boolean",
+                  "description": "Whether trace sampling rules are configured"
                 }
               }
             }


### PR DESCRIPTION
## Summary

Add `use_trace_sampling_rules` to configuration telemetry and regenerate the TypeScript declarations.

The field only reports whether rules are configured; rule contents are not included.

## Test plan

- `yarn build`
- `yarn validate`
- `yarn format`
