### PR TITLE
RUM-18377 Remove local_cache_hit field from resource schema

### DIFF
--- a/lib/cjs/generated/rum.d.ts
+++ b/lib/cjs/generated/rum.d.ts
@@ -802,10 +802,6 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
-         * Whether the resource was served from the device's local cache
-         */
-        readonly local_cache_hit?: boolean;
-        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/lib/esm/generated/rum.d.ts
+++ b/lib/esm/generated/rum.d.ts
@@ -802,10 +802,6 @@ export type RumResourceEvent = CommonProperties & ActionChildProperties & ViewCo
          */
         readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other';
         /**
-         * Whether the resource was served from the device's local cache
-         */
-        readonly local_cache_hit?: boolean;
-        /**
          * The provider for this resource
          */
         readonly provider?: {

--- a/schemas/rum/resource-schema.json
+++ b/schemas/rum/resource-schema.json
@@ -248,11 +248,6 @@
               "enum": ["cache", "navigational-prefetch", "other"],
               "readOnly": true
             },
-            "local_cache_hit": {
-              "type": "boolean",
-              "description": "Whether the resource was served from the device's local cache",
-              "readOnly": true
-            },
             "provider": {
               "type": "object",
               "description": "The provider for this resource",


### PR DESCRIPTION
### What and why?
Removes the `local_cache_hit` boolean field from `schemas/rum/resource-schema.json`. It was a mobile-only signal for local-cache-hit detection, but the schema already has `delivery_type`/`transfer_size` fields and the backend's cache-status heuristic already derives local-cache and server-validated-cache hits from byte sizes for other platforms. Mobile is moving to populate those existing fields instead of maintaining a separate boolean.