### PR TITLE
RUM-18103 Add timeseries feature to mobile usage telemetry

### DIFF
--- a/lib/cjs/generated/telemetry.d.ts
+++ b/lib/cjs/generated/telemetry.d.ts
@@ -549,7 +549,7 @@ export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartD
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = TrackWebView | AndroidNetworkInstrumentation;
+export type TelemetryMobileFeaturesUsage = TrackWebView | Timeseries | AndroidNetworkInstrumentation;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -973,6 +973,13 @@ export interface TrackWebView {
      * trackWebView API
      */
     feature: 'trackWebView';
+    [k: string]: unknown;
+}
+export interface Timeseries {
+    /**
+     * Timeseries tracking enabled
+     */
+    feature: 'timeseries';
     [k: string]: unknown;
 }
 export interface AndroidNetworkInstrumentation {

--- a/lib/esm/generated/telemetry.d.ts
+++ b/lib/esm/generated/telemetry.d.ts
@@ -549,7 +549,7 @@ export type TelemetryBrowserFeaturesUsage = StartSessionReplayRecording | StartD
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = TrackWebView | AndroidNetworkInstrumentation;
+export type TelemetryMobileFeaturesUsage = TrackWebView | Timeseries | AndroidNetworkInstrumentation;
 /**
  * Schema of common properties of Telemetry events
  */
@@ -973,6 +973,13 @@ export interface TrackWebView {
      * trackWebView API
      */
     feature: 'trackWebView';
+    [k: string]: unknown;
+}
+export interface Timeseries {
+    /**
+     * Timeseries tracking enabled
+     */
+    feature: 'timeseries';
     [k: string]: unknown;
 }
 export interface AndroidNetworkInstrumentation {

--- a/schemas/telemetry/usage/mobile-features-schema.json
+++ b/schemas/telemetry/usage/mobile-features-schema.json
@@ -17,6 +17,17 @@
       }
     },
     {
+      "required": ["feature"],
+      "title": "Timeseries",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "Timeseries tracking enabled",
+          "const": "timeseries"
+        }
+      }
+    },
+    {
       "required": ["feature", "type"],
       "title": "AndroidNetworkInstrumentation",
       "properties": {


### PR DESCRIPTION
### What and why?

This adds a timeseries entry to TelemetryMobileFeaturesUsage in schemas/telemetry/usage/mobile-features-schema.json. It lets dd-sdk-ios emit a usage telemetry event when timeseries tracking (memory and CPU) is enabled, following the same pattern already used for the trackWebView mobile usage event.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference