### PR TITLE
✨ [RUM-16985] Add WebAssembly debug info type

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -395,6 +395,10 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
              * Build ID used to identify the WebAssembly debug symbols.
              */
             readonly build_id: string;
+            /**
+             * Debug information format used to symbolicate the WebAssembly module.
+             */
+            readonly debug_info_type?: 'dwarf' | 'sourcemap' | 'unknown';
             [k: string]: unknown;
         }[];
         /**

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -395,6 +395,10 @@ export type RumErrorEvent = CommonProperties & ActionChildProperties & ViewConta
              * Build ID used to identify the WebAssembly debug symbols.
              */
             readonly build_id: string;
+            /**
+             * Debug information format used to symbolicate the WebAssembly module.
+             */
+            readonly debug_info_type?: 'dwarf' | 'sourcemap' | 'unknown';
             [k: string]: unknown;
         }[];
         /**

--- a/samples/rum-events/wasm-error.json
+++ b/samples/rum-events/wasm-error.json
@@ -23,7 +23,8 @@
     "wasm_modules": [
       {
         "url": "https://example.com/module.wasm",
-        "build_id": "abcd"
+        "build_id": "abcd",
+        "debug_info_type": "dwarf"
       }
     ]
   },

--- a/schemas/rum/error-schema.json
+++ b/schemas/rum/error-schema.json
@@ -294,6 +294,12 @@
                     "type": "string",
                     "description": "Build ID used to identify the WebAssembly debug symbols.",
                     "readOnly": true
+                  },
+                  "debug_info_type": {
+                    "type": "string",
+                    "description": "Debug information format used to symbolicate the WebAssembly module.",
+                    "enum": ["dwarf", "sourcemap", "unknown"],
+                    "readOnly": true
                   }
                 }
               },


### PR DESCRIPTION
## What does this PR do?

Adds optional per-module `error.wasm_modules[].debug_info_type` metadata with `dwarf`, `sourcemap`, and `unknown` values. This lets symbolication route each WebAssembly module using its declared debug-information format while preserving schema compatibility.

## Validation

- `yarn build`
- `yarn validate`
- `yarn format`
