### PR TITLE
✨ Introduce electron schema for main process events

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This repository accommodates various usages, specifically:
 - The [Android SDK](https://github.com/DataDog/dd-sdk-android/) generates native data models based on
   schemas coming from `rum/`, `session-replay/` and `telemetry/` folders.
 
+- The [Electron SDK](https://github.com/DataDog/electron-sdk/) generates TypeScript types from `schemas/rum-events-electron-schema.json`, `schemas/rum-events-browser-schema.json`, `schemas/telemetry-events-schema.json` and `schemas/profiling-browser-schema.json`.
+
 - The Datadog App is using TypeScript types by including the `lib/` folder as a package dependency.
 
 # Tools

--- a/schemas/rum-events-electron-schema.json
+++ b/schemas/rum-events-electron-schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum-events-electron-schema.json",
+  "title": "RumEvent",
+  "type": "object",
+  "description": "Schema of all properties of a RUM event",
+  "oneOf": [
+    {
+      "$ref": "rum/error-schema.json"
+    },
+    {
+      "$ref": "rum/resource-schema.json"
+    },
+    {
+      "$ref": "rum/view-schema.json"
+    },
+    {
+      "$ref": "rum/view_update-schema.json"
+    },
+    {
+      "title": "RumVitalEvent",
+      "oneOf": [
+        {
+          "$ref": "rum/vital-duration-schema.json"
+        },
+        {
+          "$ref": "rum/vital-operation-step-schema.json"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

Allow The electron SDK to properly types events coming from main or renderer process and to support future execution context events only from the main process.

## Changes

- Add `schemas/rum-events-electron-schema.json`, a `RumEvent` union schema mirroring the browser schema but limited to `error`, `resource`, `view`, `view_update`, and vital events.
- Document the new schema and its consumer (the [electron-sdk](https://github.com/DataDog/electron-sdk/) repo) in the README's "How this repository is consumed?" section.