### PR TITLE
[PANA-8907] Add attributes to RUM action target schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -136,6 +136,12 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly composed_path_selector?: string;
                 /**
+                 * Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key
+                 */
+                readonly attributes?: {
+                    [k: string]: string;
+                };
+                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;

--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -37,6 +37,12 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
              * Target name
              */
             name: string;
+            /**
+             * Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key
+             */
+            readonly attributes?: {
+                [k: string]: string;
+            };
             [k: string]: unknown;
         };
         /**
@@ -135,12 +141,6 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  * Selector data based on the click event composed path
                  */
                 readonly composed_path_selector?: string;
-                /**
-                 * Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key
-                 */
-                readonly attributes?: {
-                    [k: string]: string;
-                };
                 /**
                  * Width of the target element (in pixels)
                  */

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -136,6 +136,12 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  */
                 readonly composed_path_selector?: string;
                 /**
+                 * Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key
+                 */
+                readonly attributes?: {
+                    [k: string]: string;
+                };
+                /**
                  * Width of the target element (in pixels)
                  */
                 readonly width?: number;

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -37,6 +37,12 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
              * Target name
              */
             name: string;
+            /**
+             * Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key
+             */
+            readonly attributes?: {
+                [k: string]: string;
+            };
             [k: string]: unknown;
         };
         /**
@@ -135,12 +141,6 @@ export type RumActionEvent = CommonProperties & ViewContainerSchema & {
                  * Selector data based on the click event composed path
                  */
                 readonly composed_path_selector?: string;
-                /**
-                 * Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key
-                 */
-                readonly attributes?: {
-                    [k: string]: string;
-                };
                 /**
                  * Width of the target element (in pixels)
                  */

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -185,6 +185,14 @@
                       "description": "Selector data based on the click event composed path",
                       "readOnly": true
                     },
+                    "attributes": {
+                      "type": "object",
+                      "description": "Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "readOnly": true
+                    },
                     "width": {
                       "type": "integer",
                       "description": "Width of the target element (in pixels)",

--- a/schemas/rum/action-schema.json
+++ b/schemas/rum/action-schema.json
@@ -52,6 +52,14 @@
                   "type": "string",
                   "description": "Target name",
                   "readOnly": false
+                },
+                "attributes": {
+                  "type": "object",
+                  "description": "Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "readOnly": true
                 }
               },
               "readOnly": true
@@ -183,14 +191,6 @@
                     "composed_path_selector": {
                       "type": "string",
                       "description": "Selector data based on the click event composed path",
-                      "readOnly": true
-                    },
-                    "attributes": {
-                      "type": "object",
-                      "description": "Key-value map of DOM attributes (href, aria-label, name, title, alt, id, role, data-*) collected from the click event composed path, closest occurrence wins per key",
-                      "additionalProperties": {
-                        "type": "string"
-                      },
                       "readOnly": true
                     },
                     "width": {


### PR DESCRIPTION
## Motivation

The Browser SDK is adding a new field, `action.target.attributes`, to auto-collected RUM click actions: a key-value map of DOM attributes (`href`, `aria-label`, `name`, `title`, `alt`, `id`, `role`, `data-*`) collected from a click event's composed path, closest occurrence wins per key. This lets customers filter and group RUM click actions by attribute value, which the existing `composed_path_selector` CSS-like string does not support.

JIRA: [PANA-8907](https://datadoghq.atlassian.net/browse/PANA-8907)
Browser SDK implementation: [DataDog/browser-sdk#5002](https://github.com/DataDog/browser-sdk/pull/5002)
RFC: [Collecting Click-Target Attributes as a Facetable Key-Value Map](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/7160561723/RFC+Collecting+Click-Target+Attributes+as+a+Facetable+Key-Value+Map)

## Changes

- Add `attributes` to `action.target` in `schemas/rum/action-schema.json`: an object with `additionalProperties: { type: "string" }`, matching the existing `additionalProperties` pattern used for `resource.request.headers` / `resource.response.headers`.
- The field is public (not under `_dd`), since it is customer-facing facet data collected the same way the action name already is, not an internal debugging field.
- Regenerate `lib/cjs/generated/rum.d.ts` and `lib/esm/generated/rum.d.ts` (`yarn build`).

This is a new, optional field. It does not change any existing property, per this repo's backward-compatibility guideline.

## Test instructions

- `yarn validate` — all samples still validate against the updated schema.
- `yarn build` — regenerates without errors; diff limited to the `attributes` property moving into the public `action.target` in `rum.d.ts` (cjs/esm).

## Checklist

- [x] Ran `yarn validate`
- [x] Ran `yarn build` and committed the regenerated `lib/cjs`/`lib/esm` output
- [ ] Coordinated version bump / release with SDK teams once this is ready to merge


[PANA-8907]: https://datadoghq.atlassian.net/browse/PANA-8907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
