### PR TITLE
Rename StringResourceId to StringRoleResourceId

### DIFF
--- a/lib/cjs/generated/browserSessionReplay.d.ts
+++ b/lib/cjs/generated/browserSessionReplay.d.ts
@@ -155,7 +155,7 @@ export type StringLiteral = string;
 /**
  * Browser-specific. Schema representing a string role.
  */
-export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringResourceId;
+export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringRoleResourceId;
 /**
  * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
  */
@@ -191,7 +191,7 @@ export type StringRoleURL = 7;
 /**
  * A string role containing resource IDs.
  */
-export type StringResourceId = 8;
+export type StringRoleResourceId = 8;
 /**
  * Schema representing the addition of a new #document node.
  *

--- a/lib/cjs/generated/sessionReplay.d.ts
+++ b/lib/cjs/generated/sessionReplay.d.ts
@@ -163,7 +163,7 @@ export type StringLiteral = string;
 /**
  * Browser-specific. Schema representing a string role.
  */
-export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringResourceId;
+export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringRoleResourceId;
 /**
  * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
  */
@@ -199,7 +199,7 @@ export type StringRoleURL = 7;
 /**
  * A string role containing resource IDs.
  */
-export type StringResourceId = 8;
+export type StringRoleResourceId = 8;
 /**
  * Schema representing the addition of a new #document node.
  *

--- a/lib/cjs/src/session-replay-browser.d.ts
+++ b/lib/cjs/src/session-replay-browser.d.ts
@@ -87,7 +87,7 @@ export declare const StringRole: {
     FormInput: SessionReplay.StringRoleFormInput;
     CSS: SessionReplay.StringRoleCSS;
     URL: SessionReplay.StringRoleURL;
-    ResourceId: SessionReplay.StringResourceId;
+    ResourceId: SessionReplay.StringRoleResourceId;
 };
 export type StringRole = (typeof StringRole)[keyof typeof StringRole];
 export declare const PlaybackState: {

--- a/lib/esm/generated/browserSessionReplay.d.ts
+++ b/lib/esm/generated/browserSessionReplay.d.ts
@@ -155,7 +155,7 @@ export type StringLiteral = string;
 /**
  * Browser-specific. Schema representing a string role.
  */
-export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringResourceId;
+export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringRoleResourceId;
 /**
  * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
  */
@@ -191,7 +191,7 @@ export type StringRoleURL = 7;
 /**
  * A string role containing resource IDs.
  */
-export type StringResourceId = 8;
+export type StringRoleResourceId = 8;
 /**
  * Schema representing the addition of a new #document node.
  *

--- a/lib/esm/generated/sessionReplay.d.ts
+++ b/lib/esm/generated/sessionReplay.d.ts
@@ -163,7 +163,7 @@ export type StringLiteral = string;
 /**
  * Browser-specific. Schema representing a string role.
  */
-export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringResourceId;
+export type StringRoleId = StringRoleDefault | StringRoleNodeName | StringRoleAttributeName | StringRoleAttributeValue | StringRoleTextContent | StringRoleFormInput | StringRoleCSS | StringRoleURL | StringRoleResourceId;
 /**
  * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
  */
@@ -199,7 +199,7 @@ export type StringRoleURL = 7;
 /**
  * A string role containing resource IDs.
  */
-export type StringResourceId = 8;
+export type StringRoleResourceId = 8;
 /**
  * Schema representing the addition of a new #document node.
  *

--- a/lib/esm/src/session-replay-browser.d.ts
+++ b/lib/esm/src/session-replay-browser.d.ts
@@ -87,7 +87,7 @@ export declare const StringRole: {
     FormInput: SessionReplay.StringRoleFormInput;
     CSS: SessionReplay.StringRoleCSS;
     URL: SessionReplay.StringRoleURL;
-    ResourceId: SessionReplay.StringResourceId;
+    ResourceId: SessionReplay.StringRoleResourceId;
 };
 export type StringRole = (typeof StringRole)[keyof typeof StringRole];
 export declare const PlaybackState: {

--- a/lib/src/session-replay-browser.ts
+++ b/lib/src/session-replay-browser.ts
@@ -153,7 +153,7 @@ export const StringRole: {
   FormInput: SessionReplay.StringRoleFormInput
   CSS: SessionReplay.StringRoleCSS
   URL: SessionReplay.StringRoleURL
-  ResourceId: SessionReplay.StringResourceId
+  ResourceId: SessionReplay.StringRoleResourceId
 } = {
   Default: 0,
   NodeName: 1,

--- a/schemas/session-replay/browser/changes/string-references/string-role-schema.json
+++ b/schemas/session-replay/browser/changes/string-references/string-role-schema.json
@@ -45,7 +45,7 @@
       "const": 7
     },
     {
-      "title": "StringResourceId",
+      "title": "StringRoleResourceId",
       "description": "A string role containing resource IDs.",
       "const": 8
     }


### PR DESCRIPTION
# Motivation

The recently-added string role `StringResourceId` has a name that doesn't follow the pattern of the other string roles; it should've been `StringRoleResourceId`. This was my mistake; I typo'ed the name in a review commit. Let's fix this issue right now, before anything uses the new string role.

# Changes

`StringResourceId` has been renamed to `StringRoleResourceId`. Its value on the wire is unchanged.